### PR TITLE
task:compositeinput: close doc/HFP gaps from #382 (gaps 1, 3, 5, 6, 7)

### DIFF
--- a/compositeinput/current/com/rdk/hal/compositeinput/ICompositeInputPort.aidl
+++ b/compositeinput/current/com/rdk/hal/compositeinput/ICompositeInputPort.aidl
@@ -33,6 +33,15 @@ import com.rdk.hal.PropertyValue;
  *
  * Provides control and monitoring for an individual composite video input port.
  * Each port can be independently controlled, configured, and monitored.
+ *
+ * @note Video scaling, positioning and aspect-ratio control are intentionally
+ *       not exposed on this interface. Composite input video, once presented
+ *       via setActive(true), is scaled and positioned by the display pipeline
+ *       through the planecontrol HAL (package com.rdk.hal.planecontrol, see
+ *       IPlaneControl and its Property enum: X, Y, WIDTH, HEIGHT, ASPECT_RATIO,
+ *       OVERSCAN). Clients migrating from the legacy dsCompositeInScaleVideo()
+ *       API should configure the video plane via IPlaneControl rather than
+ *       looking for an equivalent method on this interface.
  */
 @VintfStability
 interface ICompositeInputPort
@@ -81,8 +90,6 @@ interface ICompositeInputPort
      * conjunction with event listeners for real-time updates.
      *
      * @returns PortStatus parcelable with current port state.
-     *
-     * @exception binder::Status EX_ILLEGAL_STATE if service is not ready.
      *
      * @see PortStatus, IPortEventListener
      */
@@ -148,16 +155,21 @@ interface ICompositeInputPort
      * Gets multiple property values in a single call.
      *
      * Efficient batch retrieval of multiple properties. Reduces IPC overhead
-     * when querying multiple properties simultaneously. Entries for unsupported
-     * properties will have default-initialized values.
+     * when querying multiple properties simultaneously.
+     *
+     * This is an all-or-nothing batch operation. If any key in propertyKeys is
+     * invalid or unsupported by this port, no values are populated and the call
+     * throws EX_ILLEGAL_ARGUMENT. Clients must therefore only pass keys they
+     * have first confirmed via getCapabilities().supportedProperties.
      *
      * @param[in] propertyKeys     Array of property key strings to retrieve.
-     * @returns Array of PropertyKVPair with keys and values populated.
+     * @returns Array of PropertyKVPair with keys and values populated. Length
+     *          matches the input array length.
      *
-     * @exception binder::Status EX_ILLEGAL_ARGUMENT if propertyKeys is null or empty.
-     * @post Returned array length matches input array length.
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if propertyKeys is null, empty,
+     *            or contains any key that is invalid or not supported by this port.
      *
-     * @see PropertyKVPair, getProperty(), setPropertyMulti()
+     * @see PropertyKVPair, getProperty(), setPropertyMulti(), getCapabilities()
      */
     PropertyKVPair[] getPropertyMulti(in @utf8InCpp String[] propertyKeys);
 

--- a/compositeinput/current/hfp-compositeinput.yaml
+++ b/compositeinput/current/hfp-compositeinput.yaml
@@ -41,18 +41,18 @@ compositeinput:
       # Port capabilities (matches PortCapabilities.aidl)
       metricsSupported: true
 
-      # HFP-defined standard property keys (discoverable via getCapabilities())
-      # These are string keys - upper layers query and decide which to use
+      # HFP-defined property keys supported on this port (maps to
+      # PortCapabilities.supportedProperties[]). Metric keys (METRIC_ prefix)
+      # are carried in this same list and distinguished via
+      # propertyMetadata[].isMetric.
       supportedProperties:
-        - "SIGNAL_STRENGTH"        # Signal strength in dBm (PropertyValue.longValue, read-only)
+        - "SIGNAL_STRENGTH"            # Signal strength in dBm (PropertyValue.longValue, read-only)
+        - "METRIC_SIGNAL_LOCK_TIME"    # Average signal lock time in ms (PropertyValue.longValue, read-only)
+        - "METRIC_SIGNAL_DROPS"        # Total count of signal drops (PropertyValue.longValue, read-only)
+        - "METRIC_UPTIME"              # Total uptime in ms (PropertyValue.longValue, read-only)
 
-      # Metrics properties (METRIC_ prefix for categorization)
-      supportedMetrics:
-        - "METRIC_SIGNAL_LOCK_TIME"   # Average signal lock time in ms (PropertyValue.longValue, read-only)
-        - "METRIC_SIGNAL_DROPS"       # Total count of signal drops (PropertyValue.longValue, read-only)
-        - "METRIC_UPTIME"             # Total uptime in ms (PropertyValue.longValue, read-only)
-
-      # Property metadata for enhanced discovery (optional but recommended)
+      # Property metadata for each supported property (maps to
+      # PortCapabilities.propertyMetadata[]). isMetric=true flags metric keys.
       propertyMetadata:
         - key: "SIGNAL_STRENGTH"
           type: LONG
@@ -92,18 +92,18 @@ compositeinput:
       # Port capabilities (matches PortCapabilities.aidl)
       metricsSupported: true
 
-      # HFP-defined standard property keys (discoverable via getCapabilities())
-      # These are string keys - upper layers query and decide which to use
+      # HFP-defined property keys supported on this port (maps to
+      # PortCapabilities.supportedProperties[]). Metric keys (METRIC_ prefix)
+      # are carried in this same list and distinguished via
+      # propertyMetadata[].isMetric.
       supportedProperties:
-        - "SIGNAL_STRENGTH"        # Signal strength in dBm (PropertyValue.longValue, read-only)
+        - "SIGNAL_STRENGTH"            # Signal strength in dBm (PropertyValue.longValue, read-only)
+        - "METRIC_SIGNAL_LOCK_TIME"    # Average signal lock time in ms (PropertyValue.longValue, read-only)
+        - "METRIC_SIGNAL_DROPS"        # Total count of signal drops (PropertyValue.longValue, read-only)
+        - "METRIC_UPTIME"              # Total uptime in ms (PropertyValue.longValue, read-only)
 
-      # Metrics properties (METRIC_ prefix for categorization)
-      supportedMetrics:
-        - "METRIC_SIGNAL_LOCK_TIME"   # Average signal lock time in ms (PropertyValue.longValue, read-only)
-        - "METRIC_SIGNAL_DROPS"       # Total count of signal drops (PropertyValue.longValue, read-only)
-        - "METRIC_UPTIME"             # Total uptime in ms (PropertyValue.longValue, read-only)
-
-      # Property metadata for enhanced discovery (optional but recommended)
+      # Property metadata for each supported property (maps to
+      # PortCapabilities.propertyMetadata[]). isMetric=true flags metric keys.
       propertyMetadata:
         - key: "SIGNAL_STRENGTH"
           type: LONG
@@ -128,3 +128,46 @@ compositeinput:
           readOnly: true
           isMetric: true
           description: "Total uptime in milliseconds"
+
+  # Platform-wide capabilities (maps to PlatformCapabilities.aidl)
+  platformCapabilities:
+    halVersion: "1.0.0"                # PlatformCapabilities.halVersion (semver)
+    maxPorts: 2                        # PlatformCapabilities.maxPorts (matches ports[].length)
+
+    # Union of all property keys supported across the platform's ports
+    supportedProperties:
+      - "SIGNAL_STRENGTH"
+      - "METRIC_SIGNAL_LOCK_TIME"
+      - "METRIC_SIGNAL_DROPS"
+      - "METRIC_UPTIME"
+
+    # Metadata for the platform-wide property set
+    propertyMetadata:
+      - key: "SIGNAL_STRENGTH"
+        type: LONG
+        readOnly: true
+        isMetric: false
+        description: "Signal strength in dBm"
+
+      - key: "METRIC_SIGNAL_LOCK_TIME"
+        type: LONG
+        readOnly: true
+        isMetric: true
+        description: "Average signal lock time in milliseconds"
+
+      - key: "METRIC_SIGNAL_DROPS"
+        type: LONG
+        readOnly: true
+        isMetric: true
+        description: "Total count of signal drops since last reset"
+
+      - key: "METRIC_UPTIME"
+        type: LONG
+        readOnly: true
+        isMetric: true
+        description: "Total uptime in milliseconds"
+
+    # Optional feature flags (PlatformCapabilities.FeatureFlags)
+    features:
+      signalMetricsSupported: true
+      macrovisionDetectionSupported: false


### PR DESCRIPTION
## Summary

Closes the doc and HFP gaps from rdkcentral/rdk-halif-aidl#382 (5 of 7 gaps). Entirely non-breaking — no AIDL method signatures changed, no new files. Split from the broader issue so the architectural work (gap 4 port lifecycle, gap 2 Property enum typing) can be reviewed separately.

### What's in this PR

**Gap #1 — `platformCapabilities:` populated in HFP**
`hfp-compositeinput.yaml` now defines every field from `PlatformCapabilities.aidl`: `halVersion` ("1.0.0" per the Doxygen semver example), `maxPorts`, `supportedProperties[]`, `propertyMetadata[]`, and the `features` flag block.

**Gap #3 — planecontrol ownership of video scaling documented**
New interface-level `@note` on `ICompositeInputPort` explaining that `dsCompositeInScaleVideo()` has no equivalent on this interface because the `planecontrol` HAL (`com.rdk.hal.planecontrol.IPlaneControl`) already owns video plane geometry via its `Property` enum (`X`, `Y`, `WIDTH`, `HEIGHT`, `ASPECT_RATIO`, `OVERSCAN`). Clients migrating from `dsCompositeInScaleVideo()` are pointed at `IPlaneControl`.

**Gap #5 — stray `EX_ILLEGAL_STATE` dropped from `getStatus()` Doxygen**
`getStatus()` is a read-only snapshot of port state and must work at any point in the port's lifetime. The `@exception EX_ILLEGAL_STATE if service is not ready` line had no corresponding thrower and has been removed.

**Gap #6 — `getPropertyMulti()` Doxygen rewritten (docstring-only)**
Docstring replaced to match the canonical wording used by `IVideoDecoder` and `IPlaneControl`: if any key in `propertyKeys` is invalid or unsupported, no values are populated and the call throws `EX_ILLEGAL_ARGUMENT`. Clients must pre-filter keys against `getCapabilities().supportedProperties`. **Note:** the method signature is intentionally not changed in this PR — sibling interfaces use `boolean getPropertyMulti(in Property[], out PropertyKVPair[])`, which is API-breaking and will land as part of the deferred Property-enum typing migration (see below).

**Gap #7 — redundant `supportedMetrics:` removed from HFP**
`PortCapabilities.aidl` has no `supportedMetrics` field, so the YAML block was dead data. The `METRIC_SIGNAL_LOCK_TIME` / `METRIC_SIGNAL_DROPS` / `METRIC_UPTIME` keys now live in `supportedProperties[]` alongside `SIGNAL_STRENGTH` and are distinguished via `propertyMetadata[].isMetric = true`, which matches the intended contract.

### What's NOT in this PR (deferred)

- **Gap #2 — `Property.aidl` enum.** Will land in a follow-up PR `feature/382-compositeinput-property-enum` as an additive new file (not yet load-bearing on the wire). Typing the interface to `Property` is API-breaking and is deferred to its own follow-up issue.
- **Gap #4 — port lifecycle (`open/close`, `State` enum, `ICompositeInputController`).** A real architectural refactor that should be reviewed against the sibling HAL pattern (hdmiinput, audiomixer, videodecoder) in its own issue, not bundled with doc cleanup. A new issue will be opened before #382 is closed.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(open(...))'`).
- [x] `platformCapabilities:` block exposes all 5 `PlatformCapabilities.aidl` fields.
- [x] `supportedMetrics:` no longer present in either port; metric keys now in `supportedProperties[]`.
- [x] `propertyMetadata[].isMetric` flags still distinguish metrics from non-metrics.
- [x] `ICompositeInputPort.aidl` Doxygen changes are comment-only; no signature drift.
- [ ] Root CMake build passes with the updated AIDL (reviewer sanity check).
- [ ] Doxygen generation doesn't emit new warnings for the cross-module plain-text reference.