### PR TITLE
feat: add per-input volume control and fader level to audiomixer (#396)

### DIFF
--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerController.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerController.aidl
@@ -117,4 +117,34 @@ interface IAudioMixerController {
      * @pre       The mixer must be in STARTED state.
      */
     void signalEOS();
+
+    /**
+     * @brief     Sets the volume level for a specific mixer input.
+     * @details   Allows per-input attenuation for use cases such as TTS overlay,
+     *            system sound mixing, or audio description level adjustment.
+     *
+     *            The input index corresponds to the mixer input as declared in
+     *            Capabilities.inputs (e.g., 0 = main, 1 = assoc, 2 = pcm1).
+     *
+     * @param[in] inputIndex  Mixer input index (0-based, matching Capabilities.inputs).
+     * @param[in] volume      Volume level in range 0..100 (0 = silent, 100 = full).
+     *
+     * @returns   true if the volume was set, false if the input index is invalid.
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if volume is outside 0..100 range.
+     * @exception binder::Status EX_ILLEGAL_STATE if mixer is not in READY or STARTED state.
+     * @pre       The mixer must be in READY or STARTED state.
+     * @see       getInputVolume()
+     */
+    boolean setInputVolume(in int inputIndex, in int volume);
+
+    /**
+     * @brief     Gets the current volume level for a specific mixer input.
+     *
+     * @param[in] inputIndex  Mixer input index (0-based, matching Capabilities.inputs).
+     *
+     * @returns   Current volume level in range 0..100.
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if inputIndex is invalid.
+     * @see       setInputVolume()
+     */
+    int getInputVolume(in int inputIndex);
 }

--- a/audiomixer/current/com/rdk/hal/audiomixer/Property.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/Property.aidl
@@ -86,5 +86,25 @@ enum Property {
      * - false: unmuted (default on open)
      * - true: muted
      */
-    MUTE = 4
+    MUTE = 4,
+
+    /**
+     * Fader level controlling the balance between main and associated audio inputs.
+     *
+     * Type: Integer
+     * Range: 0..100
+     *   - 0 = main audio only
+     *   - 50 = equal mix (default)
+     *   - 100 = associated audio only
+     * Access: Read-write.
+     * Writeable in states: READY, STARTED
+     *
+     * Primarily used for audio description (AD) where the user adjusts the
+     * relative level of the AD track against the main audio.
+     *
+     * Support for this property is platform-dependent and must be declared
+     * in the HAL Feature Profile (hfp-audiomixer.yaml). Middleware must
+     * query capabilities before using this property.
+     */
+    FADER_LEVEL = 5
 }

--- a/audiomixer/current/hfp-audiomixer.yaml
+++ b/audiomixer/current/hfp-audiomixer.yaml
@@ -29,6 +29,9 @@ audiomixer:
   resources:
     - id: 0  # Mixer instance 0 (secure)
       supportsSecure: true
+      # Supported mixer-level properties (platform-dependent)
+      supportedProperties:
+        - FADER_LEVEL
       # Supported audio source types for dynamic input routing
       supportedSourceTypes:
         - AUDIO_SINK


### PR DESCRIPTION
## Summary

Adds two mechanisms for per-input audio level control on the AudioMixer, addressing gaps identified from the dsAudio.h gap analysis (raised by @BatthalaH).

### Per-input volume methods (IAudioMixerController)

- `setInputVolume(int inputIndex, int volume)` — set volume (0-100) for a specific mixer input
- `getInputVolume(int inputIndex)` — query current volume for an input

Covers: TTS attenuation, system sound levels, audio description level adjustment.

### Fader property (Property.aidl)

- `Property.FADER_LEVEL = 5` — main/associated audio balance (0=main only, 50=equal, 100=assoc only)

Platform-dependent — must be declared in `hfp-audiomixer.yaml`. Reference HFP updated for mixer instance 0.

### Files changed

- `IAudioMixerController.aidl` — added `setInputVolume()` and `getInputVolume()` methods
- `Property.aidl` — added `FADER_LEVEL` property
- `hfp-audiomixer.yaml` — added `FADER_LEVEL` to mixer 0 supported properties

Closes #396

See also: discussion #398 (output port lifecycle rationale)