### PR TITLE
feat(decoder,sink): add input buffer-availability callbacks (#269)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ﻿################################################################################
 # This .gitignore file was automatically created by Microsoft(R) Visual Studio.
 ################################################################################
+out
 build
 src_link
 __pycache__/

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl
@@ -110,6 +110,10 @@ interface IAudioDecoderController {
      * @returns boolean
      * @retval true   Buffer successfully queued for decoding. Buffer ownership transfers to HAL.
      * @retval false  Internal decode buffer queue is full. Buffer ownership remains with caller.
+     *                The client SHOULD wait for `IAudioDecoderControllerListener.onDecodeBufferAvailable()`
+     *                before retrying, to avoid wasted binder transactions. Continuing to call this
+     *                method while the queue is full is permitted but will return `false` repeatedly
+     *                until space is available.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderControllerListener.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderControllerListener.aidl
@@ -54,8 +54,11 @@ oneway interface IAudioDecoderControllerListener {
     /**
      * Callback that signals the audio decoder input buffer queue has space again.
      *
-     * Fired exactly once after a previous `IAudioDecoderController.decodeBuffer()` call
-     * returned `false` (internal queue full), when the queue subsequently has space.
+     * Fired exactly once per back-pressure episode: when the internal queue transitions
+     * from full to has-space after `IAudioDecoderController.decodeBuffer()` returned `false`.
+     * If the client continues to call `decodeBuffer()` during back-pressure (receiving
+     * `false` repeatedly), only one callback is delivered per transition, regardless of
+     * the number of intermediate `false` returns.
      *
      * The client SHOULD wait for this callback before retrying `decodeBuffer()` to avoid
      * wasted binder transactions. Continuing to call `decodeBuffer()` while the queue is

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderControllerListener.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderControllerListener.aidl
@@ -50,4 +50,20 @@ oneway interface IAudioDecoderControllerListener {
     * @see IAudioDecoderController.decodeBuffer(), IAVBuffer.free()
     */
     void onFrameOutput(in long nsPresentationTime, in long frameAVBufferHandle, in @nullable FrameMetadata metadata);
+
+    /**
+     * Callback that signals the audio decoder input buffer queue has space again.
+     *
+     * Fired exactly once after a previous `IAudioDecoderController.decodeBuffer()` call
+     * returned `false` (internal queue full), when the queue subsequently has space.
+     *
+     * The client SHOULD wait for this callback before retrying `decodeBuffer()` to avoid
+     * wasted binder transactions. Continuing to call `decodeBuffer()` while the queue is
+     * full is permitted but will return `false` repeatedly until space is available.
+     *
+     * Not fired in steady-state operation - only after a refused buffer.
+     *
+     * @see IAudioDecoderController.decodeBuffer()
+     */
+    void onDecodeBufferAvailable();
 }

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
@@ -125,6 +125,10 @@ interface IAudioSinkController {
      * @returns boolean
      * @retval true  Buffer successfully queued for mixing. Buffer ownership transfers to HAL.
      * @retval false Buffer queue is full. Buffer ownership remains with caller.
+     *               The client SHOULD wait for `IAudioSinkControllerListener.onFrameBufferAvailable()`
+     *               before retrying, to avoid wasted binder transactions. Continuing to call this
+     *               method while the queue is full is permitted but will return `false` repeatedly
+     *               until space is available.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE    If the resource is not in the `STARTED` state or an audio frame is passed after EOS.

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
@@ -107,11 +107,12 @@ interface IAudioSinkController {
      * The audio sink must be in the `STARTED` state.
      * Buffers can be either non-secure or secure to support SAP (Secure Audio Path).
      * Each call shall reference a single audio frame with a presentation timestamp.
-     * When no AVClock is attached, the sink has no clock to drive consumption of queued frames.
-     * Depending on the implementation, the internal queue will fill and the sink will return
-     * `false` until a clock is attached. If the hardware does not support clockless queuing,
-     * the method returns `false` immediately. Pausing the clock has the same effect: data
-     * cannot be consumed out of the sink, so the queue will eventually fill.
+     * The sink will not consume queued frames until an AVClock has been linked to this sink
+     * (via `IAVClockController.setAudioSink()`) and the clock has been started. Until then,
+     * depending on the implementation, the internal queue will fill and the method will return
+     * `false`. If the hardware does not support clockless queuing, the method returns `false`
+     * immediately. Pausing the clock has the same effect: data cannot be consumed out of the
+     * sink, so the queue will eventually fill.
      * The audio sink may refuse the buffer if its internal resource usage prevents it from accepting it at that time.
      *
      * Buffer Ownership: Ownership of the buffer transfers to the Audio Sink HAL only

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
@@ -107,6 +107,7 @@ interface IAudioSinkController {
      * The audio sink must be in the `STARTED` state.
      * Buffers can be either non-secure or secure to support SAP (Secure Audio Path).
      * Each call shall reference a single audio frame with a presentation timestamp.
+     * When no AVClock is attached, frames are delivered in queue order without AV synchronisation.
      * The audio sink may refuse the buffer if its internal resource usage prevents it from accepting it at that time.
      *
      * Buffer Ownership: Ownership of the buffer transfers to the Audio Sink HAL only

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
@@ -107,7 +107,11 @@ interface IAudioSinkController {
      * The audio sink must be in the `STARTED` state.
      * Buffers can be either non-secure or secure to support SAP (Secure Audio Path).
      * Each call shall reference a single audio frame with a presentation timestamp.
-     * When no AVClock is attached, frames are delivered in queue order without AV synchronisation.
+     * When no AVClock is attached, the sink has no clock to drive consumption of queued frames.
+     * Depending on the implementation, the internal queue will fill and the sink will return
+     * `false` until a clock is attached. If the hardware does not support clockless queuing,
+     * the method returns `false` immediately. Pausing the clock has the same effect: data
+     * cannot be consumed out of the sink, so the queue will eventually fill.
      * The audio sink may refuse the buffer if its internal resource usage prevents it from accepting it at that time.
      *
      * Buffer Ownership: Ownership of the buffer transfers to the Audio Sink HAL only

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkControllerListener.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkControllerListener.aidl
@@ -91,8 +91,11 @@ oneway interface IAudioSinkControllerListener {
     /**
      * Callback that signals the audio sink input frame buffer queue has space again.
      *
-     * Fired exactly once after a previous `IAudioSinkController.queueAudioFrame()` call
-     * returned `false` (internal queue full), when the queue subsequently has space.
+     * Fired exactly once per back-pressure episode: when the internal queue transitions
+     * from full to has-space after `IAudioSinkController.queueAudioFrame()` returned `false`.
+     * If the client continues to call `queueAudioFrame()` during back-pressure (receiving
+     * `false` repeatedly), only one callback is delivered per transition, regardless of
+     * the number of intermediate `false` returns.
      *
      * The client SHOULD wait for this callback before retrying `queueAudioFrame()` to avoid
      * wasted binder transactions. Continuing to call `queueAudioFrame()` while the queue is

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkControllerListener.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkControllerListener.aidl
@@ -87,4 +87,20 @@ oneway interface IAudioSinkControllerListener {
      * Callback when a requested flush() operation has completed.
      */
     void onFlushComplete();
+
+    /**
+     * Callback that signals the audio sink input frame buffer queue has space again.
+     *
+     * Fired exactly once after a previous `IAudioSinkController.queueAudioFrame()` call
+     * returned `false` (internal queue full), when the queue subsequently has space.
+     *
+     * The client SHOULD wait for this callback before retrying `queueAudioFrame()` to avoid
+     * wasted binder transactions. Continuing to call `queueAudioFrame()` while the queue is
+     * full is permitted but will return `false` repeatedly until space is available.
+     *
+     * Not fired in steady-state operation - only after a refused frame.
+     *
+     * @see IAudioSinkController.queueAudioFrame()
+     */
+    void onFrameBufferAvailable();
 }

--- a/docs/halif/audio_decoder/current/audio_decoder.md
+++ b/docs/halif/audio_decoder/current/audio_decoder.md
@@ -334,6 +334,14 @@ The vendor layer is expected to manage the pool of decoded audio buffers private
 
 If the frame buffer pool is empty then the audio decoder cannot output the next decoded frame until a new frame buffer becomes available. While frame output is blocked, it is reasonable for the audio decoder service to either buffer additional coded input buffers or to reject new calls to `decodeBuffer()` with a `false` return value.
 
+## Input Buffer Back-Pressure
+
+`IAudioDecoderController.decodeBuffer()` returns `false` when the internal decode buffer queue is full. Buffer ownership remains with the caller and the buffer must be retained for re-submission.
+
+To avoid wasted binder transactions, the client SHOULD wait for `IAudioDecoderControllerListener.onDecodeBufferAvailable()` before calling `decodeBuffer()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+
+Continuing to call `decodeBuffer()` while the queue is full is permitted but will return `false` repeatedly until space is available.
+
 ## Presentation Time for Audio Frames
 
 The presentation time base units for audio frames is nanoseconds and passed in an int64 (long in AIDL definition) variable type. Video buffers shared the same time base units of nanoseconds.

--- a/docs/halif/audio_decoder/current/audio_decoder.md
+++ b/docs/halif/audio_decoder/current/audio_decoder.md
@@ -338,7 +338,7 @@ If the frame buffer pool is empty then the audio decoder cannot output the next 
 
 `IAudioDecoderController.decodeBuffer()` returns `false` when the internal decode buffer queue is full. Buffer ownership remains with the caller and the buffer must be retained for re-submission.
 
-To avoid wasted binder transactions, the client SHOULD wait for `IAudioDecoderControllerListener.onDecodeBufferAvailable()` before calling `decodeBuffer()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+To avoid wasted binder transactions, the client SHOULD wait for `IAudioDecoderControllerListener.onDecodeBufferAvailable()` before calling `decodeBuffer()` again. The callback fires exactly once per back-pressure episode: when the internal queue transitions from full to has-space. If the client continues to call `decodeBuffer()` during back-pressure (receiving `false` repeatedly), only one callback is delivered per transition. It is not fired in steady-state operation.
 
 Continuing to call `decodeBuffer()` while the queue is full is permitted but will return `false` repeatedly until space is available.
 

--- a/docs/halif/audio_sink/current/audio_sink.md
+++ b/docs/halif/audio_sink/current/audio_sink.md
@@ -201,7 +201,7 @@ Once the data in an audio frame buffer has been fully passed to or processed by 
 
 `IAudioSinkController.queueAudioFrame()` returns `false` when the internal frame buffer queue is full. Buffer ownership remains with the caller and the frame must be retained for re-submission.
 
-To avoid wasted binder transactions, the client SHOULD wait for `IAudioSinkControllerListener.onFrameBufferAvailable()` before calling `queueAudioFrame()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+To avoid wasted binder transactions, the client SHOULD wait for `IAudioSinkControllerListener.onFrameBufferAvailable()` before calling `queueAudioFrame()` again. The callback fires exactly once per back-pressure episode: when the internal queue transitions from full to has-space. If the client continues to call `queueAudioFrame()` during back-pressure (receiving `false` repeatedly), only one callback is delivered per transition. It is not fired in steady-state operation.
 
 Continuing to call `queueAudioFrame()` while the queue is full is permitted but will return `false` repeatedly until space is available.
 

--- a/docs/halif/audio_sink/current/audio_sink.md
+++ b/docs/halif/audio_sink/current/audio_sink.md
@@ -197,6 +197,14 @@ The audio data must be in the PCM audio format and sample rate, as reported in `
 
 Once the data in an audio frame buffer has been fully passed to or processed by the mixer, the Audio Sink shall free the handle by calling `IAVBuffer.free()`.
 
+## Input Buffer Back-Pressure
+
+`IAudioSinkController.queueAudioFrame()` returns `false` when the internal frame buffer queue is full. Buffer ownership remains with the caller and the frame must be retained for re-submission.
+
+To avoid wasted binder transactions, the client SHOULD wait for `IAudioSinkControllerListener.onFrameBufferAvailable()` before calling `queueAudioFrame()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+
+Continuing to call `queueAudioFrame()` while the queue is full is permitted but will return `false` repeatedly until space is available.
+
 ## Secure Audio Processing
 
 If any audio decoder supports SAP in non-tunnelled mode then the Audio Sink HAL must also support SAP to be able to process secure AV buffers of decoded PCM data, otherwise SAP support is optional.

--- a/docs/halif/video_decoder/current/video_decoder.md
+++ b/docs/halif/video_decoder/current/video_decoder.md
@@ -305,7 +305,7 @@ If the frame buffer pool is empty then the video decoder cannot output the next 
 
 `IVideoDecoderController.decodeBuffer()` returns `false` when the internal decode buffer queue is full. Buffer ownership remains with the caller and the buffer must be retained for re-submission.
 
-To avoid wasted binder transactions, the client SHOULD wait for `IVideoDecoderControllerListener.onDecodeBufferAvailable()` before calling `decodeBuffer()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+To avoid wasted binder transactions, the client SHOULD wait for `IVideoDecoderControllerListener.onDecodeBufferAvailable()` before calling `decodeBuffer()` again. The callback fires exactly once per back-pressure episode: when the internal queue transitions from full to has-space. If the client continues to call `decodeBuffer()` during back-pressure (receiving `false` repeatedly), only one callback is delivered per transition. It is not fired in steady-state operation.
 
 Continuing to call `decodeBuffer()` while the queue is full is permitted but will return `false` repeatedly until space is available.
 

--- a/docs/halif/video_decoder/current/video_decoder.md
+++ b/docs/halif/video_decoder/current/video_decoder.md
@@ -301,6 +301,14 @@ The vendor layer is expected to manage the pool of decoded frame buffers private
 
 If the frame buffer pool is empty then the video decoder cannot output the next decoded frame until a new frame buffer becomes available.  While frame output is blocked, it is reasonable for the video decoder service to either buffer additional coded input buffers or to reject new calls to `decodeBuffer()` with a false return value.
 
+## Input Buffer Back-Pressure
+
+`IVideoDecoderController.decodeBuffer()` returns `false` when the internal decode buffer queue is full. Buffer ownership remains with the caller and the buffer must be retained for re-submission.
+
+To avoid wasted binder transactions, the client SHOULD wait for `IVideoDecoderControllerListener.onDecodeBufferAvailable()` before calling `decodeBuffer()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+
+Continuing to call `decodeBuffer()` while the queue is full is permitted but will return `false` repeatedly until space is available.
+
 ## Presentation Time for Video Frames
 
 The presentation time base units for video frames is nanoseconds and passed in an int64 (long in AIDL definition) variable type. Audio buffers shared the same time base units of nanoseconds.

--- a/docs/halif/video_sink/current/video_sink.md
+++ b/docs/halif/video_sink/current/video_sink.md
@@ -194,7 +194,7 @@ Once the data in a video frame buffer has been presented or upon a flush request
 
 `IVideoSinkController.queueVideoFrame()` returns `false` when the internal frame buffer queue is full. Buffer ownership remains with the caller and the frame must be retained for re-submission.
 
-To avoid wasted binder transactions, the client SHOULD wait for `IVideoSinkControllerListener.onFrameBufferAvailable()` before calling `queueVideoFrame()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+To avoid wasted binder transactions, the client SHOULD wait for `IVideoSinkControllerListener.onFrameBufferAvailable()` before calling `queueVideoFrame()` again. The callback fires exactly once per back-pressure episode: when the internal queue transitions from full to has-space. If the client continues to call `queueVideoFrame()` during back-pressure (receiving `false` repeatedly), only one callback is delivered per transition. It is not fired in steady-state operation.
 
 Continuing to call `queueVideoFrame()` while the queue is full is permitted but will return `false` repeatedly until space is available.
 

--- a/docs/halif/video_sink/current/video_sink.md
+++ b/docs/halif/video_sink/current/video_sink.md
@@ -190,6 +190,14 @@ The video frame data in the buffer is vendor specific and is not decoded or unde
 
 Once the data in a video frame buffer has been presented or upon a flush request, the Video Sink shall free handles by calling `IAVBuffer.free()`.
 
+## Input Buffer Back-Pressure
+
+`IVideoSinkController.queueVideoFrame()` returns `false` when the internal frame buffer queue is full. Buffer ownership remains with the caller and the frame must be retained for re-submission.
+
+To avoid wasted binder transactions, the client SHOULD wait for `IVideoSinkControllerListener.onFrameBufferAvailable()` before calling `queueVideoFrame()` again. The callback fires exactly once after a `false` return, when the input queue has space again. It is not fired in steady-state operation.
+
+Continuing to call `queueVideoFrame()` while the queue is full is permitted but will return `false` repeatedly until space is available.
+
 ## Secure Video Processing
 
 Secure video processing (SVP) is a requirement for RDK-E.

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
@@ -108,6 +108,10 @@ interface IVideoDecoderController
      * @returns boolean
      * @retval true   Buffer successfully queued for decoding. Buffer ownership transfers to HAL.
      * @retval false  Internal decode buffer queue is full. Buffer ownership remains with caller.
+     *                The client SHOULD wait for `IVideoDecoderControllerListener.onDecodeBufferAvailable()`
+     *                before retrying, to avoid wasted binder transactions. Continuing to call this
+     *                method while the queue is full is permitted but will return `false` repeatedly
+     *                until space is available.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderControllerListener.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderControllerListener.aidl
@@ -74,8 +74,11 @@ oneway interface IVideoDecoderControllerListener {
     /**
      * Callback that signals the video decoder input buffer queue has space again.
      *
-     * Fired exactly once after a previous `IVideoDecoderController.decodeBuffer()` call
-     * returned `false` (internal queue full), when the queue subsequently has space.
+     * Fired exactly once per back-pressure episode: when the internal queue transitions
+     * from full to has-space after `IVideoDecoderController.decodeBuffer()` returned `false`.
+     * If the client continues to call `decodeBuffer()` during back-pressure (receiving
+     * `false` repeatedly), only one callback is delivered per transition, regardless of
+     * the number of intermediate `false` returns.
      *
      * The client SHOULD wait for this callback before retrying `decodeBuffer()` to avoid
      * wasted binder transactions. Continuing to call `decodeBuffer()` while the queue is

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderControllerListener.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderControllerListener.aidl
@@ -71,4 +71,20 @@ oneway interface IVideoDecoderControllerListener {
     */
     void onUserDataOutput(in long nsPresentationTime, in byte[] userData);
 
+    /**
+     * Callback that signals the video decoder input buffer queue has space again.
+     *
+     * Fired exactly once after a previous `IVideoDecoderController.decodeBuffer()` call
+     * returned `false` (internal queue full), when the queue subsequently has space.
+     *
+     * The client SHOULD wait for this callback before retrying `decodeBuffer()` to avoid
+     * wasted binder transactions. Continuing to call `decodeBuffer()` while the queue is
+     * full is permitted but will return `false` repeatedly until space is available.
+     *
+     * Not fired in steady-state operation - only after a refused buffer.
+     *
+     * @see IVideoDecoderController.decodeBuffer()
+     */
+    void onDecodeBufferAvailable();
+
 }

--- a/videodecoder/current/com/rdk/hal/videodecoder/Property.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/Property.aidl
@@ -172,7 +172,7 @@ enum Property {
 
 	/**
 	 * Count of decoded frames.
-	 * This metric is reset on open() and flush() calls.
+	 * This metric is reset on open(), flush() and stop() calls.
 	 *
 	 * Type: Integer
 	 *  -1 means this metric is not yet implemented by the vendor.
@@ -186,7 +186,7 @@ enum Property {
 
 	/**
 	 * Count of decode errors.
-	 * This metric is reset on open() and flush() calls.
+	 * This metric is reset on open(), flush() and stop() calls.
 	 *
 	 * Type: Integer
 	 *  -1 means this metric is not yet implemented by the vendor.
@@ -203,7 +203,7 @@ enum Property {
 	 * No frame was output due to corruption or decode error that could not
 	 * deliver a frame suitable for display.
 	 * This count includes any frames received before the first reference frame.
-	 * This metric is reset on open() and flush() calls.
+	 * This metric is reset on open(), flush() and stop() calls.
 	 *
 	 * Type: Integer
 	 *  -1 means this metric is not yet implemented by the vendor.

--- a/videosink/current/com/rdk/hal/videosink/IVideoSinkController.aidl
+++ b/videosink/current/com/rdk/hal/videosink/IVideoSinkController.aidl
@@ -150,6 +150,10 @@ interface IVideoSinkController
      * @returns boolean
      * @retval true  Frame successfully queued for display. Buffer ownership transfers to HAL.
      * @retval false Video sink queue is full. Buffer ownership remains with caller.
+     *               The client SHOULD wait for `IVideoSinkControllerListener.onFrameBufferAvailable()`
+     *               before retrying, to avoid wasted binder transactions. Continuing to call this
+     *               method while the queue is full is permitted but will return `false` repeatedly
+     *               until space is available.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE

--- a/videosink/current/com/rdk/hal/videosink/IVideoSinkControllerListener.aidl
+++ b/videosink/current/com/rdk/hal/videosink/IVideoSinkControllerListener.aidl
@@ -91,4 +91,20 @@ oneway interface IVideoSinkControllerListener
      * @param[in] newState  The new state that the sink has transitioned to.
      */
     void onStateChanged(in State oldState, in State newState);
+
+    /**
+     * Callback that signals the video sink input frame buffer queue has space again.
+     *
+     * Fired exactly once after a previous `IVideoSinkController.queueVideoFrame()` call
+     * returned `false` (internal queue full), when the queue subsequently has space.
+     *
+     * The client SHOULD wait for this callback before retrying `queueVideoFrame()` to avoid
+     * wasted binder transactions. Continuing to call `queueVideoFrame()` while the queue is
+     * full is permitted but will return `false` repeatedly until space is available.
+     *
+     * Not fired in steady-state operation - only after a refused frame.
+     *
+     * @see IVideoSinkController.queueVideoFrame()
+     */
+    void onFrameBufferAvailable();
 }

--- a/videosink/current/com/rdk/hal/videosink/IVideoSinkControllerListener.aidl
+++ b/videosink/current/com/rdk/hal/videosink/IVideoSinkControllerListener.aidl
@@ -95,8 +95,11 @@ oneway interface IVideoSinkControllerListener
     /**
      * Callback that signals the video sink input frame buffer queue has space again.
      *
-     * Fired exactly once after a previous `IVideoSinkController.queueVideoFrame()` call
-     * returned `false` (internal queue full), when the queue subsequently has space.
+     * Fired exactly once per back-pressure episode: when the internal queue transitions
+     * from full to has-space after `IVideoSinkController.queueVideoFrame()` returned `false`.
+     * If the client continues to call `queueVideoFrame()` during back-pressure (receiving
+     * `false` repeatedly), only one callback is delivered per transition, regardless of
+     * the number of intermediate `false` returns.
      *
      * The client SHOULD wait for this callback before retrying `queueVideoFrame()` to avoid
      * wasted binder transactions. Continuing to call `queueVideoFrame()` while the queue is


### PR DESCRIPTION
## Summary

Resolves #269. Closes #305.

Adds a one-shot callback on each decoder/sink controller listener that signals when the internal input buffer queue has space again after a refused submission. Lets clients avoid polling without changing existing input-method signatures.

| Interface | New method |
|---|---|
| `IAudioDecoderControllerListener` | `void onDecodeBufferAvailable();` |
| `IVideoDecoderControllerListener` | `void onDecodeBufferAvailable();` |
| `IAudioSinkControllerListener` | `void onFrameBufferAvailable();` |
| `IVideoSinkControllerListener` | `void onFrameBufferAvailable();` |

Naming follows the buffer that was refused (`decodeBuffer()` ↔ `onDecodeBufferAvailable()`, `queueAudioFrame()` / `queueVideoFrame()` ↔ `onFrameBufferAvailable()`). The decoder/sink itself is always available; only the input buffer queue can be temporarily full.

## Design provenance

Originated from Peter Stieglitz's "Proposal 3" in the Polaris interface review email thread (2026-04-16), with the sink-side symmetric extension proposed by Hari Krishna Batthala on the same thread. Refined during implementation review:
- **Naming**: switched from Pete's `onDecoderAvailable()` to `onDecodeBufferAvailable()` because the decoder is always available — only the input buffer queue can be full
- **Contract softened**: from "MUST NOT call input method until callback fires (violation triggers `onDecodeError()`)" to "SHOULD wait to avoid binder churn, MAY continue (will keep getting `false`)" — no new error conditions
- **Module-isolated Doxygen**: decoder docs do not reference sink, sink docs do not reference decoder
- **Symmetry**: extended to video sink (Hari only mentioned audio sink)

The full agreed design is captured in the body of #269.

## Files changed (13)

**AIDL — listeners (4 new methods):**
- `audiodecoder/.../IAudioDecoderControllerListener.aidl`
- `videodecoder/.../IVideoDecoderControllerListener.aidl`
- `audiosink/.../IAudioSinkControllerListener.aidl`
- `videosink/.../IVideoSinkControllerListener.aidl`

**AIDL — controllers (Doxygen tighten on `@retval false`):**
- `audiodecoder/.../IAudioDecoderController.aidl`
- `videodecoder/.../IVideoDecoderController.aidl`
- `audiosink/.../IAudioSinkController.aidl`
- `videosink/.../IVideoSinkController.aidl`

**Component docs (new "Input Buffer Back-Pressure" section in each):**
- `docs/halif/audio_decoder/current/audio_decoder.md`
- `docs/halif/video_decoder/current/video_decoder.md`
- `docs/halif/audio_sink/current/audio_sink.md`
- `docs/halif/video_sink/current/video_sink.md`

**Bundled #305 fix:**
- `videodecoder/.../Property.aidl` — three metrics (`METRIC_FRAMES_DECODED`, `METRIC_DECODE_ERRORS`, dropped frames) now read *"reset on open(), flush() and stop() calls"* matching the conclusion from discussion #296 that was never previously committed

**Not touched (per team convention):**
- `stable/aidl/...` — already diverges from source on `develop`; recent merged PRs (#407, #394, #390, #378, #377) do not touch it; regenerated separately
- `stable/generated/...` — same convention, regenerated separately

## File-collision heads-up with #403

The EOS work tracked in #403 is also expected to add new methods to the same four `*ControllerListener.aidl` files. Comment posted on #403 noting this. The two changes are additive and non-overlapping in semantics — whoever lands second will need a small mechanical merge slot, no design conflict.

## Test plan

- [ ] AIDL compiles for all four affected modules (build script in `site/scripts/build_interfaces.sh` runs `cmake -DAIDL_TARGET={audiodecoder,videodecoder,audiosink,videosink}`)
- [ ] mkdocs site renders without errors on the four updated component pages
- [ ] No semantic change to existing methods — only additive listener methods + Doxygen wording
- [ ] Vendor implementation guidance: HAL must fire the callback exactly once after a transition from "queue full" → "queue has space"; must NOT fire in steady-state; must NOT throw / fire `onDecodeError()` when client polls the input method during back-pressure