### PR TITLE
chore(drm): add missing metadata.yaml (#341)

### DIFF
--- a/drm/metadata.yaml
+++ b/drm/metadata.yaml
@@ -1,0 +1,68 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# component   - Machine-readable component identifier                    [manual]
+# version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
+# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
+# status      - RAG status: GREEN / AMBER / RED                          [manual]
+# description - One-line human-readable summary                          [manual]
+# type        - Responsibility: SOC or OEM                                [manual]
+component: drm
+version: 0.1.0.0
+generation: 1
+status: RED
+description: "DRM plugin and crypto plugin interfaces for content protection"
+type: SOC
+
+# lifecycle - 14+5 review cycle dates                                    [pr_cycle.sh]
+#   review_started    - Date the review window opened
+#   review_deadline   - review_started + 14 calendar days
+#   target_green_date - review_deadline + 5 business days
+lifecycle:
+  review_started: ~
+  review_deadline: ~
+  target_green_date: ~
+
+# scope - High-level architectural responsibilities                       [manual]
+scope:
+  - DRM factory and plugin interfaces (IDrmFactory, IDrmPlugin, ICryptoPlugin)
+  - DRM session lifecycle and key management
+  - Content decryption with secure buffer handling
+  - DRM scheme support (Widevine, PlayReady)
+  - HDCP output protection level reporting
+  - DRM metrics and event reporting
+
+# notes - Tracking metadata                                              [manual]
+#   priority      - Numeric priority (lower = higher)
+#   status_detail - Short current state description
+#   action        - Required action to progress
+#   risk          - Risk notes (appears as watch item on dashboard)
+#   owners        - Responsible architecture teams
+notes:
+  priority: 1
+  status_detail: "Initial interface definition — under review"
+  action: "Architecture review and vendor alignment"
+  owners: "Architecture + AV_Architecture"
+
+# reviewers - Sign-off status per stakeholder team                       [manual]
+#   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
+reviewers:
+    RTAB_Group: pending
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    VTS_Team: pending


### PR DESCRIPTION
## Summary

Adds the missing `drm/metadata.yaml` that was lost in the squash-merge of PR #405. Every module requires this file for the RAG dashboard and release tooling.

## Test plan

- [ ] `drm/metadata.yaml` exists and has correct component/version/status fields