### PR TITLE
gh #50 CSDVideoFormat.aidl: Fix syntax error

### DIFF
--- a/videodecoder/current/com/rdk/hal/videodecoder/CSDVideoFormat.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/CSDVideoFormat.aidl
@@ -51,6 +51,6 @@ enum CSDVideoFormat {
     AVC_DECODER_CONFIGURATION_RECORD = 0, /**< This value represents the AVCDecoderConfigurationRecord for H.264/AVC video. */
     HEVC_DECODER_CONFIGURATION_RECORD = 1, /**< This value represents the HEVCDecoderConfigurationRecord for H.265/HEVC video. */
     AV1_DECODER_CONFIGURATION_RECORD = 2  /**< This value represents the AV1CodecConfigurationRecord for AV1 video. */
-};
+}
 
 


### PR DESCRIPTION
There is an extra ';' at the end of enum declaration which cause compilation error

cmake error log:
```
CMake Error at CMakeModules/CompileAidl.cmake:127 (message):
  Command failed with error:

  ERROR: com/rdk/hal/videodecoder/CSDVideoFormat.aidl:54.2-3: syntax error,
  unexpected ';'

Call Stack (most recent call first):
  videodecoder/current/CMakeLists.txt:55 (compile_aidl)
```