### PR TITLE
fix: RAG workflow creates PR instead of direct push, add Vendor_Layer_Team (#375, #361)

### DIFF
--- a/.github/workflows/update-rag-report.yml
+++ b/.github/workflows/update-rag-report.yml
@@ -19,11 +19,21 @@ jobs:
         run: bash scripts/generate_rag_report.sh
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "chore: update RAG status report"
-          branch: chore/update-rag-report
-          title: "chore: update RAG status report"
-          body: "Automated update of RAG_STATUS_REPORT.md triggered by a push to develop."
-          labels: scope:infrastructure
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/update-rag-report"
+          git checkout -b "$BRANCH"
+          git add RAG_STATUS_REPORT.md
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: update RAG status report"
+          git push --force origin "$BRANCH"
+          # Create PR only if one doesn't already exist for this branch
+          if ! gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create --base develop --head "$BRANCH" \
+              --title "chore: update RAG status report" \
+              --body "Automated update of RAG_STATUS_REPORT.md triggered by a push to develop." \
+              --label "scope:infrastructure"
+          fi

--- a/.github/workflows/update-rag-report.yml
+++ b/.github/workflows/update-rag-report.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   update-report:

--- a/.github/workflows/update-rag-report.yml
+++ b/.github/workflows/update-rag-report.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-report:
@@ -17,11 +18,12 @@ jobs:
       - name: Generate RAG report
         run: bash scripts/generate_rag_report.sh
 
-      - name: Commit updated report
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add RAG_STATUS_REPORT.md
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update RAG status report [skip ci]"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update RAG status report"
+          branch: chore/update-rag-report
+          title: "chore: update RAG status report"
+          body: "Automated update of RAG_STATUS_REPORT.md triggered by a push to develop."
+          labels: scope:infrastructure
+          delete-branch: true

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -26,26 +26,26 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 6/6 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 5/6 | Architecture + VTS_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 6/6 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 6/6 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 6/6 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 5/6 | Architecture + AV_Architecture |
-| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/6 | Architecture + AV_Architecture |
-| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/6 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 6/6 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 6/6 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/5 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/5 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/5 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/5 | Architecture + AV_Architecture |
+| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/5 | Architecture + AV_Architecture |
+| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/5 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/5 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/5 | Architecture + AV_Architecture |
 
 
 ### OEM Components
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/6 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 5/6 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 5/6 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 5/6 | Architecture + Kernel_Architecture |
+| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/5 | Architecture + AV_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/5 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/5 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/5 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -107,65 +107,65 @@
 
 ### SOC — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | audiodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiomixer | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avbuffer | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avclock | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmicec | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | videodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | videosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | audiodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiomixer | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avbuffer | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avclock | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmicec | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmiinput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | hdmioutput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | videodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | videosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | vsi/kernel | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | planecontrol | 0/7 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | vsi/graphics | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | vsi/kernel | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | vsi/graphics | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | vsi/crypto | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🔴 | vsi/keyvault | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | vsi/crypto | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🔴 | vsi/keyvault | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 
 ### OEM — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | compositeinput | 2/6 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | deviceinfo | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
-| 🟢 | indicator | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | sensor | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | compositeinput | 2/5 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deviceinfo | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | indicator | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | sensor | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | panel | 2/6 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | boot | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | broadcast | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | flash | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | r4ce | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/bluetooth | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/linuxinput | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/wifi | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/abstractfilesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/filesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | ffv | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | deepsleep | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | boot | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | broadcast | 0/5 | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | flash | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | r4ce | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
+| 🟡 | vsi/bluetooth | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/linuxinput | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/wifi | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/abstractfilesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/filesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | ffv | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | cdm | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | cdm | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ---
 
@@ -178,7 +178,6 @@
 | RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
-| VTS_Team | All components |
 | AV_Architecture | Audio/Video pipeline components |
 | Broadcast_Team | Broadcast/tuner components |
 | Control_Manager_Architecture | Remote control & input management |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -26,16 +26,16 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/6 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/6 | Architecture + VTS_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/6 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/6 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/6 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/6 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 6/6 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 5/6 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 6/6 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 6/6 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 6/6 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 5/6 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/6 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/6 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/6 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/6 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 6/6 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 6/6 | Architecture + AV_Architecture |
 
 
 ### OEM Components
@@ -43,9 +43,9 @@
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/6 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/6 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/6 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/6 | Architecture + Kernel_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 5/6 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 5/6 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 5/6 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -109,16 +109,16 @@
 
 | | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | audiodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | audiomixer | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | audiosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | avbuffer | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | avclock | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | hdmicec | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | videodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | videosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiomixer | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avbuffer | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avclock | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmicec | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | videodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | videosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
@@ -140,19 +140,19 @@
 | | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟢 | compositeinput | 2/6 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | deviceinfo | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
-| 🟢 | indicator | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ☐ |
-| 🟢 | sensor | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
+| 🟢 | deviceinfo | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | indicator | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | sensor | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
 | | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟡 | panel | 2/6 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | boot | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | deepsleep | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | boot | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟡 | broadcast | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | flash | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | flash | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟡 | r4ce | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
 | 🟡 | vsi/bluetooth | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
 | 🟡 | vsi/linuxinput | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -26,26 +26,26 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/5 | Architecture + VTS_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/5 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/5 | Architecture + AV_Architecture |
-| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/5 | Architecture + AV_Architecture |
-| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/5 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 4/4 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 4/4 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
+| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
+| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 4/4 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 4/4 | Architecture + AV_Architecture |
 
 
 ### OEM Components
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/5 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/5 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/5 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/5 | Architecture + Kernel_Architecture |
+| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/4 | Architecture + AV_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/4 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/4 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -107,65 +107,65 @@
 
 ### SOC — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | audiodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiomixer | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avbuffer | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avclock | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmicec | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmiinput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | hdmioutput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | videodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | videosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | audiodecoder | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiomixer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiosink | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avbuffer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avclock | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmicec | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmiinput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | hdmioutput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | videodecoder | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | videosink | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | vsi/kernel | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | planecontrol | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | vsi/graphics | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | vsi/kernel | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | vsi/graphics | 0/4 | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | vsi/crypto | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🔴 | vsi/keyvault | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | vsi/crypto | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🔴 | vsi/keyvault | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 
 ### OEM — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | compositeinput | 2/5 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | deviceinfo | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
-| 🟢 | indicator | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | sensor | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | compositeinput | 2/4 | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deviceinfo | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | indicator | 4/4 | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | sensor | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | panel | 2/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | boot | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | broadcast | 0/5 | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | flash | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | r4ce | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/bluetooth | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/linuxinput | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/wifi | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/abstractfilesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/filesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | ffv | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/4 | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | deepsleep | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | boot | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | broadcast | 0/4 | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | flash | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | r4ce | 0/4 | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
+| 🟡 | vsi/bluetooth | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/linuxinput | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/wifi | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/abstractfilesystem | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/filesystem | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | ffv | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | cdm | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | cdm | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ---
 
@@ -175,7 +175,6 @@
 
 | Team | Role |
 |------|------|
-| RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
 | AV_Architecture | Audio/Video pipeline components |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-04-22 |
+| **Generated** | 2026-04-23 |
 | **Components** | 32 |
 | 🟢 **GREEN** | 14 |
 | 🟡 **AMBER** | 15 |
@@ -27,7 +27,7 @@
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 4/4 | Architecture + AV_Architecture |
@@ -69,7 +69,7 @@
 | 🟡 | panel | 0.1.0.0 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
 | 🟡 | deepsleep | 0.1.0.0 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
 | 🟡 | boot | 0.1.0.0 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
-| 🟡 | broadcast | 0.0.0.1 | 5 | PR under review | Review Required - Start the PR Review | 2026-03-18 | 2026-03-25 | VTS_Team + Broadcast_Team |
+| 🟡 | broadcast | 0.0.0.1 | 5 | PR under review | Review Required - Start the PR Review | 2026-03-18 | 2026-03-25 | Vendor_Layer_Team + Broadcast_Team |
 | 🟡 | flash | 0.1.0.0 | 5 | Migrate -> Image | Rename Module | — | — | Architecture + Kernel_Architecture |
 | 🟡 | r4ce | 0.0.0.1 | 5 | API Definition in progress | Control Manager Team - API Definition started | — | — | Architecture + Control_Manager_Architecture |
 | 🟡 | vsi/bluetooth | 0.0.0.1 | 6 | Docs required | Not blocking progress - Have discussions write up methodology, Discussions with Bluetooth Team | 2026-03-24 | 2026-03-31 | Architecture + Connectivity_Architecture |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,10 +2,10 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-03-11 |
+| **Generated** | 2026-04-22 |
 | **Components** | 32 |
-| 🟢 **GREEN** | 13 |
-| 🟡 **AMBER** | 16 |
+| 🟢 **GREEN** | 14 |
+| 🟡 **AMBER** | 15 |
 | 🔴 **RED** | 3 |
 
 ---
@@ -14,8 +14,8 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **13** | Reviewed & Approved — Interface stable on develop |
-| 🟡 AMBER | **16** | Under Active Ingestion — Will enter sprint review when ready |
+| 🟢 GREEN | **14** | Reviewed & Approved — Interface stable on develop |
+| 🟡 AMBER | **15** | Under Active Ingestion — Will enter sprint review when ready |
 | 🔴 RED | **3** | Not Started / Blocked — Strategy or definition required |
 
 ---
@@ -26,25 +26,26 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/5 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/5 | Architecture + AV_Architecture |
-| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/5 | Architecture + AV_Architecture |
-| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/5 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/6 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/6 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/6 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/6 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/6 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/6 | Architecture + AV_Architecture |
+| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/6 | Architecture + AV_Architecture |
+| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/6 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/6 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/6 | Architecture + AV_Architecture |
 
 
 ### OEM Components
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | compositeinput | 0.1.0.0 | Composite video input capture and control | 2/5 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/5 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/5 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/5 | Architecture + Kernel_Architecture |
+| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/6 | Architecture + AV_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/6 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/6 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/6 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -57,7 +58,6 @@
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
 | 🟡 | avbuffer *(SVP risk)* | 0.1.0.0 | 1 | Encrypted buffer (DRM/SVP) - Pending on DRM strategy | May change due to SVP changes from DRM which is being worked on | — | — | Architecture + AV_Architecture |
 | 🟡 | vsi/kernel | 0.0.0.1 | 1 | Strategy required | Not blocking progress - Architecture Strategy | — | — | Architecture |
-| 🟡 | audiomixer | 0.0.0.1 | 2 | PR under review | In Progress PR Review | — | — | VTS_Team + AV_Architecture |
 | 🟡 | planecontrol | 0.1.0.0 | 3 | Re-review required | Discussions with MW team - Simplify design. Architecture requires simplified design and restructured review. | — | — | Architecture + Graphics_Architecture |
 | 🟡 | vsi/graphics | 0.0.0.1 | 6 | Docs required | Not blocking progress - Define Versions & write up vision and direction, Planning Out Evolution of the platform, RDK-M | — | — | Architecture + Graphics_Architecture |
 
@@ -66,9 +66,9 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
-| 🟡 | panel | 0.0.0.1 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
-| 🟡 | deepsleep | 0.0.0.1 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
-| 🟡 | boot | 0.0.0.1 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
+| 🟡 | panel | 0.1.0.0 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
+| 🟡 | deepsleep | 0.1.0.0 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
+| 🟡 | boot | 0.1.0.0 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
 | 🟡 | broadcast | 0.0.0.1 | 5 | PR under review | Review Required - Start the PR Review | 2026-03-18 | 2026-03-25 | VTS_Team + Broadcast_Team |
 | 🟡 | flash | 0.1.0.0 | 5 | Migrate -> Image | Rename Module | — | — | Architecture + Kernel_Architecture |
 | 🟡 | r4ce | 0.0.0.1 | 5 | API Definition in progress | Control Manager Team - API Definition started | — | — | Architecture + Control_Manager_Architecture |
@@ -107,65 +107,65 @@
 
 ### SOC — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟢 | audiodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | audiosink | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | avbuffer | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | avclock | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | hdmicec | 4/5 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | hdmiinput | 3/5 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | hdmioutput | 3/5 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | videodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | videosink | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | audiodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiomixer | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | avbuffer | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | avclock | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | hdmicec | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | videodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | videosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### SOC — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟡 | vsi/kernel | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | audiomixer | 0/5 | ☐ | 🔍 | 🔍 | 🔍 | 🔍 | N/A | N/A | N/A | N/A | N/A |
-| 🟡 | planecontrol | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A |
-| 🟡 | vsi/graphics | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | vsi/kernel | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/7 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | vsi/graphics | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🔴 | vsi/crypto | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🔴 | vsi/keyvault | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | vsi/crypto | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🔴 | vsi/keyvault | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 
 ### OEM — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟢 | compositeinput | 2/5 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | deviceinfo | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | indicator | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A |
-| 🟢 | sensor | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | compositeinput | 2/6 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deviceinfo | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
+| 🟢 | indicator | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ☐ |
+| 🟢 | sensor | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
 
 ### OEM — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟡 | panel | 2/5 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A |
-| 🟡 | deepsleep | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | boot | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | broadcast | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A |
-| 🟡 | flash | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | r4ce | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A |
-| 🟡 | vsi/bluetooth | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A |
-| 🟡 | vsi/linuxinput | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/wifi | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A |
-| 🟡 | vsi/abstractfilesystem | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/filesystem | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | ffv | 0/5 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/6 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | deepsleep | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | boot | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | broadcast | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | flash | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | r4ce | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
+| 🟡 | vsi/bluetooth | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/linuxinput | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/wifi | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/abstractfilesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/filesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | ffv | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🔴 | cdm | 0/5 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | cdm | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ---
 
@@ -185,6 +185,7 @@
 | Graphics_Architecture | Graphics, display & composition |
 | Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity |
 | Kernel_Architecture | System, kernel, boot & platform |
+| Vendor_Layer_Team | Vendor HAL implementation review |
 
 ---
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiodecoder
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Audio decoder resource management and codec format support"
 type: SOC

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiomixer
 version: 0.1.0.1
-generation: 0
 status: GREEN
 description: "Audio mixing and routing for multi-stream output"
 type: SOC

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -50,7 +50,7 @@ scope:
 #   risk          - Risk notes (appears as watch item on dashboard)
 #   owners        - Responsible architecture teams
 notes:
-  owners: "Architecture + VTS_Team + AV_Architecture"
+  owners: "Architecture + Vendor_Layer_Team + AV_Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -60,7 +60,6 @@ reviewers:
     RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
-    VTS_Team: reviewed
     AV_Architecture: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiosink
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Audio output rendering and sink device management"
 type: SOC

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
+    Vendor_Layer_Team: pending
 

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
+    Vendor_Layer_Team: pending
 

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avbuffer
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "AV buffer allocation and secure video path management"
 type: SOC

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -63,7 +63,6 @@ reviewers:
     RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
-    VTS_Team: reviewed
     AV_Architecture: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avclock
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Audio/video clock synchronization and timing control"
 type: SOC

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: boot
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Boot reason tracking and reboot management"
 type: OEM

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Broadcast_Team: pending

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: pending
     VTS_Team: pending
     Broadcast_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: broadcast
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Broadcast tuner and RF frontend interface"
 type: OEM

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -63,7 +63,6 @@ reviewers:
     RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
-    VTS_Team: pending
     Broadcast_Team: pending
     Vendor_Layer_Team: pending
 

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -53,7 +53,7 @@ notes:
   priority: 5
   status_detail: "PR under review"
   action: "Review Required - Start the PR Review"
-  owners: "VTS_Team + Broadcast_Team"
+  owners: "Vendor_Layer_Team + Broadcast_Team"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: pending
     AV_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: cdm
 version: 0.0.0.1
-generation: 0
 status: RED
 description: "Content decryption module and DRM key management"
 type: OEM

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: pending

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: compositeinput
 version: 0.2.0.0
-generation: 2
 status: GREEN
 description: "Composite video input capture and control"
 type: OEM

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: deepsleep
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Deep sleep and low-power state management"
 type: OEM

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: deviceinfo
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Device information and platform capability reporting"
 type: OEM

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: ffv
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Far-field voice capture and mic array processing"
 type: OEM

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     AV_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: flash
 version: 0.1.0.0
-generation: 0
 status: AMBER
 description: "Firmware image storage and update management"
 type: OEM

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: hdmicec
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "HDMI CEC protocol messaging and device control"
 type: SOC

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
+    Vendor_Layer_Team: pending
 

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: recheck
     Vendor_Layer_Team: recheck
 

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: hdmiinput
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "HDMI input port management and signal detection"
 type: SOC

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: recheck
 

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
+    Vendor_Layer_Team: pending
 

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: recheck
     Vendor_Layer_Team: recheck
 

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: hdmioutput
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "HDMI output port configuration and display control"
 type: SOC

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: recheck
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: indicator
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "LED and visual indicator state management"
 type: OEM

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: panel
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Front panel display and button control"
 type: OEM

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Graphics_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: pending

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -66,4 +66,5 @@ reviewers:
     AV_Architecture: pending
     Graphics_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: planecontrol
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Graphics and video plane composition control"
 type: SOC

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -65,6 +65,5 @@ reviewers:
     Product_Architecture: pending
     AV_Architecture: pending
     Graphics_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: pending
     Control_Manager_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Control_Manager_Architecture: pending

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: r4ce
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "RF4CE remote control protocol and pairing"
 type: OEM

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Control_Manager_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -106,7 +106,7 @@ review_icon() {
 }
 
 # All teams (column order)
-ALL_TEAMS="RTAB_Group Architecture Product_Architecture VTS_Team AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture"
+ALL_TEAMS="RTAB_Group Architecture Product_Architecture VTS_Team AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
 
 # Derive component path label (e.g. "vsi/kernel" or "boot")
 component_path() {
@@ -337,8 +337,8 @@ RED_SHARED
 echo -e "$RED_SHARED_ROWS" >> "$OUTPUT"
 fi
 
-REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|"
+REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|"
 
 cat >> "$OUTPUT" << 'REVIEW_SECTION'
 
@@ -420,6 +420,7 @@ cat >> "$OUTPUT" << 'FOOTER'
 | Graphics_Architecture | Graphics, display & composition |
 | Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity |
 | Kernel_Architecture | System, kernel, boot & platform |
+| Vendor_Layer_Team | Vendor HAL implementation review |
 
 ---
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -106,7 +106,7 @@ review_icon() {
 }
 
 # All teams (column order)
-ALL_TEAMS="RTAB_Group Architecture Product_Architecture VTS_Team AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
+ALL_TEAMS="RTAB_Group Architecture Product_Architecture AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
 
 # Derive component path label (e.g. "vsi/kernel" or "boot")
 component_path() {
@@ -337,8 +337,8 @@ RED_SHARED
 echo -e "$RED_SHARED_ROWS" >> "$OUTPUT"
 fi
 
-REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|"
+REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|"
 
 cat >> "$OUTPUT" << 'REVIEW_SECTION'
 
@@ -413,7 +413,6 @@ cat >> "$OUTPUT" << 'FOOTER'
 | RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
-| VTS_Team | All components |
 | AV_Architecture | Audio/Video pipeline components |
 | Broadcast_Team | Broadcast/tuner components |
 | Control_Manager_Architecture | Remote control & input management |

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -106,7 +106,7 @@ review_icon() {
 }
 
 # All teams (column order)
-ALL_TEAMS="RTAB_Group Architecture Product_Architecture AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
+ALL_TEAMS="Architecture Product_Architecture AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
 
 # Derive component path label (e.g. "vsi/kernel" or "boot")
 component_path() {
@@ -337,8 +337,8 @@ RED_SHARED
 echo -e "$RED_SHARED_ROWS" >> "$OUTPUT"
 fi
 
-REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|"
+REVIEW_HEADER="| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|"
 
 cat >> "$OUTPUT" << 'REVIEW_SECTION'
 
@@ -410,7 +410,6 @@ cat >> "$OUTPUT" << 'FOOTER'
 
 | Team | Role |
 |------|------|
-| RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
 | AV_Architecture | Audio/Video pipeline components |

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,7 +31,7 @@ Usage:
 
 Options:
   --since <ref>  Base reference to diff from (default: nearest reachable tag).
-  --apply        Apply computed version/generation updates to metadata.yaml.
+  --apply        Apply computed version updates to metadata.yaml.
   --no-gh        Disable GitHub label lookup and use local heuristics only.
   --verbose      Print extra diagnostics.
   --help         Show this help.
@@ -276,11 +276,9 @@ fi
 
 compute_next_versions() {
     local current_version="$1"
-    local current_generation="$2"
-    local bump="$3"
+    local bump="$2"
 
     NEXT_VERSION="${current_version}"
-    NEXT_GENERATION="${current_generation}"
     NEXT_NOTE=""
 
     if [[ "${bump}" == "none" ]]; then
@@ -305,7 +303,6 @@ compute_next_versions() {
         fi
 
         NEXT_VERSION="0.${gen}.${minor}.${patch}"
-        NEXT_GENERATION="${gen}"
         return 0
     fi
 
@@ -328,12 +325,8 @@ compute_next_versions() {
 update_metadata() {
     local file="$1"
     local new_version="$2"
-    local new_generation="$3"
 
     sed -i -E "s/^version:.*/version: ${new_version}/" "${file}"
-    if grep -q '^generation:' "${file}"; then
-        sed -i -E "s/^generation:.*/generation: ${new_generation}/" "${file}"
-    fi
 }
 
 MODE="DRY-RUN"
@@ -367,8 +360,6 @@ for comp in "${TOUCHED_COMPONENTS[@]}"; do
     fi
 
     current_version="$(awk -F': *' '$1=="version"{print $2; exit}' "${meta}")"
-    current_generation="$(awk -F': *' '$1=="generation"{print $2; exit}' "${meta}")"
-    [[ -n "${current_generation}" ]] || current_generation="0"
 
     bump="none"
     if [[ "${COMP_BREAKING[$comp]:-0}" -eq 1 ]]; then
@@ -379,7 +370,7 @@ for comp in "${TOUCHED_COMPONENTS[@]}"; do
         bump="patch"
     fi
 
-    compute_next_versions "${current_version}" "${current_generation}" "${bump}"
+    compute_next_versions "${current_version}" "${bump}"
 
     status="ok"
     if [[ "${NEXT_NOTE}" == "breaking change on frozen interface: create new component instead" ]]; then
@@ -400,14 +391,14 @@ for comp in "${TOUCHED_COMPONENTS[@]}"; do
     fi
 
     if [[ "${APPLY}" -eq 1 ]]; then
-        if [[ "${current_version}" != "${NEXT_VERSION}" || "${current_generation}" != "${NEXT_GENERATION}" ]]; then
+        if [[ "${current_version}" != "${NEXT_VERSION}" ]]; then
             if [[ "${status}" == "ok" ]]; then
-                update_metadata "${meta}" "${NEXT_VERSION}" "${NEXT_GENERATION}"
+                update_metadata "${meta}" "${NEXT_VERSION}"
                 changed_count=$((changed_count + 1))
             fi
         fi
     else
-        if [[ "${current_version}" != "${NEXT_VERSION}" || "${current_generation}" != "${NEXT_GENERATION}" ]]; then
+        if [[ "${current_version}" != "${NEXT_VERSION}" ]]; then
             changed_count=$((changed_count + 1))
         fi
     fi

--- a/scripts/request_reviews.sh
+++ b/scripts/request_reviews.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2025 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+#
+# Reads the metadata.yaml reviewers for components affected by a PR,
+# maps internal team names to GitHub team slugs, and requests reviews
+# from teams that have not yet completed their review.
+#
+# Usage: bash scripts/request_reviews.sh <PR_NUMBER> [--dry-run]
+#
+# Requires: gh CLI authenticated with access to rdkcentral org
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAPPING_FILE="${REPO_ROOT}/scripts/team_mapping.yaml"
+REPO="rdkcentral/rdk-halif-aidl"
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <PR_NUMBER> [--dry-run]"
+    exit 1
+fi
+
+PR_NUMBER="$1"
+DRY_RUN="${2:-}"
+
+# --- Load team mapping ---
+declare -A TEAM_MAP
+while IFS=': ' read -r key value; do
+    # Skip comments and blank lines
+    [[ "$key" =~ ^#.*$ || -z "$key" ]] && continue
+    TEAM_MAP["$key"]="$value"
+done < "$MAPPING_FILE"
+
+echo "Loaded ${#TEAM_MAP[@]} team mappings"
+
+# --- Get changed files from the PR ---
+echo "Fetching changed files for PR #${PR_NUMBER}..."
+CHANGED_FILES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
+
+# --- Derive affected components from file paths ---
+declare -A COMPONENTS
+for file in $CHANGED_FILES; do
+    # Match top-level component dirs (e.g. audiodecoder/..., boot/...)
+    # or nested ones (e.g. vsi/kernel/...)
+    component=""
+    if [[ "$file" =~ ^(vsi/[^/]+)/ ]]; then
+        component="${BASH_REMATCH[1]}"
+    elif [[ "$file" =~ ^([^/]+)/ ]]; then
+        candidate="${BASH_REMATCH[1]}"
+        # Only count as component if it has a metadata.yaml
+        if [ -f "${REPO_ROOT}/${candidate}/metadata.yaml" ]; then
+            component="$candidate"
+        fi
+    fi
+    if [ -n "$component" ]; then
+        COMPONENTS["$component"]=1
+    fi
+done
+
+if [ ${#COMPONENTS[@]} -eq 0 ]; then
+    echo "No component metadata.yaml found for changed files. Nothing to do."
+    exit 0
+fi
+
+echo "Affected components: ${!COMPONENTS[*]}"
+
+# --- Collect teams that need to review ---
+declare -A REVIEW_TEAMS
+
+for component in "${!COMPONENTS[@]}"; do
+    metadata="${REPO_ROOT}/${component}/metadata.yaml"
+    if [ ! -f "$metadata" ]; then
+        echo "  WARN: ${metadata} not found, skipping"
+        continue
+    fi
+
+    echo "  Reading ${component}/metadata.yaml..."
+    in_reviewers=false
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^reviewers: ]]; then
+            in_reviewers=true
+            continue
+        fi
+        # Exit reviewers block on next top-level key
+        if $in_reviewers && [[ "$line" =~ ^[a-zA-Z] ]]; then
+            break
+        fi
+        if $in_reviewers; then
+            # Parse "    Team_Name: status"
+            if [[ "$line" =~ ^[[:space:]]+([A-Za-z_]+):[[:space:]]+(.+) ]]; then
+                team="${BASH_REMATCH[1]}"
+                status="${BASH_REMATCH[2]}"
+                # Request review from teams that haven't completed review
+                if [ "$status" != "reviewed" ] && [ "$status" != "abstained" ]; then
+                    if [ -n "${TEAM_MAP[$team]:-}" ]; then
+                        REVIEW_TEAMS["${TEAM_MAP[$team]}"]="$team ($status) [${component}]"
+                    else
+                        echo "    WARN: No GitHub team mapping for '${team}'"
+                    fi
+                fi
+            fi
+        fi
+    done < "$metadata"
+done
+
+if [ ${#REVIEW_TEAMS[@]} -eq 0 ]; then
+    echo "All reviewer teams have completed their reviews. No requests needed."
+    exit 0
+fi
+
+# --- Request reviews ---
+echo ""
+echo "Teams to request review from:"
+for slug in "${!REVIEW_TEAMS[@]}"; do
+    echo "  ${slug} ← ${REVIEW_TEAMS[$slug]}"
+done
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo ""
+    echo "[DRY RUN] Would run:"
+    for slug in "${!REVIEW_TEAMS[@]}"; do
+        echo "  gh pr edit ${PR_NUMBER} --repo ${REPO} --add-reviewer rdkcentral/${slug}"
+    done
+else
+    echo ""
+    for slug in "${!REVIEW_TEAMS[@]}"; do
+        echo "Requesting review from rdkcentral/${slug}..."
+        gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "rdkcentral/${slug}" 2>&1 || echo "  WARN: Failed to add ${slug}"
+    done
+    echo "Done."
+fi

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -108,7 +108,7 @@ echo ""
 # ---------------------------------------------------------------------------
 
 echo "Workflow labels:"
-create_label "breaking-change"      "b60205" "Breaking interface change — bumps generation"
+create_label "breaking-change"      "b60205" "Breaking interface change — bumps version generation segment"
 create_label "documentation"        "0075ca" "Documentation-only change — no interface change"
 
 echo ""

--- a/scripts/team_mapping.yaml
+++ b/scripts/team_mapping.yaml
@@ -4,7 +4,6 @@
 #
 # To find team slugs: gh api orgs/rdkcentral/teams --paginate --jq '.[].slug'
 
-RTAB_Group: hal-rtab-reviewers
 Architecture: hal-arch-reviewers
 Product_Architecture: hal-product-arch-reviewers
 AV_Architecture: hal-av-arch-reviewers

--- a/scripts/team_mapping.yaml
+++ b/scripts/team_mapping.yaml
@@ -1,0 +1,16 @@
+# Mapping from metadata.yaml reviewer names to GitHub team slugs (rdkcentral org)
+#
+# Format: <metadata_name>: <github_team_slug>
+#
+# To find team slugs: gh api orgs/rdkcentral/teams --paginate --jq '.[].slug'
+
+RTAB_Group: hal-rtab-reviewers
+Architecture: hal-arch-reviewers
+Product_Architecture: hal-product-arch-reviewers
+AV_Architecture: hal-av-arch-reviewers
+Broadcast_Team: hal-broadcast-reviewers
+Control_Manager_Architecture: hal-control-manager-reviewers
+Graphics_Architecture: hal-graphics-arch-reviewers
+Connectivity_Architecture: hal-connectivity-arch-reviewers
+Kernel_Architecture: hal-kernel-arch-reviewers
+Vendor_Layer_Team: rdk-halif-aidl-pr-review-team

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: sensor
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Hardware sensor data acquisition and monitoring"
 type: OEM

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videodecoder
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Video decoder resource management and codec support"
 type: SOC

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videosink
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Video output rendering and display sink management"
 type: SOC

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: abstractfilesystem
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Abstract file system interface and storage abstraction"
 type: OEM

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Connectivity_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: bluetooth
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Bluetooth stack integration and profile support"
 type: OEM

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: crypto
 version: 0.0.0.1
-generation: 0
 status: RED
 description: "HAL lower-layer cryptography and security API requirements"
 type: SOC

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: filesystem
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "File system layout standards and partition management"
 type: OEM

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: graphics
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Graphics subsystem and display pipeline interface"
 type: SOC

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Graphics_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Graphics_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Graphics_Architecture: pending

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: kernel
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Kernel interface strategy and system abstraction"
 type: SOC

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: keyvault
 version: 0.0.0.1
-generation: 0
 status: RED
 description: "HAL lower-layer key vault and encrypted storage requirements"
 type: SOC

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: linuxinput
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Linux input subsystem and event handling"
 type: OEM

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: wifi
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Wi-Fi driver integration and network management"
 type: OEM

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Connectivity_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending


### PR DESCRIPTION
## Summary

Resolves #375. Closes #361.

Overhauls the RAG reporting infrastructure:

- **#375 — RAG workflow fix:** Switched from direct `git push` (blocked by branch protection) to `gh pr create` via a `chore/update-rag-report` branch. Added `pull-requests: write` and `issues: write` permissions.

- **#361 — Reviewer team restructure:**
  - **Added** `Vendor_Layer_Team` across all 32 metadata.yaml files and the generate script
  - **Removed** `VTS_Team` (replaced by Vendor_Layer_Team — statuses mirrored before removal, no data lost)
  - **Removed** `RTAB_Group` (team dissolved)
  - Added `scripts/team_mapping.yaml` mapping internal reviewer names to GitHub team slugs
  - Added `scripts/request_reviews.sh` — reads PR changed files, finds affected components, maps pending reviewers to GH teams, requests reviews

- **Cleanup:** Removed redundant `generation:` field from all 32 metadata.yaml (value already embedded in version string). Cleaned release.sh and setup_labels.sh accordingly.

## Files changed

| Scope | Files |
|---|---|
| Workflow | `.github/workflows/update-rag-report.yml` |
| Scripts | `scripts/generate_rag_report.sh`, `scripts/release.sh`, `scripts/setup_labels.sh` |
| New scripts | `scripts/request_reviews.sh`, `scripts/team_mapping.yaml` |
| Metadata | 32 `metadata.yaml` files (all components) |
| Report | `RAG_STATUS_REPORT.md` (regenerated) |

## Test plan

- [ ] Verify `gh pr create` workflow triggers correctly on next push to develop
- [ ] Run `bash scripts/request_reviews.sh <PR> --dry-run` to verify team mapping
- [ ] Run `bash scripts/generate_rag_report.sh` locally — no errors, report reflects current teams
- [ ] Run `bash scripts/release.sh --verbose` — no errors from removed generation field