### PR TITLE
gh#12 Fix compilation error in videodecoder due to missing com/rdk/hal/State.h

### DIFF
--- a/videodecoder/current/CMakeLists.txt
+++ b/videodecoder/current/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SRC
 	${SRC_DIR}/ScanType.aidl
 	../../common/${COMMON_VERSION}/com/rdk/hal/PropertyValue.aidl
 	../../common/${COMMON_VERSION}/com/rdk/hal/AVSource.aidl
+	../../common/${COMMON_VERSION}/com/rdk/hal/State.aidl
 )
 
 set(INCLUDE_FLAGS


### PR DESCRIPTION
It is required by:
* `IVideoDecoder.aidl`
* `IVideoDecoderEventListener.aidl`