### PR TITLE
feat(motion_sensor): adopt controller pattern with StartConfig and diagnostics (#427)

### DIFF
--- a/docs/halif/sensor/current/motion/motion_sensor.md
+++ b/docs/halif/sensor/current/motion/motion_sensor.md
@@ -11,7 +11,7 @@ A clear lifecycle state machine ensures dependable operation and predictable eve
 !!! info "References"
     |||
     |-|-|
-    |**Interface Definition**|[sensor/current/com/rdk/hal/sensor/motion](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/sensor/current/com/rdk/hal/sensor/motion)|
+    |**Interface Definition**|[`sensor/current/com/rdk/hal/sensor/motion`](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/sensor/current/com/rdk/hal/sensor/motion)|
     |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
     |**Initialization**| [systemd](../../../vsi/systemd/current/systemd.md) – **hal-sensor-motion.service** |
 
@@ -66,7 +66,7 @@ Each sensor type has different characteristics (range, field-of-view, sensitivit
 | **HAL.MOTION.7** | If deep-sleep autonomy is supported, `setAutonomousDuringDeepSleep()` shall require `State==STOPPED`; when unsupported it shall return `false`. | |
 | **HAL.MOTION.8** | Active time windows shall only suppress events outside configured periods; motion detection continues but notifications are deferred or cancelled. | See `IMotionSensorController.setActiveWindows()`. |
 | **HAL.MOTION.9** | When active windows are configured, events shall only fire during the union of all configured windows. Empty array or windows with both times = 0 enables 24-hour monitoring. | |
-| **HAL.MOTION.10** | Shall register the service under the name `"MotionSensorManager"` and become operational at startup. | |
+| **HAL.MOTION.10** | Shall register the service under the name `"sensor.motion"` and become operational at startup. | Matches `IMotionSensorManager.serviceName`. |
 | **HAL.MOTION.11** | `IMotionSensorControllerListener.onStateChanged()` shall fire for every lifecycle state transition. | Matches the pattern used by all other HAL modules. |
 | **HAL.MOTION.12** | If the controller-owning client crashes, the HAL shall implicitly call `stop()` and `close()` to release the sensor. | Binder death cleanup. |
 

--- a/docs/halif/sensor/current/motion/motion_sensor.md
+++ b/docs/halif/sensor/current/motion/motion_sensor.md
@@ -11,7 +11,7 @@ A clear lifecycle state machine ensures dependable operation and predictable eve
 !!! info "References"
     |||
     |-|-|
-    |**Interface Definition**|[motion/current](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/motion/current)|
+    |**Interface Definition**|[motion/current](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/sensor/current/com/rdk/hal/sensor/motion)|
     |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
     |**Initialization**| [systemd](../../../vsi/systemd/current/systemd.md) – **hal-sensor-motion.service** |
 
@@ -26,7 +26,7 @@ The Motion HAL enables RDK Middleware to configure and receive **event-driven mo
 
 ### Sensor Types
 
-The HAL supports various motion/presence detection technologies as examples:
+The HAL supports various motion/presence detection technologies:
 
 - **PIR (Passive Infrared)**: Detects heat signatures and movement
 - **Microwave/Radar**: Active sensors measuring reflected waves
@@ -36,8 +36,6 @@ Each sensor type has different characteristics (range, field-of-view, sensitivit
 
 ### Use Cases
 
-Typical uses:
-
 - **Wake on Motion**: Resume from standby when user approaches device
 - **Power Savings**: Enter low-power mode after period of no activity
 - **Presence Detection**: Adapt UI/behaviour based on user presence
@@ -46,11 +44,12 @@ Typical uses:
 
 ### Key Features
 
+- **Controller pattern**: Exclusive ownership via `open()`/`close()` with binder death cleanup
 - **Event-driven architecture**: Async callbacks eliminate polling overhead
-- **Configurable timing**: Control activation delays, inactivity windows, and scheduled active periods
+- **Configurable timing**: Control activation delays, inactivity windows, and scheduled active periods via `StartConfig`
 - **Optional deep-sleep autonomy**: Sensor can operate and wake system from low-power states
 - **Per-sensor capabilities**: Static properties describe hardware limits and features
-- **Lifecycle state machine**: Predictable state transitions for reliable operation
+- **Diagnostics**: `getStartConfig()` and `getLastEventInfo()` for runtime inspection
 
 ---
 
@@ -59,15 +58,17 @@ Typical uses:
 | # | Requirement | Comments |
 |---|--------------|----------|
 | **HAL.MOTION.1** | Shall expose per-sensor capabilities via `getCapabilities()`; values remain immutable during runtime. | |
-| **HAL.MOTION.2** | Shall provide start/stop APIs to control detection. | |
-| **HAL.MOTION.3** | Shall support querying current state via `getState()` and operational mode via `getOperationalMode()`. | |
-| **HAL.MOTION.4** | Shall deliver events via `IMotionSensorEventListener.onEvent(mode)` according to configured operational mode and timing parameters. | |
+| **HAL.MOTION.2** | Shall provide start/stop APIs on `IMotionSensorController` to control detection. | |
+| **HAL.MOTION.3** | Shall support querying current state via `IMotionSensor.getState()` and current config via `IMotionSensorController.getStartConfig()`. | |
+| **HAL.MOTION.4** | Shall deliver motion/no-motion events via `IMotionSensorEventListener.onEvent(mode)` according to the `StartConfig`. | |
 | **HAL.MOTION.5** | If sensitivity is supported (`minSensitivity`/`maxSensitivity` > 0), `setSensitivity()` shall enforce range and require `State==STOPPED`. | Returns `false` for out-of-range; throws `EX_ILLEGAL_STATE` if not stopped. |
-| **HAL.MOTION.6** | Listener registration shall be idempotent; duplicate registrations return `false`, as do unregisters of unknown listeners. | |
+| **HAL.MOTION.6** | Event listener registration shall be idempotent; duplicate registrations return `false`, as do unregisters of unknown listeners. | |
 | **HAL.MOTION.7** | If deep-sleep autonomy is supported, `setAutonomousDuringDeepSleep()` shall require `State==STOPPED`; when unsupported it shall return `false`. | |
-| **HAL.MOTION.8** | Active time windows shall only suppress events outside configured periods; motion detection continues but notifications are deferred or cancelled. | See `setActiveWindows()` for scheduling. |
+| **HAL.MOTION.8** | Active time windows shall only suppress events outside configured periods; motion detection continues but notifications are deferred or cancelled. | See `IMotionSensorController.setActiveWindows()`. |
 | **HAL.MOTION.9** | When active windows are configured, events shall only fire during the union of all configured windows. Empty array or windows with both times = 0 enables 24-hour monitoring. | |
 | **HAL.MOTION.10** | Shall register the service under the name `"MotionSensorManager"` and become operational at startup. | |
+| **HAL.MOTION.11** | `IMotionSensorControllerListener.onStateChanged()` shall fire for every lifecycle state transition. | Matches the pattern used by all other HAL modules. |
+| **HAL.MOTION.12** | If the controller-owning client crashes, the HAL shall implicitly call `stop()` and `close()` to release the sensor. | Binder death cleanup. |
 
 ---
 
@@ -75,13 +76,17 @@ Typical uses:
 
 | Interface Definition File | Description |
 |----------------------------|-------------|
-| `com/rdk/hal/sensor/motion/IMotionSensorManager.aidl` | Manager interface to enumerate and acquire motion sensors. |
-| `com/rdk/hal/sensor/motion/IMotionSensor.aidl` | Interface representing one motion sensor instance. |
-| `com/rdk/hal/sensor/motion/IMotionSensorEventListener.aidl` | One-way callback delivering motion or no-motion events. |
-| `com/rdk/hal/sensor/motion/Capabilities.aidl` | Immutable capabilities (`sensorName`, sensitivity range, autonomy support). |
-| `com/rdk/hal/sensor/motion/OperationalMode.aidl` | Mode enum: `MOTION`, `NO_MOTION`. |
-| `com/rdk/hal/sensor/motion/State.aidl` | Lifecycle states: `STOPPED`, `STARTING`, `STARTED`, `STOPPING`, `ERROR`. |
-| `com/rdk/hal/sensor/motion/TimeWindow.aidl` | Daily time window for active period scheduling. |
+| `IMotionSensorManager.aidl` | Manager interface to enumerate and acquire motion sensors. |
+| `IMotionSensor.aidl` | Per-sensor interface: capabilities, state, open/close, event listener registration. |
+| `IMotionSensorController.aidl` | Exclusive controller: start/stop, config, sensitivity, deep sleep, active windows, diagnostics. |
+| `IMotionSensorControllerListener.aidl` | Controller callbacks: `onStateChanged`, `onActiveWindowEntered`, `onActiveWindowExited`. |
+| `IMotionSensorEventListener.aidl` | Multi-observer callback: `onEvent(mode)` for motion/no-motion detection. |
+| `Capabilities.aidl` | Immutable capabilities (`sensorName`, sensitivity range, autonomy support). |
+| `StartConfig.aidl` | Parcelable: operational mode + timing parameters for `start()`. |
+| `LastEventInfo.aidl` | Diagnostic parcelable: last event mode + timestamp. |
+| `OperationalMode.aidl` | Mode enum: `MOTION`, `NO_MOTION`. |
+| `State.aidl` | Lifecycle states: `STOPPED`, `STARTING`, `STARTED`, `STOPPING`, `ERROR`. |
+| `TimeWindow.aidl` | Daily time window for active period scheduling. |
 
 ---
 
@@ -97,25 +102,29 @@ Dependencies on drivers or low-level services must be expressed using systemd `R
 ## System Context
 
 ```mermaid
-graph RL
-    subgraph Hardware
-        A1[PIR / Radar Sensor] --> B1[Vendor Driver]
-    end
-    B1 --> C1[Motion Sensor HAL Layer]
-    subgraph Software
-        C1 --> D1[RDK Middleware / Motion]
-        D1 --> E1[Applications]
-        D1 --> F1[Telemetry Pipeline]
-    end
-    classDef background fill:#121212,stroke:none,color:#E0E0E0;
+flowchart TD
+    Client[RDK Middleware]
+    Manager[IMotionSensorManager]
+    Sensor[IMotionSensor]
+    Controller[IMotionSensorController]
+    CtrlListener[IMotionSensorControllerListener]
+    EventListener[IMotionSensorEventListener]
+    Hardware[PIR / Radar Sensor]
+
+    Client --> Manager
+    Manager --> Sensor
+    Sensor -->|open| Controller
+    Controller -->|state + window events| CtrlListener
+    Sensor -->|motion events| EventListener
+    Sensor --> Hardware
+
     classDef blue fill:#1565C0,stroke:#E0E0E0,stroke-width:2px,color:#E0E0E0;
     classDef wheat fill:#FFB74D,stroke:#424242,stroke-width:2px,color:#000000;
     classDef green fill:#4CAF50,stroke:#E0E0E0,stroke-width:2px,color:#FFFFFF;
 
-    D1:::blue
-    C1:::wheat
-    A1:::green
-    B1:::wheat
+    class Client blue;
+    class Manager,Sensor,Controller,CtrlListener,EventListener wheat;
+    class Hardware green;
 ```
 
 ---
@@ -136,6 +145,21 @@ STOPPED → STARTING → STARTED → STOPPING → STOPPED
 | **STOPPING** | Disarming detection.                                |
 | **ERROR**    | Failure occurred; requires recovery or re-init.     |
 
+`IMotionSensorControllerListener.onStateChanged(oldState, newState)` fires for every transition.
+
+---
+
+## Controller Pattern
+
+The motion sensor uses an exclusive controller pattern:
+
+1. **`IMotionSensor.open(controllerListener)`** — acquires exclusive `IMotionSensorController`
+2. Controller provides: `start()`, `stop()`, `getStartConfig()`, `getLastEventInfo()`, sensitivity, deep sleep autonomy, active windows
+3. **`IMotionSensor.close(controller)`** — releases the controller
+4. If the owning client crashes, the HAL implicitly calls `stop()` + `close()`
+
+Event listeners (`IMotionSensorEventListener`) are registered separately on `IMotionSensor` and do not require ownership — any client can observe motion events.
+
 ---
 
 ## Capabilities Structure
@@ -149,35 +173,51 @@ parcelable Capabilities {
 }
 ```
 
-### Rules
-
 - Capabilities are immutable for the process lifetime.
 - Sensitivity is unsupported when **both** min/max are `0`.
 
 ---
 
-## Operational Modes & Timing
+## StartConfig and Operational Modes
 
-`IMotionSensor.start(mode, noMotionSeconds, activeStartSeconds, activeStopSeconds)`
+`IMotionSensorController.start(StartConfig config)`:
 
-- **mode**:
+```aidl
+parcelable StartConfig {
+    OperationalMode operationalMode;
+    int noMotionSeconds;
+    int activeStartSeconds;
+    int activeStopSeconds;
+}
+```
+
+- **operationalMode**:
   - `MOTION`: fire event when motion is detected after activation window.
   - `NO_MOTION`: fire event after **contiguous** `noMotionSeconds` of inactivity.
 - **noMotionSeconds**: inactivity window (only for `NO_MOTION`); `0` disables it.
 - **activeStartSeconds**: delay after `start()` before the sensor becomes active (`0` = immediate).
 - **activeStopSeconds**: automatic stop after duration (`0` = continuous until `stop()`).
 
+The current config is retrievable via `IMotionSensorController.getStartConfig()`.
+
+---
+
+## Diagnostics
+
+```aidl
+parcelable LastEventInfo {
+    OperationalMode mode;
+    long timestampNs;
+}
+```
+
+`IMotionSensorController.getLastEventInfo()` returns the mode and timestamp of the most recent event, or null if no event has occurred since `start()`. Elapsed time since the event is `System.nanoTime() - timestampNs`.
+
 ---
 
 ## Active Time Windows
 
-The `setActiveWindows()` API allows scheduling when the sensor should actively report events. This is useful for:
-
-- Energy management (only monitor during expected occupancy hours)
-- Privacy controls (disable detection during specific times)
-- Multi-period monitoring (e.g., business hours + evening hours)
-
-### Time Window Structure
+`IMotionSensorController.setActiveWindows()` schedules when the sensor should actively report events:
 
 ```aidl
 parcelable TimeWindow {
@@ -186,26 +226,35 @@ parcelable TimeWindow {
 }
 ```
 
-### Behaviour
-
 - **Multiple Windows**: Array of `TimeWindow` objects; events fire during ANY configured window (union semantics)
 - **Midnight Wrapping**: Windows can span midnight when `endTime < startTime` (e.g., 22:00-02:00)
 - **24-Hour Monitoring**: Empty array or single window with both values = 0
 - **Configuration Timing**: Must be set in `STOPPED` state; takes effect on next `start()`
 - **Event Suppression**: Outside active windows, the sensor may continue detecting but **SHALL NOT** deliver events
-
-### Daylight Saving Time (DST) Considerations
+- **Window Callbacks**: `IMotionSensorControllerListener.onActiveWindowEntered()` / `onActiveWindowExited()` fire on transitions (only when windows are configured)
 
 !!! warning "DST Shifts"
     On days when DST shifts occur (23-hour or 25-hour days), applications should reprogram active windows to ensure reliable operation. If windows are updated daily, this occurs automatically.
 
 ---
 
-## Performance & Behaviour
+## Controller Listener (IMotionSensorControllerListener)
 
-- Event latency should be **≤ 500 ms** from physical motion to callback under typical conditions (non-normative but recommended).
-- Timing windows (`noMotionSeconds`, `activeStartSeconds`, `activeStopSeconds`) must be honoured precisely.
-- When deep-sleep autonomy is enabled and supported, the sensor should continue operating per vendor constraints during low-power states.
+Delivered exclusively to the controller owner (passed into `open()`).
+
+| Event | Description | When fired |
+|-------|-------------|------------|
+| `onStateChanged(old, new)` | Lifecycle state transition | Every start/stop/error transition |
+| `onActiveWindowEntered()` | Sensor entered active monitoring window | Only when windows configured |
+| `onActiveWindowExited()` | Sensor exited active monitoring window | Only when windows configured |
+
+## Event Listener (IMotionSensorEventListener)
+
+Available to any registered observer.
+
+| Event | Description |
+|-------|-------------|
+| `onEvent(mode)` | Motion or no-motion condition detected |
 
 ---
 
@@ -216,19 +265,30 @@ parcelable TimeWindow {
 ```mermaid
 sequenceDiagram
     participant MW as Middleware
-    participant HAL as Motion HAL
-    participant Sensor as Motion Sensor
+    participant Sensor as IMotionSensor
+    participant Ctrl as IMotionSensorController
+    participant CtrlL as IMotionSensorControllerListener
+    participant EvtL as IMotionSensorEventListener
+    participant HW as Motion Sensor
 
-    MW->>HAL: getMotionSensorIds()
-    HAL-->>MW: [id0]
-    MW->>HAL: getMotionSensor(id0)
-    HAL-->>MW: IMotionSensor
-    MW->>HAL: registerEventListener(l)
-    MW->>HAL: start(MOTION, 0, 0, 0)
-    HAL->>Sensor: Arm detection
-    Sensor-->>HAL: Motion detected
-    HAL-->>MW: onEvent(MOTION)
-    MW->>HAL: stop()
+    MW->>Sensor: registerEventListener(evtListener)
+    MW->>Sensor: open(ctrlListener)
+    Sensor-->>MW: IMotionSensorController
+    CtrlL-->>MW: onStateChanged(STOPPED, STOPPED)
+
+    MW->>Ctrl: start({MOTION, 0, 0, 0})
+    CtrlL-->>MW: onStateChanged(STOPPED, STARTING)
+    Ctrl->>HW: Arm detection
+    CtrlL-->>MW: onStateChanged(STARTING, STARTED)
+
+    HW-->>Ctrl: Motion detected
+    EvtL-->>MW: onEvent(MOTION)
+
+    MW->>Ctrl: stop()
+    CtrlL-->>MW: onStateChanged(STARTED, STOPPING)
+    CtrlL-->>MW: onStateChanged(STOPPING, STOPPED)
+
+    MW->>Sensor: close(controller)
 ```
 
 ### No-Motion Window (NO_MOTION mode)
@@ -236,156 +296,71 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant MW as Middleware
-    participant HAL as Motion HAL
-    participant Sensor as Motion Sensor
+    participant Ctrl as IMotionSensorController
+    participant CtrlL as IMotionSensorControllerListener
+    participant EvtL as IMotionSensorEventListener
+    participant HW as Motion Sensor
 
-    MW->>HAL: start(NO_MOTION, 5, 0, 0)
-    HAL->>Sensor: Arm detection with 5s inactivity window
-    Sensor-->>HAL: No motion for 5s
-    HAL-->>MW: onEvent(NO_MOTION)
+    MW->>Ctrl: start({NO_MOTION, 5, 0, 0})
+    CtrlL-->>MW: onStateChanged(STOPPED, STARTING)
+    CtrlL-->>MW: onStateChanged(STARTING, STARTED)
+    Ctrl->>HW: Arm detection with 5s inactivity window
+    HW-->>Ctrl: No motion for 5s
+    EvtL-->>MW: onEvent(NO_MOTION)
 ```
 
 ---
 
-## Timing Scenarios
+## Performance & Behaviour
 
-### Scenario 1: Motion Detection After Active Start Time
-
-User goes to standby at 06:30, configuring:
-
-- Active window start: 08:00
-- No-motion period: 30 minutes
-- Mode: NO_MOTION
-
-The sensor waits 30 minutes before the active window, then arms for motion detection once the no-motion period expires.
-
-```mermaid
-gantt
-    title Motion Detection After Active Period Start
-    dateFormat HH:mm
-    axisFormat %H:%M
-    
-    section Host State
-    Active (TV in use)          :active, 06:00, 30m
-    Standby (User pressed standby) :crit, 06:30, 3h30m
-    Active (Motion woke TV)     :active, 10:00, 1h
-    
-    section Motion Sensor State
-    Unarmed                     :done, 06:00, 30m
-    Armed-Waiting (Config set)  :active, 06:30, 1h
-    Armed-DetectNoMotion        :crit, 07:30, 30m
-    Armed-DetectMotion          :milestone, 08:00, 2h
-    Event: Motion Detected      :milestone, 10:00, 0m
-    Unarmed                     :done, 10:00, 1h
-```
-
-**Timeline:**
-
-| Time | Event | Motion Sensor State |
-|------|-------|---------------------|
-| 06:00 | TV active, in use | `STOPPED` (Unarmed) |
-| 06:30 | User presses standby; `start(NO_MOTION, 1800, 5400, 0)` called | `STARTING` → `STARTED` (Armed-Waiting) |
-| 07:30 | 30 minutes before active window, no-motion countdown begins | `STARTED` (Armed-DetectNoMotion) |
-| 08:00 | Active window starts; no-motion period expires | `STARTED` (Armed-DetectMotion) |
-| 10:00 | Motion event occurs | Event fired, transitions to `STOPPED` |
-
----
-
-### Scenario 2: Motion Detection Before and After Active Start
-
-User goes to standby at 06:30 with same configuration, but motion is detected before and during the active window start, extending the no-motion period.
-
-```mermaid
-gantt
-    title Motion Detection Before/After Active Period (Extended No-Motion)
-    dateFormat HH:mm
-    axisFormat %H:%M
-    
-    section Host State
-    Active (TV in use)          :active, 06:00, 30m
-    Standby                     :crit, 06:30, 4h
-    Active (Motion woke TV)     :active, 10:30, 30m
-    
-    section Motion Sensor State
-    Unarmed                     :done, 06:00, 30m
-    Armed-Waiting               :active, 06:30, 1h
-    Armed-DetectNoMotion (1)    :crit, 07:30, 15m
-    Motion Detected (reset)     :milestone, 07:45, 0m
-    Armed-DetectNoMotion (2)    :crit, 07:45, 45m
-    Motion Detected (reset)     :milestone, 08:30, 0m
-    Armed-DetectNoMotion (3)    :crit, 08:30, 30m
-    Armed-DetectMotion          :milestone, 09:00, 1h30m
-    Event: Motion Detected      :milestone, 10:30, 0m
-    Unarmed                     :done, 10:30, 30m
-```
-
-**Timeline:**
-
-| Time | Event | Motion Sensor State |
-|------|-------|---------------------|
-| 06:00 | TV active, in use | `STOPPED` (Unarmed) |
-| 06:30 | User presses standby; sensor armed | `STARTING` → `STARTED` (Armed-Waiting) |
-| 07:30 | No-motion countdown begins (30 min before window) | `STARTED` (Armed-DetectNoMotion) |
-| 07:45 | **Motion detected** → no-motion timer resets | `STARTED` (Armed-DetectNoMotion, timer reset) |
-| 08:00 | Active window starts, but no-motion period still running | `STARTED` (Armed-DetectNoMotion) |
-| 08:30 | **Motion stops** → no-motion timer resets again | `STARTED` (Armed-DetectNoMotion, timer reset) |
-| 09:00 | No-motion period (30 min) expires | `STARTED` (Armed-DetectMotion) |
-| 10:30 | Motion event occurs | Event fired, transitions to `STOPPED` |
-
-**Key Insight:** The active window defines WHEN events can fire, but the no-motion period must still be satisfied. Motion during the no-motion countdown resets the timer, even if it spans across the active window start time.
+- Event latency should be **≤ 500 ms** from physical motion to callback under typical conditions (non-normative but recommended).
+- Timing parameters in `StartConfig` must be honoured precisely.
+- When deep-sleep autonomy is enabled and supported, the sensor should continue operating per vendor constraints during low-power states.
 
 ---
 
 ## Hardware Configuration Example
 
-The HAL Feature Profile (HFP) defines platform-specific capabilities. Fields marked with `Capabilities.*` comments
-correspond to immutable values returned by `getCapabilities()`.
+The HAL Feature Profile (HFP) defines platform-specific capabilities and defaults:
 
 ```yaml
 sensor:
   motion:
-    # ========================================================================
-    # CAPABILITIES (Immutable - returned by getCapabilities())
-    # ========================================================================
-    - id: 0                                   # IMotionSensor.Id.value
-      sensorName: "PIR-Front-1"               # Capabilities.sensorName
+    - id: 0
+      sensorName: "PIR-Front-1"
       sensitivity_range:
-        minSensitivity: 1                     # Capabilities.minSensitivity
-        maxSensitivity: 10                    # Capabilities.maxSensitivity
-      supportsDeepSleepAutonomy: true         # Capabilities.supportsDeepSleepAutonomy
-      
-      # ========================================================================
-      # OPERATIONAL CONFIGURATION (Platform-specific defaults and constraints)
-      # ========================================================================
+        minSensitivity: 1
+        maxSensitivity: 10
+      supportsDeepSleepAutonomy: true
+
       operational_modes:
         - MOTION
         - NO_MOTION
-      default_mode: MOTION
-      timing:
-        no_motion_seconds: 5     # Default inactivity window before NO_MOTION event
-        active_start_seconds: 0  # Activation delay after start()
-        active_stop_seconds: 0   # Continuous monitoring until stop()
+
+      # Factory default StartConfig values (maps to StartConfig.aidl fields)
+      defaultStartConfig:
+        operationalMode: MOTION
+        noMotionSeconds: 5
+        activeStartSeconds: 0
+        activeStopSeconds: 0
+
       active_windows:
-        # Example: Monitor during business hours (9am-5pm) and evening (8pm-10pm)
-        - startTimeOfDaySeconds: 32400  # 09:00:00 (9 * 3600)
-          endTimeOfDaySeconds: 61200    # 17:00:00 (17 * 3600)
-        - startTimeOfDaySeconds: 72000  # 20:00:00 (20 * 3600)
-          endTimeOfDaySeconds: 79200    # 22:00:00 (22 * 3600)
-        # Leave empty or set both values to 0 for 24-hour monitoring
+        - startTimeOfDaySeconds: 32400  # 09:00
+          endTimeOfDaySeconds: 61200    # 17:00
+        - startTimeOfDaySeconds: 72000  # 20:00
+          endTimeOfDaySeconds: 79200    # 22:00
+
       requirements:
-        min_reaction_time_ms: 500  # Minimum reaction time to motion events
+        min_reaction_time_ms: 500
       notes:
         - "Front-facing PIR motion detector."
         - "Supports autonomous operation during deep sleep."
-        - "Active windows can be configured via setActiveWindows()."
 ```
-
-**Capabilities vs. Configuration:**
 
 | Section | Purpose | Mutability |
 |---------|---------|------------|
-| `id`, `sensorName`, `sensitivity_range`, `supportsDeepSleepAutonomy` | Hardware capabilities exposed via `getCapabilities()` | **Immutable** at runtime |
-| `operational_modes`, `default_mode`, `timing`, `active_windows` | Platform defaults and operational constraints | Configuration values for testing/validation |
+| `id`, `sensorName`, `sensitivity_range`, `supportsDeepSleepAutonomy` | Hardware capabilities via `getCapabilities()` | **Immutable** at runtime |
+| `operational_modes`, `defaultStartConfig`, `active_windows` | Platform defaults for testing/validation | Configuration values |
 
 ---
 
@@ -394,8 +369,13 @@ sensor:
 | Test                   | Expected Behaviour                                                           |
 | ---------------------- | ---------------------------------------------------------------------------- |
 | Capabilities Stability | Values constant across calls.                                                |
-| Start/Stop Sequence    | State transitions follow the model; timing windows honoured.                 |
+| Open/Close Lifecycle   | `open()` returns controller; `close()` releases it; double-open fails.       |
+| Start/Stop Sequence    | State transitions follow the model; `onStateChanged()` fires for each.       |
+| StartConfig Retrieval  | `getStartConfig()` matches the config passed to `start()`.                   |
+| LastEventInfo          | Returns null before first event; populated after `onEvent()` fires.          |
 | Sensitivity Control    | Enforced only in `STOPPED`; range-checked or returns `false` if unsupported. |
 | Listener Semantics     | Idempotent register/unregister; single delivery per event condition.         |
 | NO_MOTION Window       | Event fires only after contiguous inactivity equals `noMotionSeconds`.       |
 | Deep-Sleep Autonomy    | `setAutonomousDuringDeepSleep()` behaviour matches capability flag.          |
+| Active Window Callbacks | `onActiveWindowEntered`/`onActiveWindowExited` fire at window boundaries.   |
+| Crash Cleanup          | Controller owner crash triggers implicit `stop()` + `close()`.              |

--- a/docs/halif/sensor/current/motion/motion_sensor.md
+++ b/docs/halif/sensor/current/motion/motion_sensor.md
@@ -11,7 +11,7 @@ A clear lifecycle state machine ensures dependable operation and predictable eve
 !!! info "References"
     |||
     |-|-|
-    |**Interface Definition**|[motion/current](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/sensor/current/com/rdk/hal/sensor/motion)|
+    |**Interface Definition**|[sensor/current/com/rdk/hal/sensor/motion](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/sensor/current/com/rdk/hal/sensor/motion)|
     |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
     |**Initialization**| [systemd](../../../vsi/systemd/current/systemd.md) – **hal-sensor-motion.service** |
 

--- a/docs/halif/sensor/current/motion/motion_sensor.md
+++ b/docs/halif/sensor/current/motion/motion_sensor.md
@@ -274,7 +274,7 @@ sequenceDiagram
     MW->>Sensor: registerEventListener(evtListener)
     MW->>Sensor: open(ctrlListener)
     Sensor-->>MW: IMotionSensorController
-    CtrlL-->>MW: onStateChanged(STOPPED, STOPPED)
+    Note over Ctrl: sensor remains in STOPPED state
 
     MW->>Ctrl: start({MOTION, 0, 0, 0})
     CtrlL-->>MW: onStateChanged(STOPPED, STARTING)

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -34,4 +34,43 @@ endif()
 # ENABLE_SENSOR_THERMAL options. Platforms that do not ship a sensor type
 # can disable it via -DENABLE_SENSOR_MOTION=OFF or
 # -DENABLE_SENSOR_THERMAL=OFF.
-add_subdirectory(com/rdk/hal/sensor)
+set(MOTION_SRC_DIR com/rdk/hal/sensor/motion)
+set(THERMAL_SRC_DIR com/rdk/hal/sensor/thermal)
+
+set(SRC
+	${MOTION_SRC_DIR}/Capabilities.aidl
+	${MOTION_SRC_DIR}/IMotionSensor.aidl
+	${MOTION_SRC_DIR}/IMotionSensorController.aidl
+	${MOTION_SRC_DIR}/IMotionSensorControllerListener.aidl
+	${MOTION_SRC_DIR}/IMotionSensorEventListener.aidl
+	${MOTION_SRC_DIR}/IMotionSensorManager.aidl
+	${MOTION_SRC_DIR}/LastEventInfo.aidl
+	${MOTION_SRC_DIR}/OperationalMode.aidl
+	${MOTION_SRC_DIR}/StartConfig.aidl
+	${MOTION_SRC_DIR}/State.aidl
+	${MOTION_SRC_DIR}/TimeWindow.aidl
+	${THERMAL_SRC_DIR}/ActionEvent.aidl
+	${THERMAL_SRC_DIR}/IThermalEventListener.aidl
+	${THERMAL_SRC_DIR}/IThermalSensor.aidl
+	${THERMAL_SRC_DIR}/State.aidl
+	${THERMAL_SRC_DIR}/TemperatureReading.aidl
+)
+
+set(INCLUDE_DIRECTORY
+	.
+)
+
+set(COMPILE_AIDL_ARGV "")
+
+if (DEFINED AIDL_GEN_DIR)
+	list(APPEND COMPILE_AIDL_ARGV TARGET_DIRECTORY ${AIDL_GEN_DIR})
+endif()
+
+if (DEFINED AIDL_BIN)
+	list(APPEND COMPILE_AIDL_ARGV AIDL_BIN ${AIDL_BIN})
+endif()
+
+compile_aidl(${SRC}
+	INCLUDE_DIRECTORY ${INCLUDE_DIRECTORY}
+	${COMPILE_AIDL_ARGV}
+)

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -22,50 +22,16 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(Sensor
-	LANGUAGES NONE
-	VERSION 1.0)
+    LANGUAGES NONE
+    VERSION 1.0)
 
 if (NOT COMMAND compile_aidl)
-	message(FATAL_ERROR "Do not invoke module level CMake directly!\nInvoke CMake at root level instead!")
+    message(FATAL_ERROR "Do not invoke module level CMake directly!\nInvoke CMake at root level instead!")
 endif()
 
-set(MOTION_SRC_DIR com/rdk/hal/sensor/motion)
-set(THERMAL_SRC_DIR com/rdk/hal/sensor/thermal)
-
-set(SRC
-	${MOTION_SRC_DIR}/Capabilities.aidl
-	${MOTION_SRC_DIR}/IMotionSensor.aidl
-	${MOTION_SRC_DIR}/IMotionSensorController.aidl
-	${MOTION_SRC_DIR}/IMotionSensorControllerListener.aidl
-	${MOTION_SRC_DIR}/IMotionSensorEventListener.aidl
-	${MOTION_SRC_DIR}/IMotionSensorManager.aidl
-	${MOTION_SRC_DIR}/LastEventInfo.aidl
-	${MOTION_SRC_DIR}/OperationalMode.aidl
-	${MOTION_SRC_DIR}/StartConfig.aidl
-	${MOTION_SRC_DIR}/State.aidl
-	${MOTION_SRC_DIR}/TimeWindow.aidl
-	${THERMAL_SRC_DIR}/ActionEvent.aidl
-	${THERMAL_SRC_DIR}/IThermalEventListener.aidl
-	${THERMAL_SRC_DIR}/IThermalSensor.aidl
-	${THERMAL_SRC_DIR}/State.aidl
-	${THERMAL_SRC_DIR}/TemperatureReading.aidl
-)
-
-set(INCLUDE_DIRECTORY
-	.
-)
-
-set(COMPILE_AIDL_ARGV "")
-
-if (DEFINED AIDL_GEN_DIR)
-	list(APPEND COMPILE_AIDL_ARGV TARGET_DIRECTORY ${AIDL_GEN_DIR})
-endif()
-
-if (DEFINED AIDL_BIN)
-	list(APPEND COMPILE_AIDL_ARGV AIDL_BIN ${AIDL_BIN})
-endif()
-
-compile_aidl(${SRC}
-	INCLUDE_DIRECTORY ${INCLUDE_DIRECTORY}
-	${COMPILE_AIDL_ARGV}
-)
+# Each sensor type is independent and not present on every platform.
+# Delegate to the per-sensor build, which exposes ENABLE_SENSOR_MOTION /
+# ENABLE_SENSOR_THERMAL options. Platforms that do not ship a sensor type
+# can disable it via -DENABLE_SENSOR_MOTION=OFF or
+# -DENABLE_SENSOR_THERMAL=OFF.
+add_subdirectory(com/rdk/hal/sensor)

--- a/sensor/current/com/rdk/hal/sensor/motion/CMakeLists.txt
+++ b/sensor/current/com/rdk/hal/sensor/motion/CMakeLists.txt
@@ -33,9 +33,13 @@ set(SRC_DIR com/rdk/hal/sensor/motion)
 set(SRC
     ${SRC_DIR}/Capabilities.aidl
     ${SRC_DIR}/IMotionSensor.aidl
+    ${SRC_DIR}/IMotionSensorController.aidl
+    ${SRC_DIR}/IMotionSensorControllerListener.aidl
     ${SRC_DIR}/IMotionSensorEventListener.aidl
     ${SRC_DIR}/IMotionSensorManager.aidl
+    ${SRC_DIR}/LastEventInfo.aidl
     ${SRC_DIR}/OperationalMode.aidl
+    ${SRC_DIR}/StartConfig.aidl
     ${SRC_DIR}/State.aidl
     ${SRC_DIR}/TimeWindow.aidl
 )

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensor.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensor.aidl
@@ -117,8 +117,16 @@ interface IMotionSensor {
     /**
      * @brief Close this sensor and release the controller.
      *
-     * The sensor must be in STOPPED state. On success the controller
-     * is invalidated and another client may open() the sensor.
+     * Accepted from STOPPED or ERROR. From STOPPED this is the normal close
+     * path. From ERROR this is the recovery path: after a start() failure
+     * (which transitions the sensor to ERROR), the client calls close() to
+     * release the controller and the sensor returns to a state where it can
+     * be opened again. On success the controller is invalidated and another
+     * client may `open()` the sensor.
+     *
+     * If the sensor is in STARTED, STARTING, or STOPPING the call fails with
+     * EX_ILLEGAL_STATE — the client must call stop() first (or, from ERROR,
+     * close() directly).
      *
      * @param controller The IMotionSensorController instance returned by open().
      *
@@ -126,10 +134,10 @@ interface IMotionSensor {
      * @retval true  Successfully closed.
      * @retval false The supplied controller is not the instance returned by open().
      *
-     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED or ERROR state.
      * @exception binder::Status EX_NULL_POINTER if controller is null.
      *
-     * @see open()
+     * @see open(), IMotionSensorController.start()
      */
     boolean close(in IMotionSensorController controller);
 

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensor.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensor.aidl
@@ -25,35 +25,39 @@
  * or "no-motion" events after an inactivity window. Sensitivity is optional:
  * if unsupported, both minSensitivity and maxSensitivity are 0.
  *
- * @details
  * Lifecycle ownership:
- * The sensor uses a single-owner lifecycle model. start() and stop()
- * operate on the sensor instance directly — there is no per-client
- * controller or exclusive open/close pattern. A single middleware
- * component (e.g., a power management service) should own the sensor
- * lifecycle, while other components register as event listeners only.
+ * The sensor uses a controller pattern. A single middleware component
+ * (e.g., a power management service) calls open() to acquire an exclusive
+ * IMotionSensorController for lifecycle and configuration control. Other
+ * components register as event listeners via registerEventListener() to
+ * observe motion/no-motion events without needing ownership.
+ *
+ * If the client that opened the controller crashes, stop() and close()
+ * are implicitly called by the HAL to release the sensor.
  *
  * Timing controls vs active windows:
- * activeStartSeconds/activeStopSeconds (passed to start()) and active
- * windows (configured via setActiveWindows()) are independent, layered
- * mechanisms:
+ * StartConfig.activeStartSeconds/activeStopSeconds and active windows
+ * (configured via IMotionSensorController.setActiveWindows()) are
+ * independent, layered mechanisms:
  *   - Timing controls govern the sensor hardware lifecycle — whether
  *     the sensor is active at all.
  *   - Active windows govern event suppression — whether detected events
  *     are delivered to listeners.
  *
  * Timing controls take precedence. Callers are responsible for ensuring
- * sensible combinations (e.g., that activeStartSeconds does not exceed
- * the remaining window duration).
+ * sensible combinations.
+ *
+ * @author Gerald Weatherup
  */
 package com.rdk.hal.sensor.motion;
 
 import com.rdk.hal.sensor.motion.State;
 import com.rdk.hal.sensor.motion.Capabilities;
+import com.rdk.hal.sensor.motion.IMotionSensorController;
+import com.rdk.hal.sensor.motion.IMotionSensorControllerListener;
 import com.rdk.hal.sensor.motion.IMotionSensorEventListener;
-import com.rdk.hal.sensor.motion.OperationalMode;
-import com.rdk.hal.sensor.motion.TimeWindow;
 
+@VintfStability
 interface IMotionSensor {
 
     /**
@@ -73,162 +77,85 @@ interface IMotionSensor {
 
     /**
      * @brief Returns immutable capabilities for this sensor.
+     *
+     * Can be called at any time, regardless of sensor state.
+     *
      * @returns Immutable capabilities describing this sensor instance.
      */
     Capabilities getCapabilities();
 
     /**
-     * @brief Start the motion sensor.
-     *
-     * On success, the state transitions STOPPED → STARTING → STARTED.
-     * If initialization fails, the state becomes ERROR.
-     *
-     * @param operationalMode Operational mode (MOTION or NO_MOTION).
-     * @param noMotionSeconds After the sensor becomes active, the contiguous number
-     *        of seconds without motion before a NO_MOTION event is reported. Use 0 for none.
-     * @param activeStartSeconds Delay in seconds before the sensor becomes active after start().
-     *        Use 0 for immediate activation.
-     * @param activeStopSeconds Duration in seconds after which the sensor becomes inactive.
-     *        Use 0 for no automatic stop.
-     *
-     * @pre Sensor must be in STOPPED state.
-     *
-     * @returns Success flag indicating sensor start status.
-     * @retval true Sensor accepted the start request.
-     * @retval false Sensor could not be started due to an internal or hardware initialisation failure.
-     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not STOPPED.
-     */
-    boolean start(in OperationalMode operationalMode,
-                  in int noMotionSeconds,
-                  in int activeStartSeconds,
-                  in int activeStopSeconds);
-
-    /**
-     * @brief Stop the motion sensor.
-     *
-     * On success, the state transitions STARTED → STOPPING → STOPPED.
-     *
-     * @returns Success flag indicating sensor stop status.
-     * @retval true Sensor accepted the stop request.
-     * @retval false Sensor could not be stopped.
-     */
-    boolean stop();
-
-    /**
      * @brief Get the current lifecycle state of the sensor.
+     *
      * @returns Current state (e.g. STARTED, STOPPED, ERROR).
      */
     State getState();
 
     /**
-     * @brief Get the operational mode configured at start().
+     * @brief Open this sensor for exclusive control.
      *
-     * @returns Current mode (MOTION or NO_MOTION).
-     * @exception binder::Status EX_ILLEGAL_STATE if sensor is STOPPED or ERROR.
+     * On success the sensor is ready for configuration and start().
+     * The returned IMotionSensorController provides lifecycle control,
+     * configuration, and diagnostic queries.
+     *
+     * Only one controller may exist at a time. If the owning client
+     * crashes, the HAL implicitly calls stop() and close() to release
+     * the sensor.
+     *
+     * @param listener Listener for controller callbacks (state changes,
+     *                 active window transitions).
+     *
+     * @returns IMotionSensorController, or null if the sensor cannot be opened.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is already open.
+     * @exception binder::Status EX_NULL_POINTER if listener is null.
+     *
+     * @see close(), IMotionSensorController
      */
-    OperationalMode getOperationalMode();
+    @nullable IMotionSensorController open(in IMotionSensorControllerListener listener);
 
     /**
-     * @brief Get the current sensitivity value.
+     * @brief Close this sensor and release the controller.
      *
-     * @returns Current sensitivity level (within minSensitivity..maxSensitivity range).
+     * The sensor must be in STOPPED state. On success the controller
+     * is invalidated and another client may open() the sensor.
+     *
+     * @param controller The IMotionSensorController instance returned by open().
+     *
+     * @returns Success flag.
+     * @retval true  Successfully closed.
+     * @retval false The supplied controller is not the instance returned by open().
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     * @exception binder::Status EX_NULL_POINTER if controller is null.
+     *
+     * @see open()
      */
-    int getSensitivity();
+    boolean close(in IMotionSensorController controller);
 
     /**
-     * @brief Set the sensitivity level.
+     * @brief Register an event listener.
      *
-     * @param sensitivity Desired level. Must be within
-     *        {@link Capabilities#minSensitivity}..{@link Capabilities#maxSensitivity}.
+     * Multiple listeners may be registered. Event listeners receive
+     * motion/no-motion detection events via onEvent(). Registration does
+     * not require the sensor to be open.
      *
-     * @returns Success flag indicating whether sensitivity was set.
-     * @retval true Sensitivity was set.
-     * @retval false Sensitivity out of range or unsupported.
-     * @exception binder::Status EX_ILLEGAL_STATE if the sensor is not STOPPED.
-     */
-    boolean setSensitivity(in int sensitivity);
-
-    /**
-     * @brief Enable or disable autonomous motion detection during deep sleep.
-     *
-     * When enabled and supported by the platform, the sensor may wake the system
-     * from deep sleep based on motion activity without full SoC resume.
-     *
-     * Since this wake source could be hardware independent of the CPU, the sensor
-     * enabling has no effect on deep sleep of the CPU. The deep sleep module must
-     * be configured independently to support the CPU wake-up reasons.
-     *
-     * @param enabled True to enable, false to disable.
-     *
-     * @returns Success flag indicating configuration status.
-     * @retval true Mode updated (or already at requested value).
-     * @retval false Operation not supported (see Capabilities.supportsDeepSleepAutonomy).
-     * @exception binder::Status EX_ILLEGAL_STATE if the sensor is not STOPPED.
-     */
-    boolean setAutonomousDuringDeepSleep(in boolean enabled);
-
-    /**
-     * @brief Query whether autonomous deep-sleep mode is enabled.
-     * @returns True if enabled, false otherwise (or unsupported).
-     */
-    boolean isAutonomousDuringDeepSleepEnabled();
-
-    /**
-     * @brief Register an event listener. A listener may only be registered once.
      * @param motionSensorEventListener Listener to receive motion events.
-     * @returns Success flag indicating registration status.
-     * @retval true Listener registered.
+     *
+     * @returns Success flag.
+     * @retval true  Listener registered.
      * @retval false Listener already registered.
      */
     boolean registerEventListener(in IMotionSensorEventListener motionSensorEventListener);
 
     /**
      * @brief Unregister a previously registered listener.
+     *
      * @param motionSensorEventListener Listener to remove.
-     * @returns Success flag indicating unregistration status.
-     * @retval true Listener unregistered.
+     *
+     * @returns Success flag.
+     * @retval true  Listener unregistered.
      * @retval false Listener not found.
      */
     boolean unregisterEventListener(in IMotionSensorEventListener motionSensorEventListener);
-
-    /**
-     * @brief Set daily time windows when the sensor should actively monitor.
-     *
-     * Windows wrapping across midnight are supported (endTime < startTime).
-     * Changes take effect on next start() call. Calling this method replaces
-     * any previously configured windows.
-     *
-     * @param windows Array of time windows. Motion events outside these windows
-     *        are suppressed. Empty array or windows with both values set to 0
-     *        enables 24-hour monitoring. Windows may overlap; the union of all
-     *        windows defines the active periods.
-     *
-     * @returns Success flag indicating configuration status.
-     * @retval true Time windows configured successfully.
-     * @retval false Invalid window ranges or sensor state prevents configuration.
-     * @exception binder::Status EX_ILLEGAL_ARGUMENT if any window has invalid
-     *            time values (outside 0-86399 range).
-     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not STOPPED.
-     */
-    boolean setActiveWindows(in TimeWindow[] windows);
-
-    /**
-     * @brief Get the currently configured active time windows.
-     *
-     * @returns Array of active windows. Empty if 24-hour monitoring is configured
-     *         or no windows have been set.
-     */
-    TimeWindow[] getActiveWindows();
-
-    /**
-     * @brief Clear all active time windows, enabling 24-hour monitoring.
-     *
-     * Equivalent to calling setActiveWindows() with an empty array.
-     *
-     * @returns Success flag indicating clear operation status.
-     * @retval true Windows cleared successfully.
-     * @retval false Unable to clear (e.g., sensor not in valid state).
-     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not STOPPED.
-     */
-    boolean clearActiveWindows();
 }

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorController.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorController.aidl
@@ -48,11 +48,20 @@ interface IMotionSensorController {
      *
      * @param config Start configuration (mode, timing parameters).
      *
-     * @returns Success flag indicating whether the sensor accepted the start request.
-     * @retval true  Sensor started successfully.
-     * @retval false Sensor could not start due to an internal or hardware failure.
+     * @returns Success flag for hardware-level acceptance.
+     * @retval true  Sensor hardware initialised and started successfully.
+     * @retval false Sensor could not start due to an internal or hardware
+     *               initialisation failure (state transitions to ERROR).
      *
      * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if StartConfig contains
+     *            invalid values (e.g. noMotionSeconds outside 0–86400 range).
+     *
+     * Note: the boolean return signals operational (hardware) failure, while
+     * the binder exception signals a programming error (wrong state). This
+     * dual-signal pattern differs from modules where start() is void+exception
+     * (e.g. compositeinput) because motion sensor hardware probe failures are
+     * a normal operational condition, not an exceptional case.
      */
     boolean start(in StartConfig config);
 

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorController.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorController.aidl
@@ -44,26 +44,25 @@ interface IMotionSensorController {
      *
      * On success, the state transitions STOPPED → STARTING → STARTED.
      * IMotionSensorControllerListener.onStateChanged() fires for each transition.
-     * If initialisation fails, the state becomes ERROR.
+     * If hardware initialisation fails, the state transitions to ERROR
+     * (observable via onStateChanged()) and this call fails with
+     * EX_SERVICE_SPECIFIC. Use IMotionSensor.close() to release the sensor
+     * from ERROR; close() accepts STOPPED or ERROR.
      *
      * @param config Start configuration (mode, timing parameters).
-     *
-     * @returns Success flag for hardware-level acceptance.
-     * @retval true  Sensor hardware initialised and started successfully.
-     * @retval false Sensor could not start due to an internal or hardware
-     *               initialisation failure (state transitions to ERROR).
      *
      * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
      * @exception binder::Status EX_ILLEGAL_ARGUMENT if StartConfig contains
      *            invalid values (e.g. noMotionSeconds outside 0–86400 range).
+     * @exception binder::Status EX_SERVICE_SPECIFIC if hardware initialisation
+     *            fails. The state transitions to ERROR before the exception
+     *            is raised.
      *
-     * Note: the boolean return signals operational (hardware) failure, while
-     * the binder exception signals a programming error (wrong state). This
-     * dual-signal pattern differs from modules where start() is void+exception
-     * (e.g. compositeinput) because motion sensor hardware probe failures are
-     * a normal operational condition, not an exceptional case.
+     * Aligned with the repo-wide controller convention (`void start()` +
+     * binder exceptions for failure, lifecycle observable via state change
+     * listener) — same shape as compositeinput, hdmiinput, audiosink, etc.
      */
-    boolean start(in StartConfig config);
+    void start(in StartConfig config);
 
     /**
      * @brief Stop the motion sensor.
@@ -71,13 +70,12 @@ interface IMotionSensorController {
      * On success, the state transitions STARTED → STOPPING → STOPPED.
      * IMotionSensorControllerListener.onStateChanged() fires for each transition.
      *
-     * @returns Success flag indicating whether the sensor accepted the stop request.
-     * @retval true  Sensor stopped successfully.
-     * @retval false Sensor could not be stopped.
-     *
      * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STARTED state.
+     *
+     * Aligned with the repo-wide controller convention (`void stop()` +
+     * binder exception for failure).
      */
-    boolean stop();
+    void stop();
 
     /**
      * @brief Retrieve the configuration passed to start().

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorController.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorController.aidl
@@ -1,0 +1,184 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file IMotionSensorController.aidl
+ * @brief Exclusive controller interface for a motion sensor instance.
+ *
+ * Returned by {@link IMotionSensor#open(IMotionSensorControllerListener)}.
+ * Provides lifecycle control (start/stop), configuration, and diagnostic
+ * queries. Only one controller may exist per sensor at a time.
+ *
+ * If the client that opened this controller crashes, stop() and close()
+ * are implicitly called by the HAL to release the sensor.
+ *
+ * @author Gerald Weatherup
+ */
+package com.rdk.hal.sensor.motion;
+
+import com.rdk.hal.sensor.motion.LastEventInfo;
+import com.rdk.hal.sensor.motion.StartConfig;
+import com.rdk.hal.sensor.motion.TimeWindow;
+
+@VintfStability
+interface IMotionSensorController {
+
+    /**
+     * @brief Start the motion sensor.
+     *
+     * On success, the state transitions STOPPED → STARTING → STARTED.
+     * IMotionSensorControllerListener.onStateChanged() fires for each transition.
+     * If initialisation fails, the state becomes ERROR.
+     *
+     * @param config Start configuration (mode, timing parameters).
+     *
+     * @returns Success flag indicating whether the sensor accepted the start request.
+     * @retval true  Sensor started successfully.
+     * @retval false Sensor could not start due to an internal or hardware failure.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     */
+    boolean start(in StartConfig config);
+
+    /**
+     * @brief Stop the motion sensor.
+     *
+     * On success, the state transitions STARTED → STOPPING → STOPPED.
+     * IMotionSensorControllerListener.onStateChanged() fires for each transition.
+     *
+     * @returns Success flag indicating whether the sensor accepted the stop request.
+     * @retval true  Sensor stopped successfully.
+     * @retval false Sensor could not be stopped.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STARTED state.
+     */
+    boolean stop();
+
+    /**
+     * @brief Retrieve the configuration passed to start().
+     *
+     * @returns The StartConfig used for the current session.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is in STOPPED or ERROR state.
+     */
+    StartConfig getStartConfig();
+
+    /**
+     * @brief Retrieve diagnostic info about the most recent event.
+     *
+     * Returns the mode and timestamp of the last onEvent() delivered to
+     * listeners. Returns null if no event has been delivered since start().
+     *
+     * @returns LastEventInfo, or null if no event has occurred.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is in STOPPED or ERROR state.
+     */
+    @nullable LastEventInfo getLastEventInfo();
+
+    /**
+     * @brief Get the current sensitivity value.
+     *
+     * @returns Current sensitivity level (within Capabilities.minSensitivity..maxSensitivity).
+     */
+    int getSensitivity();
+
+    /**
+     * @brief Set the sensitivity level.
+     *
+     * @param sensitivity Desired level. Must be within
+     *        {@link Capabilities#minSensitivity}..{@link Capabilities#maxSensitivity}.
+     *
+     * @returns Success flag.
+     * @retval true  Sensitivity was set.
+     * @retval false Sensitivity out of range or unsupported.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     */
+    boolean setSensitivity(in int sensitivity);
+
+    /**
+     * @brief Enable or disable autonomous motion detection during deep sleep.
+     *
+     * When enabled and supported by the platform, the sensor may wake the system
+     * from deep sleep based on motion activity without full SoC resume.
+     *
+     * The deep sleep module must be configured independently to support the
+     * CPU wake-up reasons — enabling sensor autonomy alone does not affect
+     * CPU deep sleep behaviour.
+     *
+     * @param enabled True to enable, false to disable.
+     *
+     * @returns Success flag.
+     * @retval true  Mode updated (or already at requested value).
+     * @retval false Not supported (see Capabilities.supportsDeepSleepAutonomy).
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     */
+    boolean setAutonomousDuringDeepSleep(in boolean enabled);
+
+    /**
+     * @brief Query whether autonomous deep-sleep mode is enabled.
+     *
+     * @returns True if enabled, false otherwise (or unsupported).
+     */
+    boolean isAutonomousDuringDeepSleepEnabled();
+
+    /**
+     * @brief Set daily time windows when the sensor should actively monitor.
+     *
+     * Windows wrapping across midnight are supported (endTime < startTime).
+     * Changes take effect on next start() call. Calling this method replaces
+     * any previously configured windows.
+     *
+     * @param windows Array of time windows. Motion events outside these windows
+     *        are suppressed. Empty array or windows with both values set to 0
+     *        enables 24-hour monitoring. Windows may overlap; the union of all
+     *        windows defines the active periods.
+     *
+     * @returns Success flag.
+     * @retval true  Windows configured successfully.
+     * @retval false Invalid window ranges or sensor state prevents configuration.
+     *
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if any window has invalid
+     *            time values (outside 0–86399 range).
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     */
+    boolean setActiveWindows(in TimeWindow[] windows);
+
+    /**
+     * @brief Get the currently configured active time windows.
+     *
+     * @returns Array of active windows. Empty if 24-hour monitoring is configured
+     *          or no windows have been set.
+     */
+    TimeWindow[] getActiveWindows();
+
+    /**
+     * @brief Clear all active time windows, enabling 24-hour monitoring.
+     *
+     * Equivalent to calling setActiveWindows() with an empty array.
+     *
+     * @returns Success flag.
+     * @retval true  Windows cleared successfully.
+     * @retval false Unable to clear (e.g., sensor not in valid state).
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if sensor is not in STOPPED state.
+     */
+    boolean clearActiveWindows();
+}

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorControllerListener.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorControllerListener.aidl
@@ -50,7 +50,12 @@ oneway interface IMotionSensorControllerListener {
     void onStateChanged(in State oldState, in State newState);
 
     /**
-     * @brief Called when the sensor enters a configured active monitoring window.
+     * @brief Called when the sensor enters an active monitoring period.
+     *
+     * Fires when the current time enters the union of all configured active
+     * windows. If windows overlap, this callback fires once on the first
+     * entry — not per-window. Motion events may be delivered while inside
+     * the active period.
      *
      * Only fires when active windows have been configured via
      * IMotionSensorController.setActiveWindows(). Not fired if 24-hour
@@ -59,10 +64,12 @@ oneway interface IMotionSensorControllerListener {
     void onActiveWindowEntered();
 
     /**
-     * @brief Called when the sensor exits a configured active monitoring window.
+     * @brief Called when the sensor exits all active monitoring windows.
      *
-     * Motion events are suppressed while outside active windows. Only fires
-     * when active windows have been configured via
+     * Fires when the current time leaves the union of all configured active
+     * windows. Motion events are suppressed while outside active windows.
+     *
+     * Only fires when active windows have been configured via
      * IMotionSensorController.setActiveWindows().
      */
     void onActiveWindowExited();

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorControllerListener.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorControllerListener.aidl
@@ -41,8 +41,12 @@ oneway interface IMotionSensorControllerListener {
     /**
      * @brief Called when the sensor transitions to a new lifecycle state.
      *
-     * Fired for all transitions driven by start(), stop(), open(), close(),
-     * and error conditions.
+     * Fired for all transitions driven by start(), stop(), and error
+     * conditions. The motion sensor State enum covers STOPPED, STARTING,
+     * STARTED, STOPPING, ERROR — controller acquisition (IMotionSensor.open)
+     * and release (IMotionSensor.close) do not produce dedicated state
+     * values; they bracket the STOPPED period during which the controller
+     * exists.
      *
      * @param[in] oldState  The state being left.
      * @param[in] newState  The state being entered.
@@ -58,8 +62,10 @@ oneway interface IMotionSensorControllerListener {
      * the active period.
      *
      * Only fires when active windows have been configured via
-     * IMotionSensorController.setActiveWindows(). Not fired if 24-hour
-     * monitoring is active (no windows configured).
+     * IMotionSensorController.setActiveWindows() with a non-empty array.
+     * Not fired when 24-hour monitoring is in effect, whether that is
+     * because no windows have been set or because setActiveWindows() was
+     * called with an empty array.
      */
     void onActiveWindowEntered();
 
@@ -70,7 +76,8 @@ oneway interface IMotionSensorControllerListener {
      * windows. Motion events are suppressed while outside active windows.
      *
      * Only fires when active windows have been configured via
-     * IMotionSensorController.setActiveWindows().
+     * IMotionSensorController.setActiveWindows() with a non-empty array.
+     * Not fired in 24-hour monitoring mode (no windows / empty array).
      */
     void onActiveWindowExited();
 }

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorControllerListener.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorControllerListener.aidl
@@ -1,0 +1,69 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file IMotionSensorControllerListener.aidl
+ * @brief Controller callback listener for motion sensor lifecycle and
+ *        active window transitions.
+ *
+ * Passed into {@link IMotionSensor#open(IMotionSensorControllerListener)}.
+ * Delivered exclusively to the controller owner. All callbacks are oneway
+ * (non-blocking, fire-and-forget).
+ *
+ * Motion/no-motion detection events are delivered separately on
+ * {@link IMotionSensorEventListener} to any registered observer.
+ *
+ * @author Gerald Weatherup
+ */
+package com.rdk.hal.sensor.motion;
+
+import com.rdk.hal.sensor.motion.State;
+
+@VintfStability
+oneway interface IMotionSensorControllerListener {
+
+    /**
+     * @brief Called when the sensor transitions to a new lifecycle state.
+     *
+     * Fired for all transitions driven by start(), stop(), open(), close(),
+     * and error conditions.
+     *
+     * @param[in] oldState  The state being left.
+     * @param[in] newState  The state being entered.
+     */
+    void onStateChanged(in State oldState, in State newState);
+
+    /**
+     * @brief Called when the sensor enters a configured active monitoring window.
+     *
+     * Only fires when active windows have been configured via
+     * IMotionSensorController.setActiveWindows(). Not fired if 24-hour
+     * monitoring is active (no windows configured).
+     */
+    void onActiveWindowEntered();
+
+    /**
+     * @brief Called when the sensor exits a configured active monitoring window.
+     *
+     * Motion events are suppressed while outside active windows. Only fires
+     * when active windows have been configured via
+     * IMotionSensorController.setActiveWindows().
+     */
+    void onActiveWindowExited();
+}

--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorManager.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorManager.aidl
@@ -33,6 +33,7 @@ import com.rdk.hal.sensor.motion.IMotionSensor;
  * @interface IMotionSensorManager
  * @brief Top-level manager interface for Motion Sensor HAL access.
  */
+@VintfStability
 interface IMotionSensorManager {
     /**
      * @brief Binder service registration name.

--- a/sensor/current/com/rdk/hal/sensor/motion/LastEventInfo.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/LastEventInfo.aidl
@@ -37,8 +37,9 @@ parcelable LastEventInfo {
     OperationalMode mode;
 
     /**
-     * @brief Wall-clock timestamp in nanoseconds when the event occurred.
+     * @brief Monotonic timestamp in nanoseconds when the event occurred.
      *
+     * Uses the same time base as CLOCK_MONOTONIC / System.nanoTime().
      * Elapsed time since the event is computed as (System.nanoTime() - timestampNs).
      */
     long timestampNs;

--- a/sensor/current/com/rdk/hal/sensor/motion/LastEventInfo.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/LastEventInfo.aidl
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2025 RDK Management
+ * Copyright 2026 RDK Management
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,28 @@
  */
 
 /**
- * @file IMotionSensorEventListener.aidl
- * @brief Client callback interface for motion sensor events.
+ * @file LastEventInfo.aidl
+ * @brief Diagnostic snapshot of the most recent motion sensor event.
+ *
+ * Returned by {@link IMotionSensorController#getLastEventInfo()}.
+ * Allows debug tools to determine what happened last and when, without
+ * replaying the event stream.
  */
 package com.rdk.hal.sensor.motion;
 
 import com.rdk.hal.sensor.motion.OperationalMode;
 
 @VintfStability
-oneway interface IMotionSensorEventListener {
+parcelable LastEventInfo {
     /**
-     * @brief Invoked when the sensor detects an event that matches the active operational mode.
-     * @param mode The active mode whose condition was met (MOTION or NO_MOTION).
+     * @brief The event type (MOTION or NO_MOTION).
      */
-    void onEvent(in OperationalMode mode);
+    OperationalMode mode;
+
+    /**
+     * @brief Wall-clock timestamp in nanoseconds when the event occurred.
+     *
+     * Elapsed time since the event is computed as (System.nanoTime() - timestampNs).
+     */
+    long timestampNs;
 }

--- a/sensor/current/com/rdk/hal/sensor/motion/OperationalMode.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/OperationalMode.aidl
@@ -21,8 +21,8 @@
  * @file OperationalMode.aidl
  * @brief Operation trigger mode for motion detection.
  *
- * When {@link IMotionSensor#start(OperationalMode,int,int,int)} is called,
- * the sensor fires the event only for the selected mode (motion vs. no-motion).
+ * When {@link IMotionSensorController#start(StartConfig)} is called,
+ * the sensor fires events only for the mode specified in StartConfig.operationalMode.
  */
 package com.rdk.hal.sensor.motion;
 

--- a/sensor/current/com/rdk/hal/sensor/motion/StartConfig.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/StartConfig.aidl
@@ -42,6 +42,9 @@ parcelable StartConfig {
      * @brief Contiguous seconds without motion before a NO_MOTION event fires.
      *
      * Only meaningful when operationalMode is NO_MOTION. Use 0 to disable.
+     *
+     * Valid range: 0 (disabled), or 1–86400 (1 second to 24 hours).
+     * Values outside this range cause start() to throw EX_ILLEGAL_ARGUMENT.
      */
     int noMotionSeconds;
 

--- a/sensor/current/com/rdk/hal/sensor/motion/StartConfig.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/StartConfig.aidl
@@ -1,0 +1,62 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file StartConfig.aidl
+ * @brief Configuration parameters for starting a motion sensor session.
+ *
+ * Passed to {@link IMotionSensorController#start(StartConfig)} and
+ * retrievable via {@link IMotionSensorController#getStartConfig()}.
+ */
+package com.rdk.hal.sensor.motion;
+
+import com.rdk.hal.sensor.motion.OperationalMode;
+
+@VintfStability
+parcelable StartConfig {
+    /**
+     * @brief Operational mode — determines which event type the sensor reports.
+     *
+     * MOTION: fire onEvent when motion is detected.
+     * NO_MOTION: fire onEvent after noMotionSeconds of inactivity.
+     */
+    OperationalMode operationalMode;
+
+    /**
+     * @brief Contiguous seconds without motion before a NO_MOTION event fires.
+     *
+     * Only meaningful when operationalMode is NO_MOTION. Use 0 to disable.
+     */
+    int noMotionSeconds;
+
+    /**
+     * @brief Delay in seconds before the sensor becomes active after start().
+     *
+     * Allows the caller to vacate the detection area before monitoring begins.
+     * Use 0 for immediate activation.
+     */
+    int activeStartSeconds;
+
+    /**
+     * @brief Duration in seconds after which the sensor automatically stops.
+     *
+     * Use 0 for no automatic stop (sensor runs until stop() is called).
+     */
+    int activeStopSeconds;
+}

--- a/sensor/current/com/rdk/hal/sensor/motion/hfp-sensor-motion.yaml
+++ b/sensor/current/com/rdk/hal/sensor/motion/hfp-sensor-motion.yaml
@@ -75,4 +75,4 @@ sensor:
       notes:
         - "Front-facing PIR motion detector."
         - "Supports autonomous operation during deep sleep."
-        - "Active windows can be configured via setActiveWindows()."
+        - "Active windows can be configured via IMotionSensorController.setActiveWindows()."

--- a/sensor/current/com/rdk/hal/sensor/motion/hfp-sensor-motion.yaml
+++ b/sensor/current/com/rdk/hal/sensor/motion/hfp-sensor-motion.yaml
@@ -45,7 +45,8 @@ sensor:
       #
       # These values declare the platform's factory defaults and supported
       # modes. They are NOT runtime configuration — actual runtime parameters
-      # are set via IMotionSensor.start() and setActiveWindows().
+      # are set via IMotionSensorController.start(StartConfig) and
+      # IMotionSensorController.setActiveWindows().
       #
       # Used by:
       #   - VTS test automation to validate against declared capabilities
@@ -55,11 +56,13 @@ sensor:
       operational_modes:       # Supported OperationalMode values
         - MOTION
         - NO_MOTION
-      default_mode: MOTION     # Factory default operational mode
-      timing:                  # Factory default timing parameters for start()
-        no_motion_seconds: 5     # Default inactivity window before NO_MOTION event
-        active_start_seconds: 0  # Default activation delay (0 = immediate)
-        active_stop_seconds: 0   # Default auto-stop (0 = no automatic stop)
+
+      # Factory default StartConfig values (maps to StartConfig.aidl fields)
+      defaultStartConfig:
+        operationalMode: MOTION       # StartConfig.operationalMode
+        noMotionSeconds: 5            # StartConfig.noMotionSeconds
+        activeStartSeconds: 0         # StartConfig.activeStartSeconds (0 = immediate)
+        activeStopSeconds: 0          # StartConfig.activeStopSeconds (0 = no auto-stop)
       active_windows:          # Factory default active windows (example values)
         # Example: Monitor during business hours (9am-5pm) and evening (8pm-10pm)
         - startTimeOfDaySeconds: 32400  # 09:00:00 (9 * 3600)


### PR DESCRIPTION
## Summary

Adopts the controller pattern for the motion sensor HAL, aligning with hdmiinput, compositeinput, and other stateful modules. Resolves #427.

- **`IMotionSensorController`** — exclusive write controller returned by `open()`: `start(StartConfig)`, `stop()`, `getStartConfig()`, `getLastEventInfo()`, sensitivity, deep sleep autonomy, active windows
- **`IMotionSensorControllerListener`** — `onStateChanged(oldState, newState)`, `onActiveWindowEntered()`, `onActiveWindowExited()`
- **`StartConfig`** parcelable — bundles all `start()` parameters with a getter for config retrieval
- **`LastEventInfo`** parcelable — diagnostic: last event mode + timestamp
- **`IMotionSensor`** refactored — gains `open(listener)`/`close(controller)`, keeps `getCapabilities()`/`getState()`/event listener registration, all mutators moved to controller
- Fixed missing `@VintfStability` on `IMotionSensor`, `IMotionSensorManager`, `IMotionSensorEventListener` (pre-existing omissions)
- HFP timing section renamed to `defaultStartConfig` matching parcelable field names

### Breaking change

`start()` moves from `IMotionSensor` (4 params) to `IMotionSensorController.start(StartConfig)`. All configuration/mutation methods move to the controller. Pre-freeze, no consumers — no migration shim needed.

## Test plan

- [ ] AIDL compiles cleanly (verified locally)
- [ ] `IMotionSensor.open()` / `close()` present and correctly typed
- [ ] `IMotionSensorController.start(StartConfig)` / `stop()` / `getStartConfig()` / `getLastEventInfo()` present
- [ ] `IMotionSensorControllerListener.onStateChanged()` / `onActiveWindowEntered()` / `onActiveWindowExited()` present
- [ ] `IMotionSensorEventListener.onEvent()` unchanged
- [ ] `IMotionSensor` no longer has start/stop/setSensitivity/setActiveWindows etc.
- [ ] All interfaces have `@VintfStability`
- [ ] CMakeLists.txt includes all new files
- [ ] HFP `defaultStartConfig` fields match `StartConfig.aidl` field names