### PR TITLE
sensor: Fix build issues by adding CMakeLists and VINTF stability

### DIFF
--- a/.github/workflows/update-rag-report.yml
+++ b/.github/workflows/update-rag-report.yml
@@ -19,11 +19,21 @@ jobs:
         run: bash scripts/generate_rag_report.sh
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "chore: update RAG status report"
-          branch: chore/update-rag-report
-          title: "chore: update RAG status report"
-          body: "Automated update of RAG_STATUS_REPORT.md triggered by a push to develop."
-          labels: scope:infrastructure
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/update-rag-report"
+          git checkout -b "$BRANCH"
+          git add RAG_STATUS_REPORT.md
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: update RAG status report"
+          git push --force origin "$BRANCH"
+          # Create PR only if one doesn't already exist for this branch
+          if ! gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create --base develop --head "$BRANCH" \
+              --title "chore: update RAG status report" \
+              --body "Automated update of RAG_STATUS_REPORT.md triggered by a push to develop." \
+              --label "scope:infrastructure"
+          fi

--- a/.github/workflows/update-rag-report.yml
+++ b/.github/workflows/update-rag-report.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   update-report:

--- a/.github/workflows/update-rag-report.yml
+++ b/.github/workflows/update-rag-report.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-report:
@@ -17,11 +18,12 @@ jobs:
       - name: Generate RAG report
         run: bash scripts/generate_rag_report.sh
 
-      - name: Commit updated report
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add RAG_STATUS_REPORT.md
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update RAG status report [skip ci]"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update RAG status report"
+          branch: chore/update-rag-report
+          title: "chore: update RAG status report"
+          body: "Automated update of RAG_STATUS_REPORT.md triggered by a push to develop."
+          labels: scope:infrastructure
+          delete-branch: true

--- a/NOTICE
+++ b/NOTICE
@@ -14,6 +14,12 @@ at build or documentation time. These dependencies are not distributed as part o
 
 ---
 
+Uses material from Android which is:
+Copyright (C) 2009 The Android Open Source Project
+Licensed under the Apache License, Version 2.0
+
+---
+
 Third-Party Components (Cloned via Script):
 
 1. linux_binder_idl  

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -26,26 +26,26 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 6/6 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 5/6 | Architecture + VTS_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 6/6 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 6/6 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 6/6 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 5/6 | Architecture + AV_Architecture |
-| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/6 | Architecture + AV_Architecture |
-| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/6 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 6/6 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 6/6 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/5 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/5 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/5 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/5 | Architecture + AV_Architecture |
+| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/5 | Architecture + AV_Architecture |
+| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/5 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/5 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/5 | Architecture + AV_Architecture |
 
 
 ### OEM Components
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/6 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 5/6 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 5/6 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 5/6 | Architecture + Kernel_Architecture |
+| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/5 | Architecture + AV_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/5 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/5 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/5 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -107,65 +107,65 @@
 
 ### SOC — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | audiodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiomixer | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avbuffer | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avclock | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmicec | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | videodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | videosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | audiodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiomixer | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avbuffer | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avclock | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmicec | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmiinput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | hdmioutput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | videodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | videosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | vsi/kernel | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | planecontrol | 0/7 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | vsi/graphics | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | vsi/kernel | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | vsi/graphics | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | vsi/crypto | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🔴 | vsi/keyvault | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | vsi/crypto | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🔴 | vsi/keyvault | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 
 ### OEM — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | compositeinput | 2/6 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | deviceinfo | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
-| 🟢 | indicator | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | sensor | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | compositeinput | 2/5 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deviceinfo | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | indicator | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | sensor | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | panel | 2/6 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | boot | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | broadcast | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | flash | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | r4ce | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/bluetooth | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/linuxinput | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/wifi | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/abstractfilesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/filesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | ffv | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | deepsleep | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | boot | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | broadcast | 0/5 | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | flash | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | r4ce | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
+| 🟡 | vsi/bluetooth | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/linuxinput | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/wifi | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/abstractfilesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/filesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | ffv | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | cdm | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | cdm | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ---
 
@@ -178,7 +178,6 @@
 | RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
-| VTS_Team | All components |
 | AV_Architecture | Audio/Video pipeline components |
 | Broadcast_Team | Broadcast/tuner components |
 | Control_Manager_Architecture | Remote control & input management |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -26,16 +26,16 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/6 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/6 | Architecture + VTS_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/6 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/6 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/6 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/6 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 6/6 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 5/6 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 6/6 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 6/6 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 6/6 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 5/6 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/6 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/6 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/6 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/6 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 6/6 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 6/6 | Architecture + AV_Architecture |
 
 
 ### OEM Components
@@ -43,9 +43,9 @@
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/6 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/6 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/6 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/6 | Architecture + Kernel_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 5/6 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 5/6 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 5/6 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -109,16 +109,16 @@
 
 | | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | audiodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | audiomixer | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | audiosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | avbuffer | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | avclock | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | hdmicec | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | videodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | videosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiomixer | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avbuffer | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avclock | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmicec | 5/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | videodecoder | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | videosink | 6/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
@@ -140,19 +140,19 @@
 | | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟢 | compositeinput | 2/6 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | deviceinfo | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
-| 🟢 | indicator | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ☐ |
-| 🟢 | sensor | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
+| 🟢 | deviceinfo | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | indicator | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | sensor | 5/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
 | | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟡 | panel | 2/6 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | boot | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | deepsleep | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | boot | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟡 | broadcast | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | flash | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | flash | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟡 | r4ce | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
 | 🟡 | vsi/bluetooth | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
 | 🟡 | vsi/linuxinput | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -26,26 +26,26 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/5 | Architecture + VTS_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/5 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/5 | Architecture + AV_Architecture |
-| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/5 | Architecture + AV_Architecture |
-| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/5 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 4/4 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 4/4 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
+| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
+| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 4/4 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 4/4 | Architecture + AV_Architecture |
 
 
 ### OEM Components
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/5 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/5 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/5 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/5 | Architecture + Kernel_Architecture |
+| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/4 | Architecture + AV_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/4 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/4 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -107,65 +107,65 @@
 
 ### SOC — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | audiodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiomixer | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avbuffer | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avclock | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmicec | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | hdmiinput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | hdmioutput | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | videodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | videosink | 5/5 | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | audiodecoder | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiomixer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | audiosink | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avbuffer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | avclock | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmicec | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | hdmiinput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | hdmioutput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | videodecoder | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| 🟢 | videosink | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | vsi/kernel | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | planecontrol | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | vsi/graphics | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | vsi/kernel | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | vsi/graphics | 0/4 | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | vsi/crypto | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🔴 | vsi/keyvault | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | vsi/crypto | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🔴 | vsi/keyvault | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 
 ### OEM — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟢 | compositeinput | 2/5 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | deviceinfo | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
-| 🟢 | indicator | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | sensor | 4/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | compositeinput | 2/4 | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deviceinfo | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | indicator | 4/4 | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | sensor | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | panel | 2/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | boot | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | broadcast | 0/5 | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | flash | 3/5 | ☐ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | r4ce | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/bluetooth | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/linuxinput | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/wifi | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
-| 🟡 | vsi/abstractfilesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | vsi/filesystem | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | ffv | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/4 | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | deepsleep | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | boot | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | broadcast | 0/4 | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | flash | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
+| 🟡 | r4ce | 0/4 | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
+| 🟡 | vsi/bluetooth | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/linuxinput | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/wifi | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/abstractfilesystem | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/filesystem | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | ffv | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | cdm | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | cdm | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ---
 
@@ -175,7 +175,6 @@
 
 | Team | Role |
 |------|------|
-| RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
 | AV_Architecture | Audio/Video pipeline components |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-04-22 |
+| **Generated** | 2026-04-23 |
 | **Components** | 32 |
 | 🟢 **GREEN** | 14 |
 | 🟡 **AMBER** | 15 |
@@ -27,7 +27,7 @@
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 4/4 | Architecture + AV_Architecture |
@@ -69,7 +69,7 @@
 | 🟡 | panel | 0.1.0.0 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
 | 🟡 | deepsleep | 0.1.0.0 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
 | 🟡 | boot | 0.1.0.0 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
-| 🟡 | broadcast | 0.0.0.1 | 5 | PR under review | Review Required - Start the PR Review | 2026-03-18 | 2026-03-25 | VTS_Team + Broadcast_Team |
+| 🟡 | broadcast | 0.0.0.1 | 5 | PR under review | Review Required - Start the PR Review | 2026-03-18 | 2026-03-25 | Vendor_Layer_Team + Broadcast_Team |
 | 🟡 | flash | 0.1.0.0 | 5 | Migrate -> Image | Rename Module | — | — | Architecture + Kernel_Architecture |
 | 🟡 | r4ce | 0.0.0.1 | 5 | API Definition in progress | Control Manager Team - API Definition started | — | — | Architecture + Control_Manager_Architecture |
 | 🟡 | vsi/bluetooth | 0.0.0.1 | 6 | Docs required | Not blocking progress - Have discussions write up methodology, Discussions with Bluetooth Team | 2026-03-24 | 2026-03-31 | Architecture + Connectivity_Architecture |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,10 +2,10 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-03-11 |
+| **Generated** | 2026-04-22 |
 | **Components** | 32 |
-| 🟢 **GREEN** | 13 |
-| 🟡 **AMBER** | 16 |
+| 🟢 **GREEN** | 14 |
+| 🟡 **AMBER** | 15 |
 | 🔴 **RED** | 3 |
 
 ---
@@ -14,8 +14,8 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **13** | Reviewed & Approved — Interface stable on develop |
-| 🟡 AMBER | **16** | Under Active Ingestion — Will enter sprint review when ready |
+| 🟢 GREEN | **14** | Reviewed & Approved — Interface stable on develop |
+| 🟡 AMBER | **15** | Under Active Ingestion — Will enter sprint review when ready |
 | 🔴 RED | **3** | Not Started / Blocked — Strategy or definition required |
 
 ---
@@ -26,25 +26,26 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/5 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/5 | Architecture + AV_Architecture |
-| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/5 | Architecture + AV_Architecture |
-| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/5 | Architecture + AV_Architecture |
-| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/5 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/5 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/5 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 5/6 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/6 | Architecture + VTS_Team + AV_Architecture |
+| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 5/6 | Architecture + AV_Architecture |
+| 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 5/6 | Architecture + AV_Architecture |
+| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 5/6 | Architecture + AV_Architecture |
+| 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/6 | Architecture + AV_Architecture |
+| 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/6 | Architecture + AV_Architecture |
+| 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/6 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 5/6 | Architecture + AV_Architecture |
+| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 5/6 | Architecture + AV_Architecture |
 
 
 ### OEM Components
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | compositeinput | 0.1.0.0 | Composite video input capture and control | 2/5 | Architecture + AV_Architecture |
-| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/5 | Architecture + Kernel_Architecture |
-| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/5 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/5 | Architecture + Kernel_Architecture |
+| 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/6 | Architecture + AV_Architecture |
+| 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/6 | Architecture + Kernel_Architecture |
+| 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/6 | Architecture + Graphics_Architecture |
+| 🟢 | sensor | 0.1.0.0 | Hardware sensor data acquisition and monitoring | 4/6 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -57,7 +58,6 @@
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
 | 🟡 | avbuffer *(SVP risk)* | 0.1.0.0 | 1 | Encrypted buffer (DRM/SVP) - Pending on DRM strategy | May change due to SVP changes from DRM which is being worked on | — | — | Architecture + AV_Architecture |
 | 🟡 | vsi/kernel | 0.0.0.1 | 1 | Strategy required | Not blocking progress - Architecture Strategy | — | — | Architecture |
-| 🟡 | audiomixer | 0.0.0.1 | 2 | PR under review | In Progress PR Review | — | — | VTS_Team + AV_Architecture |
 | 🟡 | planecontrol | 0.1.0.0 | 3 | Re-review required | Discussions with MW team - Simplify design. Architecture requires simplified design and restructured review. | — | — | Architecture + Graphics_Architecture |
 | 🟡 | vsi/graphics | 0.0.0.1 | 6 | Docs required | Not blocking progress - Define Versions & write up vision and direction, Planning Out Evolution of the platform, RDK-M | — | — | Architecture + Graphics_Architecture |
 
@@ -66,9 +66,9 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
-| 🟡 | panel | 0.0.0.1 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
-| 🟡 | deepsleep | 0.0.0.1 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
-| 🟡 | boot | 0.0.0.1 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
+| 🟡 | panel | 0.1.0.0 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
+| 🟡 | deepsleep | 0.1.0.0 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
+| 🟡 | boot | 0.1.0.0 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
 | 🟡 | broadcast | 0.0.0.1 | 5 | PR under review | Review Required - Start the PR Review | 2026-03-18 | 2026-03-25 | VTS_Team + Broadcast_Team |
 | 🟡 | flash | 0.1.0.0 | 5 | Migrate -> Image | Rename Module | — | — | Architecture + Kernel_Architecture |
 | 🟡 | r4ce | 0.0.0.1 | 5 | API Definition in progress | Control Manager Team - API Definition started | — | — | Architecture + Control_Manager_Architecture |
@@ -107,65 +107,65 @@
 
 ### SOC — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟢 | audiodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | audiosink | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | avbuffer | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | avclock | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | hdmicec | 4/5 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | hdmiinput | 3/5 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | hdmioutput | 3/5 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | videodecoder | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | videosink | 5/5 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | audiodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiomixer | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | avbuffer | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | avclock | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | hdmicec | 4/6 | ☐ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | hdmiinput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | hdmioutput | 3/6 | ☐ | ✅ | ✅ | 🔄 | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | videodecoder | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | videosink | 5/6 | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### SOC — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟡 | vsi/kernel | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | audiomixer | 0/5 | ☐ | 🔍 | 🔍 | 🔍 | 🔍 | N/A | N/A | N/A | N/A | N/A |
-| 🟡 | planecontrol | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A |
-| 🟡 | vsi/graphics | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | vsi/kernel | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/7 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | vsi/graphics | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🔴 | vsi/crypto | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🔴 | vsi/keyvault | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | vsi/crypto | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🔴 | vsi/keyvault | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 
 ### OEM — 🟢 GREEN
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟢 | compositeinput | 2/5 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A |
-| 🟢 | deviceinfo | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | indicator | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A |
-| 🟢 | sensor | 4/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | compositeinput | 2/6 | ☐ | ✅ | ✅ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deviceinfo | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
+| 🟢 | indicator | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ☐ |
+| 🟢 | sensor | 4/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ☐ |
 
 ### OEM — 🟡 AMBER
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🟡 | panel | 2/5 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A |
-| 🟡 | deepsleep | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | boot | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | broadcast | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A |
-| 🟡 | flash | 3/5 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | r4ce | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A |
-| 🟡 | vsi/bluetooth | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A |
-| 🟡 | vsi/linuxinput | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/wifi | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A |
-| 🟡 | vsi/abstractfilesystem | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | vsi/filesystem | 0/5 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟡 | ffv | 0/5 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/6 | ☐ | ✅ | ✅ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | deepsleep | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | boot | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | broadcast | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | flash | 3/6 | ☐ | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | r4ce | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |
+| 🟡 | vsi/bluetooth | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/linuxinput | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/wifi | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | ☐ | N/A | ☐ |
+| 🟡 | vsi/abstractfilesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | vsi/filesystem | 0/6 | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | ffv | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🔴 RED
 
-| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|
-| 🔴 | cdm | 0/5 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A |
+| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | cdm | 0/6 | ☐ | ☐ | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ---
 
@@ -185,6 +185,7 @@
 | Graphics_Architecture | Graphics, display & composition |
 | Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity |
 | Kernel_Architecture | System, kernel, boot & platform |
+| Vendor_Layer_Team | Vendor HAL implementation review |
 
 ---
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiodecoder
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Audio decoder resource management and codec format support"
 type: SOC

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiomixer
 version: 0.1.0.1
-generation: 0
 status: GREEN
 description: "Audio mixing and routing for multi-stream output"
 type: SOC

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -50,7 +50,7 @@ scope:
 #   risk          - Risk notes (appears as watch item on dashboard)
 #   owners        - Responsible architecture teams
 notes:
-  owners: "Architecture + VTS_Team + AV_Architecture"
+  owners: "Architecture + Vendor_Layer_Team + AV_Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -60,7 +60,6 @@ reviewers:
     RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
-    VTS_Team: reviewed
     AV_Architecture: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiosink
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Audio output rendering and sink device management"
 type: SOC

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
+    Vendor_Layer_Team: pending
 

--- a/avbuffer/current/com/rdk/hal/avbuffer/IAVBuffer.aidl
+++ b/avbuffer/current/com/rdk/hal/avbuffer/IAVBuffer.aidl
@@ -62,8 +62,11 @@ interface IAVBuffer
      * 
      * If the `videoDecoderId` is invalid then the `binder::Status EX_ILLEGAL_ARGUMENT` exception status is returned.
      * 
-     * It the platform has exhausted all available memory from the requested heap then the exception status
+     * If the platform has exhausted all available memory from the requested heap then the exception status
      * `binder::Status::Exception::EX_SERVICE_SPECIFIC` with `HALError::OUT_OF_MEMORY` is returned.
+     *
+     * If a `secureHeap` is created and the video decoder has not been configured then the exception status
+     * `binder::Status::Exception::EX_ILLEGAL_STATE` is returned.
      *
      * @param[in] secureHeap            Indicates if the pool is secure.
      * @param[in] videoDecoderIndex     The index of the video decoder resource.
@@ -72,10 +75,10 @@ interface IAVBuffer
      * @returns A new `Pool` object with a valid handle.
      *
      * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if videoDecoderIndex is invalid
-     * @exception binder::Status::Exception::EX_SERVICE_SPECIFIC, HALError::OUT_OF_MEMORY if heap is exhausted
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT  if videoDecoderIndex is invalid
+     * @exception binder::Status::Exception::EX_SERVICE_SPECIFIC, HALError::OUT_OF_MEMORY  if heap is exhausted
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE decoder not configured
      *
-     * 
      * @pre The IVideoDecoder.Id must have been obtained from IVideoDecoderManager.getVideoDecoderIds()
      * 
      * @see destroyPool()
@@ -88,9 +91,12 @@ interface IAVBuffer
      * If the audio pool is for audio data not destinated for a vendor audio decoder
      * (e.g. system audio PCM) then the ID must be IAudioDecoder.Id.UNDEFINED.
      * 
-     * It the platform has exhausted all available memory from the requested heap then the exception status
+     * If the platform has exhausted all available memory from the requested heap then the exception status
      * `binder::Status::Exception::EX_SERVICE_SPECIFIC` with `HALError::OUT_OF_MEMORY` is returned.
      * 
+     * If a `secureHeap` is created and the audio decoder has not been configured then the exception status
+     * `binder::Status::Exception::EX_ILLEGAL_STATE` is returned.
+     *
      * If the `audioDecoderId` is invalid then the `binder::Status EX_ILLEGAL_ARGUMENT` exception status is returned.
      *
      * @param[in] secureHeap            Indicates if the pool is secure.
@@ -101,8 +107,8 @@ interface IAVBuffer
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if audioDecoderId is invalid
-     * @exception binder::Status::Exception::EX_SERVICE_SPECIFIC, HALError::OUT_OF_MEMORY if heap is exhausted
-     *
+     * @exception binder::Status::Exception::EX_SERVICE_SPECIFIC, HALError::OUT_OF_MEMORY  if heap is exhausted
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE decoder not configured
      * 
      * @pre The IAudioDecoder.Id must have been obtained from IAudioDecoderManager.getAudioDecoderIds()
      *      or IAudioDecoder.Id.UNDEFINED must be used.

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
+    Vendor_Layer_Team: pending
 

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avbuffer
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "AV buffer allocation and secure video path management"
 type: SOC

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     VTS_Team: reviewed
     AV_Architecture: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -63,7 +63,6 @@ reviewers:
     RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
-    VTS_Team: reviewed
     AV_Architecture: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avclock
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Audio/video clock synchronization and timing control"
 type: SOC

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: boot
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Boot reason tracking and reboot management"
 type: OEM

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/boot/metadata.yaml
+++ b/boot/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Broadcast_Team: pending

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: pending
     VTS_Team: pending
     Broadcast_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: broadcast
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Broadcast tuner and RF frontend interface"
 type: OEM

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -63,7 +63,6 @@ reviewers:
     RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
-    VTS_Team: pending
     Broadcast_Team: pending
     Vendor_Layer_Team: pending
 

--- a/broadcast/metadata.yaml
+++ b/broadcast/metadata.yaml
@@ -53,7 +53,7 @@ notes:
   priority: 5
   status_detail: "PR under review"
   action: "Review Required - Start the PR Review"
-  owners: "VTS_Team + Broadcast_Team"
+  owners: "Vendor_Layer_Team + Broadcast_Team"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: pending
     AV_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/cdm/metadata.yaml
+++ b/cdm/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: cdm
 version: 0.0.0.1
-generation: 0
 status: RED
 description: "Content decryption module and DRM key management"
 type: OEM

--- a/cdm/readme.md
+++ b/cdm/readme.md
@@ -1,2 +1,3 @@
 # Content Decryption Module Support
 
+Deprecated. See the [DRM HAL documentation](../docs/halif/drm/current/) and the [DRM interface directory](../drm/current/).

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: pending

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/compositeinput/metadata.yaml
+++ b/compositeinput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: compositeinput
 version: 0.2.0.0
-generation: 2
 status: GREEN
 description: "Composite video input capture and control"
 type: OEM

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: deepsleep
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Deep sleep and low-power state management"
 type: OEM

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: deviceinfo
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Device information and platform capability reporting"
 type: OEM

--- a/deviceinfo/metadata.yaml
+++ b/deviceinfo/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/docs/halif/cdm/current/cdm.md
+++ b/docs/halif/cdm/current/cdm.md
@@ -1,5 +1,7 @@
 # CDM
 
+CDM is deprecated. Please see ../drm and https://github.com/rdkcentral/rdk-halif-aidl/tree/main/drm/current
+
 ## References
 
 !!! info References

--- a/docs/halif/drm/current/drm.md
+++ b/docs/halif/drm/current/drm.md
@@ -1,0 +1,305 @@
+# DRM HAL
+
+## Overview
+
+
+
+The DRM (Digital Rights Management) HAL provides a platform-independent interface for managing content protection and secure media playback. It allows middleware and media services to interact with vendor-specific DRM implementations whilst maintaining a consistent interface across diverse hardware platforms. This abstraction enables secure content delivery, licence management, and cryptographic operations for protected media streams.
+
+This DRM interface definition is almost identical to Android 16's DRM and Crypto Plugin interfaces. Usage of the Plugins and discovery by the RDK framework is identical.
+This approach minimises SoC vendor (and DRM vendor) effort by using a model that is well known and understood, thereby reducing bring-up and maintenance issues.
+See: https://source.android.com/docs/core/media/drm#drm-plugin-details
+In principle the same Android VTS approach can be applied early in SoC bring up.
+
+The significant differences: 
+- AVBuffer for the input and output buffers.
+- No support for legacy "secure stop"
+- No support required for "offline keys" - REQUIREMENT UNDER REVIEW 
+
+---
+
+!!! info "References"
+    |||
+    |-|-|
+    |**Interface Definition**|[drm/current](https://github.com/rdkcentral/rdk-halif-aidl/tree/main/drm/current)|
+    |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
+
+!!! tip "Related Pages"
+    - [HAL Interface Overview](../../key_concepts/hal/hal_interfaces.md)
+    - [HAL Feature Profile](../../key_concepts/hal/hal_feature_profiles.md)
+    - [CDM](../../cdm/current/cdm.md)
+
+---
+
+## Functional Overview
+
+The DRM HAL is responsible for:
+
+- Managing DRM sessions and secure media pipelines.
+- Processing licence requests and responses.
+- Providing cryptographic operations for content decryption.
+- Supporting multiple DRM schemes (e.g., PlayReady, Widevine).
+- Reporting DRM capabilities, security levels, and HDCP status.
+- Handling device provisioning and certificate management.
+
+The interface design follows a factory pattern: `IDrmFactory` is the entry point, creating `IDrmPlugin` instances (for key and session management) and `ICryptoPlugin` instances (for content decryption). A session ID created by `IDrmPlugin` is passed to `ICryptoPlugin` to cryptographically link the DRM session to the decryption context.
+
+---
+
+## Implementation Requirements
+
+| #            | Requirement                                                                  | Comments                           |
+|--------------|-------------------------------------------------------------------------------|------------------------------------|
+| HAL.DRM.1    | Each DRM scheme shall register an `IDrmFactory` instance using the format `com.rdk.hal.drm.IDrmFactory/<instanceName>`. | The `<instanceName>` is vendor-defined (e.g. `clearkey`, `widevine`, `playready`). Multiple unique instanceNames may be registered simultaneously. |
+| HAL.DRM.2    | The service shall support DRM capabilities as declared in the HFP.           | Validated via `IDrmFactory.getSupportedCryptoSchemes()`. |
+| HAL.DRM.3    | The service shall maintain secure media pipelines for protected content.     | Security level enforcement via `SecurityLevel`. |
+| HAL.DRM.4    | The service shall support licence acquisition and renewal.                   | Via `IDrmPlugin.getKeyRequest()` and `IDrmPlugin.provideKeyResponse()`. |
+| HAL.DRM.5    | The service shall provide cryptographic operations for content decryption.   | Via `ICryptoPlugin.decrypt()`. Support for multiple DRM schemes via UUID. |
+
+---
+
+## Interface Definitions
+
+### Interfaces
+
+| AIDL File                  | Description                                                                 |
+|----------------------------|-----------------------------------------------------------------------------|
+| `IDrmFactory.aidl`         | Entry-point factory; creates `IDrmPlugin` and `ICryptoPlugin` instances     |
+| `IDrmPlugin.aidl`          | DRM plugin; session lifecycle, key requests, provisioning, and properties   |
+| `ICryptoPlugin.aidl`       | Crypto plugin; content decryption and secure decoder configuration          |
+| `IDrmPluginListener.aidl`  | Callback interface for DRM events (key expiry, key status changes)          |
+
+### Enumerations
+
+| AIDL File              | Description                                           |
+|------------------------|-------------------------------------------------------|
+| `DrmErrors.aidl`       | DRM error codes used in implicit error reporting      |
+| `EventType.aidl`       | DRM event types delivered via `IDrmPluginListener`    |
+| `HdcpLevel.aidl`       | Individual HDCP level values                          |
+| `KeyRequestType.aidl`  | Key request types: initial, renewal, or release       |
+| `KeyStatusType.aidl`   | Key status types: usable, expired, output not allowed, etc. |
+| `KeyType.aidl`         | Key types: streaming, offline, or release             |
+| `Mode.aidl`            | Cipher modes: CBC or CTR                              |
+| `SecurityLevel.aidl`   | DRM security levels (e.g. SW_SECURE_CRYPTO, HW_SECURE_ALL) |
+
+### Parcelables
+
+| AIDL File                          | Description                                                      |
+|------------------------------------|------------------------------------------------------------------|
+| `CryptoSchemes.aidl`               | List of supported crypto scheme UUIDs and content types          |
+| `DecryptArgs.aidl`                 | Arguments bundle for `ICryptoPlugin.decrypt()`                   |
+| `DrmMetric.aidl`                   | A single DRM diagnostic metric                                   |
+| `DrmMetricGroup.aidl`              | A named group of DRM metrics                                     |
+| `DrmMetricNamedValue.aidl`         | A named value within a DRM metric                                |
+| `DrmMetricValue.aidl`              | Typed value (int, double, string) within a DRM metric            |
+| `HdcpLevels.aidl`                  | Current and maximum negotiated HDCP levels                       |
+| `KeyRequest.aidl`                  | Opaque key request blob returned by `getKeyRequest()`            |
+| `KeySetId.aidl`                    | Identifies a set of keys for offline licence use                 |
+| `KeyStatus.aidl`                   | Key identifier paired with its current `KeyStatusType`           |
+| `KeyValue.aidl`                    | Key-value string pair for optional parameters                    |
+| `NumberOfSessions.aidl`            | Current open session count and maximum supported sessions        |
+| `Pattern.aidl`                     | Encryption pattern (skip and encrypt block counts for CBC-CTS)   |
+| `ProvideProvisionResponseResult.aidl` | Result of `provideProvisionResponse()` (certificate, wrapped key) |
+| `ProvisionRequest.aidl`            | Opaque provisioning request blob                                 |
+| `Status.aidl`                      | DRM operation status code                                        |
+| `SubSample.aidl`                   | Clear and encrypted byte counts for one subsample                |
+| `SupportedContentType.aidl`        | Mime type and security level for a supported content type        |
+| `Uuid.aidl`                        | 128-bit UUID identifying a DRM scheme                            |
+
+---
+
+## Initialization
+
+The DRM HAL service is registered at system boot via a systemd unit, typically named `hal-drm.service`.  
+
+At startup:
+
+1. The service process is launched by systemd.
+2. Each `IDrmFactory` implementation registers itself with the AIDL Service Manager using the format:
+
+    ```
+    com.rdk.hal.drm.IDrmFactory/<instanceName>
+    ```
+
+    where `<instanceName>` is a vendor-defined identifier for the DRM scheme, for example:
+
+    | InstanceName | DRM scheme |
+    |---|---|
+    | `clearkey` | ClearKey (built-in) |
+    | `widevine` | Google Widevine |
+    | `playready` | Microsoft PlayReady |
+    | `default` | Platform default scheme |
+
+    Multiple `IDrmFactory` instances may be registered simultaneously — one per supported DRM scheme. Clients discover available schemes by calling `getSupportedCryptoSchemes()` on each registered factory.
+
+3. Implementation-specific initialisation may occur, such as:
+   - Loading DRM scheme libraries (PlayReady, Widevine, etc.).
+   - Initialising secure execution environments (TEE, TrustZone).
+   - Establishing communication with hardware security modules.
+   - Verifying platform security credentials.
+
+Once registered, the service is expected to remain available for the lifetime of the system.
+
+---
+
+## Product Customisation
+
+- Supported DRM schemes are declared via `IDrmFactory.getSupportedCryptoSchemes()`, which returns a `CryptoSchemes` parcelable containing supported UUIDs and content types.
+- A platform may implement support for specific DRM systems depending on:
+  - Hardware security capabilities (TEE, secure boot, hardware keys).
+  - Licensing agreements with DRM vendors.
+  - Security certification levels (e.g., Widevine L1/L3).
+- Platform-specific policies are reflected in:
+  - The `SecurityLevel` returned by `IDrmPlugin.getSecurityLevel()`, and
+  - The HAL Feature Profile (HFP) YAML for static configuration.
+
+---
+
+## System Context
+
+```mermaid
+flowchart TD
+    Client[Media Pipeline] -->|Scheme Discovery / Plugin Creation| DrmFactory[IDrmFactory]
+    DrmFactory -->|createDrmPlugin| DrmPlugin[IDrmPlugin]
+    DrmFactory -->|createCryptoPlugin| CryptoPlugin[ICryptoPlugin]
+    DrmPlugin -->|Session ID| CryptoPlugin
+    DrmPlugin -->|Licence Operations| Network[Network Stack]
+    DrmPlugin -->|Secure Operations| TEE[Trusted Execution Environment]
+    CryptoPlugin -->|Decrypt| TEE
+    DrmPlugin -->|Key Storage| SecureStorage[Secure Storage]
+
+    classDef background fill:#121212,stroke:none,color:#E0E0E0;
+    classDef blue fill:#1565C0,stroke:#E0E0E0,stroke-width:2px,color:#E0E0E0;
+    classDef wheat fill:#FFB74D,stroke:#424242,stroke-width:2px,color:#000000;
+    classDef green fill:#4CAF50,stroke:#E0E0E0,stroke-width:2px,color:#FFFFFF;
+    classDef default fill:#1E1E1E,stroke:#E0E0E0,stroke-width:1px,color:#E0E0E0;
+
+    Client:::blue
+    DrmFactory:::wheat
+    DrmPlugin:::wheat
+    CryptoPlugin:::wheat
+    TEE:::green
+    Network:::green
+    SecureStorage:::green
+```
+
+* **Media Pipeline**: RDK media framework or streaming client.
+* **IDrmFactory**: Entry-point binder service; instantiates DRM and crypto plugins.
+* **IDrmPlugin**: Manages DRM sessions, key requests, provisioning, and properties.
+* **ICryptoPlugin**: Performs content decryption within the secure execution environment.
+* **Trusted Execution Environment**: Secure execution context for cryptographic operations.
+* **Network Stack**: For licence server communication.
+* **Secure Storage**: Persistent storage for keys and credentials.
+
+---
+
+## Resource Management
+
+- Multiple `IDrmFactory` instances are registered — one per supported DRM scheme — each under `com.rdk.hal.drm.IDrmFactory/<instanceName>`. They create per-scheme plugin instances on demand.
+- `IDrmFactory.createDrmPlugin(uuid, appPackageName)` returns an `IDrmPlugin` for the specified DRM scheme.
+- `IDrmFactory.createCryptoPlugin(uuid, initData)` returns an `ICryptoPlugin` for content decryption.
+- `IDrmPlugin` manages one or more sessions identified by opaque `byte[] sessionId` values.
+- `ICryptoPlugin` is linked to a DRM session via `setMediaDrmSession(sessionId)`, establishing the secure binding between key management and decryption.
+- Error conditions are reported via AIDL exceptions using codes from `DrmErrors`.
+
+---
+
+## Operation and Data Flow
+
+General call flow for protected content playback:
+
+1. **Scheme Discovery**  
+   Client calls `IDrmFactory.getSupportedCryptoSchemes()` to enumerate supported DRM scheme UUIDs and content types.
+
+2. **Plugin Creation**  
+   Client calls `IDrmFactory.createDrmPlugin(uuid, appPackageName)` to obtain an `IDrmPlugin` for the selected scheme. Optionally calls `IDrmFactory.createCryptoPlugin(uuid, initData)` to obtain an `ICryptoPlugin`.
+
+3. **Session Creation**  
+   Client calls `IDrmPlugin.openSession(securityLevel)` to obtain a `byte[] sessionId`. Security level may be set to the native device level or overridden for lower levels when frame manipulation is required.
+
+4. **Bind Crypto to Session**  
+   Client calls `ICryptoPlugin.setMediaDrmSession(sessionId)` to cryptographically link the crypto plugin to the DRM session, enabling secure key use during decryption.
+
+5. **Provisioning** *(if required)*  
+   - `IDrmPlugin.getProvisionRequest(certificateType, certificateAuthority)` obtains an opaque request blob.
+   - Client sends the blob to the provisioning server.
+   - `IDrmPlugin.provideProvisionResponse(response)` delivers the response and returns a `ProvideProvisionResponseResult` containing the certificate and wrapped key.
+
+6. **Licence Acquisition**  
+   - `IDrmPlugin.getKeyRequest(scope, initData, mimeType, keyType, optionalParameters)` generates an opaque licence request.
+   - Client sends the request to the licence server.
+   - `IDrmPlugin.provideKeyResponse(scope, response)` delivers the licence response and loads keys.
+
+7. **Content Decryption**  
+   Encrypted media buffers are passed to `ICryptoPlugin.decrypt(DecryptArgs)`, which performs decryption within the secure context using the loaded keys.
+
+8. **Session Termination**  
+   `IDrmPlugin.closeSession(sessionId)` releases session resources when playback completes or stops.
+
+---
+
+## Platform Capabilities
+
+Runtime capability information is obtained via:
+
+- `IDrmFactory.getSupportedCryptoSchemes()` — supported scheme UUIDs and associated content types (`SupportedContentType`).
+- `IDrmPlugin.getSecurityLevel(sessionId)` — current security level for a session (`SecurityLevel`).
+- `IDrmPlugin.getHdcpLevels()` — current and maximum negotiated HDCP levels (`HdcpLevels`).
+- `IDrmPlugin.getNumberOfSessions()` — current open session count and platform maximum (`NumberOfSessions`).
+- `IDrmPlugin.getPropertyString("vendor")` / `"version"` / `"description"` — scheme metadata.
+
+---
+
+## Decryption Buffer Life Cycle
+
+There is a departure from the RDK AIDL model where the consuming component releases `AVBuffers` back to the `Pool`. The `ICryptoPlugin::decrypt` function is blocking for the decryption. On return, the input `AVBuffer` must  be released/recycled by the calling component. Similarly the output `AVBuffer` is passed to the decoder for the decoding. 
+
+- **Non-secure Input and Output**: No restrictions apply (under review). 
+
+- **Secure Output**: For secure `AVBuffers` the pool must be created after the consuming secure Decoder has been initialized.
+
+## Security Considerations
+
+- **Secure Path**: DRM HAL must maintain secure data paths from encrypted input to decrypted output.
+- **Key Protection**: Cryptographic keys must be protected in hardware-backed storage where available.
+- **Attestation**: Platform may require security attestation for high-security content; use `IDrmPlugin.getPropertyByteArray("deviceUniqueId")` for device identity.
+- **HDCP Enforcement**: Output protection must be enforced per content policy; use `IDrmPlugin.getHdcpLevels()` for informational queries only — trusted enforcement is the responsibility of the DRM system.
+
+---
+
+## Error Handling
+
+- All errors are reported via AIDL exceptions with codes defined in `DrmErrors`.
+- Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `ERROR_DRM_NO_LICENSE` | No licence keys loaded |
+| `ERROR_DRM_LICENSE_EXPIRED` | Licence keys have expired |
+| `ERROR_DRM_SESSION_NOT_OPENED` | Session ID is invalid or closed |
+| `ERROR_DRM_NOT_PROVISIONED` | Device requires provisioning before key request |
+| `ERROR_DRM_INSUFFICIENT_SECURITY` | Device security level insufficient for content policy |
+| `ERROR_DRM_INSUFFICIENT_OUTPUT_PROTECTION` | HDCP or other output protections not active |
+| `ERROR_DRM_RESOURCE_BUSY` | Decryption resources temporarily unavailable |
+| `ERROR_DRM_RESOURCE_CONTENTION` | Crypto resource contention; retry likely to succeed |
+| `ERROR_DRM_INVALID_STATE` | HAL in an invalid state for the requested operation |
+| `ERROR_DRM_VENDOR_MIN` – `ERROR_DRM_VENDOR_MAX` | Vendor-defined error range |
+
+---
+
+## Testing
+
+DRM HAL implementations must pass:
+
+- **L1 Tests**: Basic DRM operations (session creation, licence processing).
+- **L2 Tests**: DRM scheme-specific validation.
+- **L3 Tests**: Integration with secure media pipeline.
+- **L4 Tests**: End-to-end protected content playback and throughput performance
+
+---
+
+## References
+
+- AIDL interface definitions in `drm/current/com/rdk/hal/drm/`
+- HAL Feature Profile: `drm/current/hfp-drm.yaml`
+- Build configuration: `drm/current/CMakeLists.txt`

--- a/drm/current/CMakeLists.txt
+++ b/drm/current/CMakeLists.txt
@@ -1,0 +1,85 @@
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2025 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+cmake_minimum_required(VERSION 3.8)
+
+project(Drm
+	LANGUAGES NONE
+	VERSION 1.0)
+
+if (NOT COMMAND compile_aidl)
+	message(FATAL_ERROR "Do not invoke module level CMake directly!\nInvoke CMake at root level instead!")
+endif()
+
+set(SRC_DIR com/rdk/hal/drm)
+
+set(SRC
+	${SRC_DIR}/CryptoSchemes.aidl
+	${SRC_DIR}/DecryptArgs.aidl
+	${SRC_DIR}/DrmErrors.aidl
+	${SRC_DIR}/DrmMetric.aidl
+	${SRC_DIR}/DrmMetricGroup.aidl
+	${SRC_DIR}/DrmMetricNamedValue.aidl
+	${SRC_DIR}/DrmMetricValue.aidl
+	${SRC_DIR}/EventType.aidl
+	${SRC_DIR}/HdcpLevel.aidl
+	${SRC_DIR}/HdcpLevels.aidl
+	${SRC_DIR}/ICryptoPlugin.aidl
+	${SRC_DIR}/IDrmFactory.aidl
+	${SRC_DIR}/IDrmPlugin.aidl
+	${SRC_DIR}/IDrmPluginListener.aidl
+	${SRC_DIR}/KeyRequest.aidl
+	${SRC_DIR}/KeyRequestType.aidl
+	${SRC_DIR}/KeySetId.aidl
+	${SRC_DIR}/KeyStatus.aidl
+	${SRC_DIR}/KeyStatusType.aidl
+	${SRC_DIR}/KeyType.aidl
+	${SRC_DIR}/KeyValue.aidl
+	${SRC_DIR}/Mode.aidl
+	${SRC_DIR}/NumberOfSessions.aidl
+	${SRC_DIR}/Pattern.aidl
+	${SRC_DIR}/ProvideProvisionResponseResult.aidl
+	${SRC_DIR}/ProvisionRequest.aidl
+	${SRC_DIR}/SecurityLevel.aidl
+	${SRC_DIR}/Status.aidl
+	${SRC_DIR}/SubSample.aidl
+	${SRC_DIR}/SupportedContentType.aidl
+	${SRC_DIR}/Uuid.aidl
+)
+
+set(INCLUDE_DIRECTORY
+	.
+)
+
+set(COMPILE_AIDL_ARGV "")
+
+if (DEFINED AIDL_GEN_DIR)
+	list(APPEND COMPILE_AIDL_ARGV TARGET_DIRECTORY ${AIDL_GEN_DIR})
+endif()
+
+if (DEFINED AIDL_BIN)
+	list(APPEND COMPILE_AIDL_ARGV AIDL_BIN ${AIDL_BIN})
+endif()
+
+compile_aidl(${SRC}
+	INCLUDE_DIRECTORY ${INCLUDE_DIRECTORY}
+	${COMPILE_AIDL_ARGV}
+)

--- a/drm/current/com/rdk/hal/drm/CryptoSchemes.aidl
+++ b/drm/current/com/rdk/hal/drm/CryptoSchemes.aidl
@@ -1,0 +1,48 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.SupportedContentType;
+import com.rdk.hal.drm.Uuid;
+
+@VintfStability
+parcelable CryptoSchemes {
+
+    /**
+     * Supported crypto schemes
+     */
+    List<Uuid> uuids;
+
+    /**
+     * Supported mime types, and supported SecurityLevels for each mime
+     */
+    List<SupportedContentType> mimeTypes;
+
+}

--- a/drm/current/com/rdk/hal/drm/DecryptArgs.aidl
+++ b/drm/current/com/rdk/hal/drm/DecryptArgs.aidl
@@ -1,0 +1,93 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.Mode;
+import com.rdk.hal.drm.Pattern;
+import com.rdk.hal.drm.SubSample;
+
+/**
+ * Arguments to ICryptoPlugin decrypt
+ */
+@VintfStability
+parcelable DecryptArgs {
+
+    /**
+     * A flag to indicate if a secure decoder is being used.
+     *
+     * This enables the plugin to configure buffer modes to work consistently
+     * with a secure decoder.
+     *
+     */
+    boolean secure;
+
+    /**
+     * The keyId for the key that is used to do the decryption.
+     *
+     * The keyId refers to a key in the associated MediaDrm instance.
+     */
+    byte[] keyId;
+
+    /**
+     * The initialization vector
+     */
+    byte[] iv;
+
+    /**
+     * Crypto mode
+     */
+    Mode mode;
+
+    /**
+     * Crypto pattern
+     */
+    Pattern pattern;
+
+    /**
+     * A vector of subsamples indicating the number of clear and encrypted
+     * bytes to process.
+     *
+     * This allows the decrypt call to operate on a range of subsamples in a
+     * single call
+     */
+    SubSample[] subSamples;
+
+    /**
+     * Input AVBuffer handle for the encrypted data.
+     * 
+     * It is the responsibility of the caller to recycle/free the allocated AVBuffer after the call to decrypt returns.
+     */
+    long sourceBufferHandle;
+
+    /**
+     * Output AVBuffer handle for the decrypted data.
+     */
+    long destinationBufferHandle;
+
+}

--- a/drm/current/com/rdk/hal/drm/DrmErrors.aidl
+++ b/drm/current/com/rdk/hal/drm/DrmErrors.aidl
@@ -1,0 +1,91 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * Enumerate the supported DRM errors
+ * Errors from Android 16
+ * https://android.googlesource.com/platform/frameworks/av/+/refs/tags/android-16.0.0_r4/media/libstagefright/include/media/stagefright/MediaErrors.h
+ *
+ * Errors added as a convenience for Clients and Interface plug-ins
+ */
+@VintfStability
+@Backing(type="int")
+enum DrmErrors {
+
+    DRM_ERROR_BASE = -2000,
+
+    ERROR_DRM_UNKNOWN                        = DRM_ERROR_BASE,
+    ERROR_DRM_NO_LICENSE                     = DRM_ERROR_BASE - 1,
+    ERROR_DRM_LICENSE_EXPIRED                = DRM_ERROR_BASE - 2,
+    ERROR_DRM_SESSION_NOT_OPENED             = DRM_ERROR_BASE - 3,
+    ERROR_DRM_DECRYPT_UNIT_NOT_INITIALIZED   = DRM_ERROR_BASE - 4,
+    ERROR_DRM_DECRYPT                        = DRM_ERROR_BASE - 5,
+    ERROR_DRM_CANNOT_HANDLE                  = DRM_ERROR_BASE - 6,
+    ERROR_DRM_TAMPER_DETECTED                = DRM_ERROR_BASE - 7,
+    ERROR_DRM_NOT_PROVISIONED                = DRM_ERROR_BASE - 8,
+    ERROR_DRM_DEVICE_REVOKED                 = DRM_ERROR_BASE - 9,
+    ERROR_DRM_RESOURCE_BUSY                  = DRM_ERROR_BASE - 10,
+    ERROR_DRM_INSUFFICIENT_OUTPUT_PROTECTION = DRM_ERROR_BASE - 11,
+    ERROR_DRM_INSUFFICIENT_SECURITY          = DRM_ERROR_BASE - 12,
+    ERROR_DRM_FRAME_TOO_LARGE                = DRM_ERROR_BASE - 13,
+    ERROR_DRM_RESOURCE_CONTENTION            = DRM_ERROR_BASE - 14,
+    ERROR_DRM_SESSION_LOST_STATE             = DRM_ERROR_BASE - 15,
+    ERROR_DRM_INVALID_STATE                  = DRM_ERROR_BASE - 16,
+
+    // New in S / drm@1.4:
+    ERROR_DRM_CERTIFICATE_MALFORMED          = DRM_ERROR_BASE - 17,
+    ERROR_DRM_CERTIFICATE_MISSING            = DRM_ERROR_BASE - 18,
+    ERROR_DRM_CRYPTO_LIBRARY                 = DRM_ERROR_BASE - 19,
+    ERROR_DRM_GENERIC_OEM                    = DRM_ERROR_BASE - 20,
+    ERROR_DRM_GENERIC_PLUGIN                 = DRM_ERROR_BASE - 21,
+    ERROR_DRM_INIT_DATA                      = DRM_ERROR_BASE - 22,
+    ERROR_DRM_KEY_NOT_LOADED                 = DRM_ERROR_BASE - 23,
+    ERROR_DRM_LICENSE_PARSE                  = DRM_ERROR_BASE - 24,
+    ERROR_DRM_LICENSE_POLICY                 = DRM_ERROR_BASE - 25,
+    ERROR_DRM_LICENSE_RELEASE                = DRM_ERROR_BASE - 26,
+    ERROR_DRM_LICENSE_REQUEST_REJECTED       = DRM_ERROR_BASE - 27,
+    ERROR_DRM_LICENSE_RESTORE                = DRM_ERROR_BASE - 28,
+    ERROR_DRM_LICENSE_STATE                  = DRM_ERROR_BASE - 29,
+    ERROR_DRM_MEDIA_FRAMEWORK                = DRM_ERROR_BASE - 30,
+    ERROR_DRM_PROVISIONING_CERTIFICATE       = DRM_ERROR_BASE - 31,
+    ERROR_DRM_PROVISIONING_CONFIG            = DRM_ERROR_BASE - 32,
+    ERROR_DRM_PROVISIONING_PARSE             = DRM_ERROR_BASE - 33,
+    ERROR_DRM_PROVISIONING_REQUEST_REJECTED  = DRM_ERROR_BASE - 34,
+    ERROR_DRM_PROVISIONING_RETRY             = DRM_ERROR_BASE - 35,
+    ERROR_DRM_SECURE_STOP_RELEASE            = DRM_ERROR_BASE - 36,
+    ERROR_DRM_STORAGE_READ                   = DRM_ERROR_BASE - 37,
+    ERROR_DRM_STORAGE_WRITE                  = DRM_ERROR_BASE - 38,
+    ERROR_DRM_ZERO_SUBSAMPLES                = DRM_ERROR_BASE - 39,
+    ERROR_DRM_LAST_USED_ERRORCODE            = ERROR_DRM_ZERO_SUBSAMPLES,
+
+    ERROR_DRM_VENDOR_MAX                     = DRM_ERROR_BASE - 500,
+    ERROR_DRM_VENDOR_MIN                     = DRM_ERROR_BASE - 999,
+}

--- a/drm/current/com/rdk/hal/drm/DrmMetric.aidl
+++ b/drm/current/com/rdk/hal/drm/DrmMetric.aidl
@@ -1,0 +1,59 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.DrmMetricNamedValue;
+
+/**
+ * The metric being captured.
+ *
+ * A metric must have a name and at least one value. A metric may have 0 or
+ * more attributes. The fields of a Metric are opaque to the framework.
+ */
+@VintfStability
+parcelable DrmMetric {
+    String name;
+
+    /**
+     * Detail(s) about the metric being captured.
+     *
+     * The fields of an Attribute are opaque to the framework.
+     */
+    List<DrmMetricNamedValue> attributes;
+
+    /**
+     * Value(s) of the metric.
+     *
+     * A metric may have multiple values. The component name may be left empty
+     * if there is only supposed to be one value for the given metric. The
+     * fields of the Value are opaque to the framework.
+     */
+    List<DrmMetricNamedValue> values;
+}

--- a/drm/current/com/rdk/hal/drm/DrmMetricGroup.aidl
+++ b/drm/current/com/rdk/hal/drm/DrmMetricGroup.aidl
@@ -1,0 +1,74 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.DrmMetric;
+
+/**
+ * This message contains plugin-specific metrics made available to the client.
+ * The message is used for making vendor-specific metrics available to an
+ * application. The framework is not consuming any of the information.
+ *
+ * Metrics are grouped in instances of DrmMetricGroup. Each group contains
+ * multiple instances of Metric.
+ *
+ * Example:
+ *
+ * Capture the timing information of a buffer copy event, "buf_copy", broken
+ * out by the "size" of the buffer.
+ *
+ * DrmMetricGroup {
+ *   metrics[0] {
+ *     name: "buf_copy"
+ *     attributes[0] {
+ *       name: "size"
+ *       type: INT64_TYPE
+ *       int64Value: 1024
+ *     }
+ *     values[0] {
+ *       componentName: "operation_count"
+ *       type: INT64_TYPE
+ *       int64Value: 75
+ *     }
+ *     values[1] {
+ *       component_name: "average_time_seconds"
+ *       type: DOUBLE_TYPE
+ *       doubleValue: 0.00000042
+ *     }
+ *   }
+ * }
+ */
+@VintfStability
+parcelable DrmMetricGroup {
+    /**
+     * The list of metrics to be captured.
+     */
+    List<DrmMetric> metrics;
+}

--- a/drm/current/com/rdk/hal/drm/DrmMetricNamedValue.aidl
+++ b/drm/current/com/rdk/hal/drm/DrmMetricNamedValue.aidl
@@ -1,0 +1,41 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.DrmMetricValue;
+
+/**
+ * A name-value pair used in drm metrics.
+ */
+@VintfStability
+parcelable DrmMetricNamedValue {
+    String name;
+    DrmMetricValue value;
+}

--- a/drm/current/com/rdk/hal/drm/DrmMetricValue.aidl
+++ b/drm/current/com/rdk/hal/drm/DrmMetricValue.aidl
@@ -1,0 +1,40 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * The value of a metric or a metric's attribute.
+ */
+@VintfStability
+union DrmMetricValue {
+    long int64Value;
+    double doubleValue;
+    String stringValue;
+}

--- a/drm/current/com/rdk/hal/drm/EventType.aidl
+++ b/drm/current/com/rdk/hal/drm/EventType.aidl
@@ -1,0 +1,64 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * EventType enumerates the events that can be delivered by sendEvent
+ */
+@VintfStability
+@Backing(type="int")
+enum EventType {
+    /**
+     * This event type indicates that the app needs to request a certificate
+     * from the provisioning server. The request message data is obtained using
+     * getProvisionRequest().
+     */
+    PROVISION_REQUIRED,
+    /**
+     * This event type indicates that the app needs to request keys from a
+     * license server. The request message data is obtained using getKeyRequest.
+     */
+    KEY_NEEDED,
+    /**
+     * This event type indicates that the licensed usage duration for keys in a
+     * session has expired. The keys are no longer valid.
+     */
+    KEY_EXPIRED,
+    /**
+     * This event may indicate some specific vendor-defined condition, see your
+     * DRM provider documentation for details.
+     */
+    VENDOR_DEFINED,
+    /**
+     * This event indicates that a session opened by the app has been reclaimed
+     * by the resource manager.
+     */
+    SESSION_RECLAIMED,
+}

--- a/drm/current/com/rdk/hal/drm/HdcpLevel.aidl
+++ b/drm/current/com/rdk/hal/drm/HdcpLevel.aidl
@@ -1,0 +1,72 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * HDCP specifications are defined by Digital Content Protection LLC (DCP).
+ *   "HDCP Specification Rev. 2.3 Interface Independent Adaptation"
+ *   "HDCP 2.3 on HDMI Specification"
+ */
+@VintfStability
+@Backing(type="int")
+enum HdcpLevel {
+    /**
+     * Unable to determine the HDCP level
+     */
+    HDCP_UNKNOWN,
+    /**
+     * No HDCP, output is unprotected
+     */
+    HDCP_NONE,
+    /**
+     * HDCP version 1.0
+     */
+    HDCP_V1,
+    /**
+     * HDCP version 2.0 Type 1.
+     */
+    HDCP_V2,
+    /**
+     * HDCP version 2.1 Type 1.
+     */
+    HDCP_V2_1,
+    /**
+     *  HDCP version 2.2 Type 1.
+     */
+    HDCP_V2_2,
+    /**
+     * No digital output, implicitly secure
+     */
+    HDCP_NO_OUTPUT,
+    /**
+     * HDCP version 2.3 Type 1.
+     */
+    HDCP_V2_3,
+}

--- a/drm/current/com/rdk/hal/drm/HdcpLevels.aidl
+++ b/drm/current/com/rdk/hal/drm/HdcpLevels.aidl
@@ -1,0 +1,41 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.HdcpLevel;
+
+@VintfStability
+parcelable HdcpLevels {
+    /** The lowest HDCP level for any connected displays. */
+    HdcpLevel connectedLevel;
+
+    /** The highest HDCP level that can be supported by the device. */
+    HdcpLevel maxLevel;
+}

--- a/drm/current/com/rdk/hal/drm/ICryptoPlugin.aidl
+++ b/drm/current/com/rdk/hal/drm/ICryptoPlugin.aidl
@@ -1,0 +1,111 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+import com.rdk.hal.drm.DecryptArgs;
+
+
+/**
+ * ICryptoPlugin is the HAL for vendor-provided crypto plugins.
+ *
+ * It allows crypto sessions to be opened and operated on, to
+ * load crypto keys for a codec to decrypt protected video content.
+ */
+@VintfStability
+interface ICryptoPlugin {
+    /**
+     * Decrypt an array of subsamples from the source memory buffer to the
+     * destination memory buffer.
+     * 
+     * Decrypt is a synchronous call.
+     * After decryption the source AVBuffer must be recycled/freed by the caller.
+     * This approach is the same as Android and is unlike other RDK-E AIDL HALs where the HAL component consumes and frees buffers.
+     * 
+     * @return number of decrypted bytes
+     * 
+     * Error codes are returned via binder::status EX_SERVICE_SPECIFIC error codes
+     *     Implicit error codes:
+     *       + ERROR_DRM_CANNOT_HANDLE in other failure cases
+     *       + ERROR_DRM_DECRYPT if the decrypt operation fails
+     *       + ERROR_DRM_FRAME_TOO_LARGE if the frame being decrypted into
+     *             the secure output buffer exceeds the size of the buffer
+     *       + ERROR_DRM_INSUFFICIENT_OUTPUT_PROTECTION if required output
+     *             protections are not active
+     *       + ERROR_DRM_INSUFFICIENT_SECURITY if the security level of the
+     *             device is not sufficient to meet the requirements in
+     *             the license policy
+     *       + ERROR_DRM_INVALID_STATE if the device is in a state where it
+     *             is not able to perform decryption
+     *       + ERROR_DRM_LICENSE_EXPIRED if the license keys have expired
+     *       + ERROR_DRM_NO_LICENSE if no license keys have been loaded
+     *       + ERROR_DRM_RESOURCE_BUSY if the resources required to perform
+     *             the decryption are not available
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the decrypt session is not
+     *             opened
+     */
+    int decrypt(in DecryptArgs args);
+
+    /**
+     * Notify a plugin of the currently configured resolution.
+     *
+     * @param width - the display resolution's width
+     * @param height - the display resolution's height
+     */
+    void notifyResolution(in int width, in int height);
+
+    /**
+     * Check if the specified mime-type requires a secure decoder
+     * component.
+     *
+     * Video:	video/avc (H.264), video/hevc (H.265), video/x-vnd.on2.vp9, video/av1, video/mp4v-es
+     * Audio:	audio/mp4a-latm (AAC), audio/ac3, audio/eac3, audio/vnd.dts, audio/opus
+     *
+     * @param mime The content mime-type
+     * @return must be true only if a secure decoder is required
+     * for the specified mime-type
+     */
+    boolean requiresSecureDecoderComponent(in String mime);
+
+    /**
+     * Associate a mediadrm session with this crypto session.
+     *
+     * The session (if known) can be passed in at creation, or this call can be used. 
+     * Potentially the sessionID can change if there is a key change.
+     *
+     * @param sessionId the MediaDrm session ID to associate with
+     *     this crypto session
+     * @return (implicit) the status of the call, status can be:
+     *     ERROR_DRM_SESSION_NOT_OPENED if the session is not opened, or
+     *     ERROR_DRM_CANNOT_HANDLE if the operation is not supported by
+     *         the drm scheme
+     */
+    void setMediaDrmSession(in byte[] sessionId);
+
+
+
+}

--- a/drm/current/com/rdk/hal/drm/IDrmFactory.aidl
+++ b/drm/current/com/rdk/hal/drm/IDrmFactory.aidl
@@ -1,0 +1,83 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.CryptoSchemes;
+import com.rdk.hal.drm.Uuid;
+
+/**
+ * IDrmFactory is the main entry point for interacting with a vendor's
+ * drm HAL to create drm plugin instances. A drm plugin instance
+ * creates drm sessions which are used to obtain keys for a crypto
+ * session so it can decrypt protected video content.
+ */
+@VintfStability
+interface IDrmFactory {
+    /**
+     * Create a drm plugin instance for the specified uuid and
+     * scheme-specific initialization data.
+     *
+     * @param uuid uniquely identifies the drm scheme. See
+     *     http://dashif.org/identifiers/protection for uuid assignments
+     * @param appPackageName identifies the package name of the calling
+     *     application.
+     *
+     * @return A DRM plugin instance if successful, or null if not created.
+     *     Implicit error codes:
+     *       + ERROR_DRM_CANNOT_HANDLE if the plugin cannot be created.
+     */
+    @nullable com.rdk.hal.drm.IDrmPlugin createDrmPlugin(
+            in Uuid uuid, in String appPackageName);
+
+    /**
+     * Create a crypto plugin for the specified uuid and scheme-specific
+     * initialization data.
+     *
+     * @param uuid uniquely identifies the drm scheme. See
+     *     http://dashif.org/identifiers/protection for uuid assignments
+     *
+     * @param initData scheme-specific init data. 
+     *        The initData can (if known) contain the SessionId created by DRMPlugin::openSession(), else a byte array of zero length.
+     *
+     * @return A crypto plugin instance if successful, or null if not created.
+     */
+    @nullable com.rdk.hal.drm.ICryptoPlugin createCryptoPlugin(
+            in Uuid uuid, in byte[] initData);
+
+    /**
+     * Return vector of uuids identifying crypto schemes supported by
+     * this HAL.
+     *
+     * @return List of uuids for which isCryptoSchemeSupported is true;
+     *      each uuid can be used as input to createPlugin.
+     */
+    CryptoSchemes getSupportedCryptoSchemes();
+
+}

--- a/drm/current/com/rdk/hal/drm/IDrmPlugin.aidl
+++ b/drm/current/com/rdk/hal/drm/IDrmPlugin.aidl
@@ -1,0 +1,556 @@
+
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.DrmMetricGroup;
+import com.rdk.hal.drm.HdcpLevels;
+import com.rdk.hal.drm.IDrmPluginListener;
+import com.rdk.hal.drm.KeySetId;
+import com.rdk.hal.drm.KeyRequest;
+import com.rdk.hal.drm.KeyStatus;
+import com.rdk.hal.drm.KeyType;
+import com.rdk.hal.drm.KeyValue;
+import com.rdk.hal.drm.NumberOfSessions;
+import com.rdk.hal.drm.ProvideProvisionResponseResult;
+import com.rdk.hal.drm.ProvisionRequest;
+import com.rdk.hal.drm.SecurityLevel;
+
+
+/**
+ * IDrmPlugin is used to interact with a specific drm plugin that was
+ * created by IDrmFactory::createPlugin.
+ *
+ * A drm plugin provides methods for obtaining drm keys to be used by a codec
+ * to decrypt protected video content.
+ */
+@VintfStability
+interface IDrmPlugin {
+    /**
+     * Close a session on the DrmPlugin object
+     *
+     * @param sessionId the session id the call applies to
+     *
+     * @return (implicit) the status of the call:
+     *     BAD_VALUE if the sessionId is invalid
+     *     ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *         the session cannot be closed.
+     *     ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    void closeSession(in byte[] sessionId);
+
+    /**
+     * Decrypt the provided input buffer with the cipher algorithm
+     * specified by setCipherAlgorithm and the key selected by keyId,
+     * and return the decrypted data.
+     *
+     * @param sessionId the session id the call applies to
+     * @param keyId the ID of the key to use for decryption
+     * @param input the input data to decrypt
+     * @param iv the initialization vector to use for decryption
+     *
+     * @return decrypted output buffer
+     *     Implicit error codes:
+     *       + BAD_VALUE if the sessionId is invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             the decrypt operation cannot be performed.
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    byte[] decrypt(in byte[] sessionId, in byte[] keyId, in byte[] input, in byte[] iv);
+
+    /**
+     * Encrypt the provided input buffer with the cipher algorithm specified by
+     * setCipherAlgorithm and the key selected by keyId, and return the
+     * encrypted data.
+     *
+     * @param sessionId the session id the call applies to
+     * @param keyId the ID of the key to use for encryption
+     * @param input the input data to encrypt
+     * @param iv the initialization vector to use for encryption
+     *
+     * @return encrypted output buffer
+     *     Implicit error codes:
+     *       + BAD_VALUE if the sessionId is invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             the encrypt operation cannot be performed.
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    byte[] encrypt(in byte[] sessionId, in byte[] keyId, in byte[] input, in byte[] iv);
+
+    /**
+     * Return the currently negotiated and max supported HDCP levels.
+     *
+     * For a HDMI source device:
+     * 
+     * The current level is based on the display(s) the device is connected to.
+     * If multiple HDCP-capable displays are simultaneously connected to
+     * separate interfaces, this method returns the lowest negotiated HDCP level
+     * of all interfaces.
+     *
+     * The maximum HDCP level is the highest level that can potentially be
+     * negotiated. It is a constant for any device, i.e. it does not depend on
+     * downstream receiving devices that could be connected. For example, if
+     * the device has HDCP 1.x keys and is capable of negotiating HDCP 1.x, but
+     * does not have HDCP 2.x keys, then the maximum HDCP capability would be
+     * reported as 1.x. If multiple HDCP-capable interfaces are present, it
+     * indicates the highest of the maximum HDCP levels of all interfaces.
+     * 
+     * For a HDMI sink device:
+     * 
+     * On a Smart TV where the SoC is wired directly to the internal panel, 
+     * the DRM stack typically reports the Maximum Security Level the hardware can 
+     * attest to.
+     *
+     * This method should only be used for informational purposes, not for
+     * enforcing compliance with HDCP requirements. Trusted enforcement of HDCP
+     * policies must be handled by the DRM system.
+     * 
+     * Polling should be avoided or at a level that has very low performance impact on the system.
+     *
+     * @return HdcpLevels parcelable
+     *     Implicit error codes:
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             the HDCP level cannot be queried
+     */
+    HdcpLevels getHdcpLevels();
+
+      /**
+     * A key request/response exchange occurs between the app and a License
+     * Server to obtain the keys required to decrypt the content.
+     * getKeyRequest() is used to obtain an opaque key request blob that is
+     * delivered to the license server.
+     *
+     * @param scope either a sessionId or a keySetId, depending on the
+     *     specified keyType. When the keyType is OFFLINE or STREAMING, scope
+     *     must be set to the sessionId the keys will be provided to. When the
+     *     keyType is RELEASE, scope must be set to the keySetId of the keys
+     *     being released.
+     * @param initData container-specific data, its meaning is interpreted
+     *     based on the mime type provided in the mimeType parameter. It could
+     *     contain, for example, the content ID, key ID or other data obtained
+     *     from the content metadata that is required to generate the key
+     *     request. initData must be empty when keyType is RELEASE.
+     * @param mimeType identifies the mime type of the content
+     * @param keyType specifies if the keys are to be used for streaming,
+     *     offline or a release
+     * @param optionalParameters included in the key request message to
+     *     allow a client application to provide additional message parameters
+     *     to the server.
+     *
+     * @return KeyRequest parcelable
+     *     Implicit error codes:
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_CANNOT_HANDLE if getKeyRequest is not supported at
+     *             the time of the call
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             a key request cannot be generated
+     *       + ERROR_DRM_NOT_PROVISIONED if the device requires provisioning
+     *             before it is able to generate a key request
+     *       + ERROR_DRM_RESOURCE_CONTENTION if client applications using the
+     *             hal are temporarily exceeding the available crypto resources
+     *             such that a retry of the operation is likely to succeed
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    KeyRequest getKeyRequest(in byte[] scope, in byte[] initData, in String mimeType,
+            in KeyType keyType, in KeyValue[] optionalParameters);
+
+    /**
+     * Returns the plugin-specific metrics. Multiple metric groups may be
+     * returned in one call to getMetrics(). The scope and definition of the
+     * metrics is defined by the plugin.
+     *
+     * @return collection of metric groups provided by the plugin
+     *     Implicit error codes:
+     *       + ERROR_DRM_INVALID_STATE if the metrics are not available to be
+     *             returned.
+     */
+    List<DrmMetricGroup> getMetrics();
+
+    /**
+     * Return the current number of open sessions and the maximum number of
+     * sessions that may be opened simultaneously among all DRM instances
+     * for the active DRM scheme.
+     *
+     * @return NumberOfSessions parcelable
+     *     Implicit error codes:
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             number of sessions cannot be queried
+     */
+    NumberOfSessions getNumberOfSessions();
+
+    /**
+     * Read a byte array property value given the property name.
+     * See getPropertyString.
+     *
+     * @param propertyName the name of the property
+     *
+     * @return property value byte array
+     *     Implicit error codes:
+     *       + BAD_VALUE if the property name is invalid
+     *       + ERROR_DRM_CANNOT_HANDLE if the property is not supported
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             property cannot be obtained
+     */
+    byte[] getPropertyByteArray(in String propertyName);
+
+    /**
+     * A drm scheme can have properties that are settable and readable
+     * by an app. There are a few forms of property access methods,
+     * depending on the data type of the property.
+     *
+     * Property values defined by the public API are:
+     *   "vendor" [string] identifies the maker of the drm scheme
+     *   "version" [string] identifies the version of the drm scheme
+     *   "description" [string] describes the drm scheme
+     *   'deviceUniqueId' [byte array] The device unique identifier is
+     *   established during device provisioning and provides a means of
+     *   uniquely identifying each device.
+     *
+     * Since drm scheme properties may vary, additional field names may be
+     * defined by each DRM vendor. Refer to your DRM provider documentation
+     * for definitions of its additional field names.
+     *
+     * Read a string property value given the property name.
+     *
+     * @param propertyName the name of the property
+     *
+     * @return the property value string.
+     *     Implicit error codes:
+     *       + BAD_VALUE if the property name is invalid
+     *       + ERROR_DRM_CANNOT_HANDLE if the property is not supported
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             property cannot be obtained
+     */
+    String getPropertyString(in String propertyName);
+
+    /**
+     * A provision request/response exchange occurs between the app
+     * and a provisioning server to retrieve a device certificate.
+     * getProvisionRequest is used to obtain an opaque provisioning
+     * request blob that is delivered to the provisioning server.
+     *
+     * @param certificateType the type of certificate requested, e.g. "X.509"
+     * @param certificateAuthority identifies the certificate authority.
+     *     A certificate authority (CA) is an entity which issues digital
+     *     certificates for use by other parties. It is an example of a
+     *     trusted third party.
+     *
+     * @return ProvisionRequest parcelable
+     *     Implicit error codes:
+     *       + ERROR_DRM_CANNOT_HANDLE if the drm scheme does not require
+     *             provisioning
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             the provision request cannot be generated
+     *       + ERROR_DRM_RESOURCE_CONTENTION if client applications using
+     *             the hal are temporarily exceeding the available crypto
+     *             resources such that a retry of the operation is likely
+     *             to succeed
+     */
+    ProvisionRequest getProvisionRequest(
+            in String certificateType, in String certificateAuthority);
+
+    /**
+     * Return the current security level of a session. A session has an initial
+     * security level determined by the robustness of the DRM system's
+     * implementation on the device.
+     *
+     * @param sessionId the session id the call applies to
+     *
+     * @return the current security level for the session.
+     *     Implicit error codes:
+     *       + BAD_VALUE if the sessionId is invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             the security level cannot be queried
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    SecurityLevel getSecurityLevel(in byte[] sessionId);
+
+    /**
+     * Open a new session at a requested security level. The security level
+     * represents the robustness of the device's DRM implementation. By default,
+     * sessions are opened at the native security level of the device which is
+     * the maximum level that can be supported. Overriding the security level is
+     * necessary when the decrypted frames need to be manipulated, such as for
+     * image compositing. The security level parameter must be equal to or lower
+     * than the native level. If the requested level is not supported, the next
+     * lower supported security level must be set. The level can be queried
+     * using {@link #getSecurityLevel}. A session ID is returned.
+     *
+     * @param[in] securityLevel the requested security level
+     *
+     * @returns Session ID.
+     */
+    byte[] openSession(in SecurityLevel securityLevel);
+
+    /**
+     * After a key response is received by the app, it is provided to the
+     * Drm plugin using provideKeyResponse.
+     *
+     * @param scope may be a sessionId or a keySetId depending on the
+     *     type of the response. Scope should be set to the sessionId
+     *     when the response is for either streaming or offline key requests.
+     *     Scope should be set to the keySetId when the response is for
+     *     a release request.
+     * @param response the response from the key server that is being
+     *     provided to the drm HAL.
+     *
+     * @return a keySetId that can be used to later restore the keys to a new
+     *     session with the method restoreKeys when the response is for an
+     *     offline key request.
+     *     Implicit error codes:
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_CANNOT_HANDLE if provideKeyResponse is not supported
+     *             at the time of the call
+     *       + ERROR_DRM_DEVICE_REVOKED if the device has been disabled by
+     *             the license policy
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *             a key response cannot be handled.
+     *       + ERROR_DRM_NOT_PROVISIONED if the device requires provisioning
+     *             before it can handle the key response
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    KeySetId provideKeyResponse(in byte[] scope, in byte[] response);
+
+    /**
+     * After a provision response is received by the app from a provisioning
+     * server, it is provided to the Drm HAL using provideProvisionResponse.
+     * The HAL implementation must receive the provision request and
+     * store the provisioned credentials.
+     *
+     * @param response the opaque provisioning response received by the
+     * app from a provisioning server.
+     *
+     * @return ProvideProvisionResponseResult parcelable, which contains
+     *     the public certificate and encrypted private key that can be
+     *     used by signRSA to compute an RSA signature on a message.
+     *     Implicit error codes:
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_DEVICE_REVOKED if the device has been disabled by
+     *             the license policy
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             provision response cannot be handled
+     */
+    ProvideProvisionResponseResult provideProvisionResponse(in byte[] response);
+
+    /**
+     * Request an informative description of the license for the session.
+     * The status is in the form of {name, value} pairs. Since DRM license
+     * policies vary by vendor, the specific status field names are
+     * determined by each DRM vendor. Refer to your DRM provider
+     * documentation for definitions of the field names for a particular
+     * drm scheme.
+     *
+     * @param sessionId the session id the call applies to
+     *
+     * @return a list of name value pairs describing the license.
+     *     Implicit error codes:
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             key status cannot be queried.
+     */
+    List<KeyValue> queryKeyStatus(in byte[] sessionId);
+
+    /**
+     * Remove the current keys from a session
+     *
+     * @param sessionId the session id the call applies to
+     *
+     * @return (implicit) the status of the call:
+     *     BAD_VALUE if the sessionId is invalid
+     *     ERROR_DRM_INVALID_STATE if the HAL is in a state where
+     *         the keys cannot be removed.
+     *     ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    void removeKeys(in byte[] sessionId);
+
+    /**
+     * Check if the specified mime-type & security level require a secure decoder
+     * component.
+     *
+     * @param mime The content mime-type
+     * @param level the requested security level
+     *
+     * @return must be true if and only if a secure decoder is
+     *     required for the specified mime-type & security level
+     */
+    boolean requiresSecureDecoder(in String mime, in SecurityLevel level);
+
+    /**
+     * The following methods implement operations on a CryptoSession to support
+     * encrypt, decrypt, sign verify operations on operator-provided
+     * session keys.
+     *
+     *
+     * Set the cipher algorithm to be used for the specified session.
+     *
+     * @param sessionId the session id the call applies to
+     * @param algorithm the algorithm to use. The string conforms to JCA
+     *     Standard Names for Cipher Transforms and is case insensitive. An
+     *     example algorithm is "AES/CBC/PKCS5Padding".
+     *
+     * @return (implicit) the status of the call:
+     *     BAD_VALUE if any parameters are invalid
+     *     ERROR_DRM_INVALID_STATE  if the HAL is in a state where
+     *         the algorithm cannot be set.
+     *     ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    void setCipherAlgorithm(in byte[] sessionId, in String algorithm);
+
+    /**
+     * Plugins call the following methods to deliver events 
+     *
+     *
+     * Set a listener for a drm session. This allows the drm HAL to
+     * make asynchronous calls back to the client of IDrm.
+     *
+     * @param listener instance of IDrmPluginListener to receive the events
+     */
+    void setListener(in IDrmPluginListener listener);
+
+    /**
+     * Set the MAC algorithm to be used for computing hashes in a session.
+     *
+     * @param sessionId the session id the call applies to
+     * @param algorithm the algorithm to use. The string conforms to JCA
+     *     Standard Names for Mac Algorithms and is case insensitive. An example MAC
+     *     algorithm string is "HmacSHA256".
+     *
+     * @return (implicit) the status of the call:
+     *     BAD_VALUE if any parameters are invalid
+     *     ERROR_DRM_INVALID_STATE  if the HAL is in a state where
+     *         the algorithm cannot be set.
+     *     ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    void setMacAlgorithm(in byte[] sessionId, in String algorithm);
+
+    /**
+     * Set playback id of a drm session. The playback id can be used to join drm session metrics
+     * with metrics from other low level media components, e.g. codecs, or metrics from the high
+     * level player.
+     *
+     * @param sessionId drm session id
+     * @param playbackId high level playback id
+     *
+     * @return (implicit) the status of the call:
+     *    ERROR_DRM_SESSION_NOT_OPENED if the drm session cannot be found
+     */
+    void setPlaybackId(in byte[] sessionId, in String playbackId);
+
+    /**
+     * Write a property byte array value given the property name
+     *
+     * @param propertyName the name of the property
+     * @param value the value to write
+     *
+     * @return (implicit) the status of the call:
+     *     BAD_VALUE if the property name is invalid
+     *     ERROR_DRM_CANNOT_HANDLE if the property is not supported
+     *     ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *         property cannot be set
+     */
+    void setPropertyByteArray(in String propertyName, in byte[] value);
+
+    /**
+     * Write a property string value given the property name
+     *
+     * @param propertyName the name of the property
+     * @param value the value to write
+     *
+     * @return (implicit) status of the call:
+     *     BAD_VALUE if the property name is invalid
+     *     ERROR_DRM_CANNOT_HANDLE if the property is not supported
+     *     ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *         property cannot be set
+     */
+    void setPropertyString(in String propertyName, in String value);
+
+    /**
+     * Compute a signature over the provided message using the mac algorithm
+     * specified by setMacAlgorithm and the key selected by keyId and return
+     * the signature.
+     *
+     * @param sessionId the session id the call applies to
+     * @param keyId the ID of the key to use for decryption
+     * @param message the message to compute a signature over
+     *
+     * @return signature computed over the message
+     *     Implicit error codes:
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             sign operation cannot be performed.
+     */
+    byte[] sign(in byte[] sessionId, in byte[] keyId, in byte[] message);
+
+    /**
+     * Compute an RSA signature on the provided message using the specified
+     * algorithm.
+     *
+     * @param sessionId the session id the call applies to
+     * @param algorithm the signing algorithm, such as "RSASSA-PSS-SHA1"
+     *     or "PKCS1-BlockType1"
+     * @param message the message to compute the signature on
+     * @param wrappedKey the private key returned during provisioning as
+     *     returned by provideProvisionResponse.
+     *
+     * @return signature computed over the message
+     *     Implicit error codes:
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             signRSA operation operation cannot be performed
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     */
+    byte[] signRSA(
+            in byte[] sessionId, in String algorithm, in byte[] message,
+            in byte[] wrappedKey);
+
+    /**
+     * Compute a hash of the provided message using the mac algorithm specified
+     * by setMacAlgorithm and the key selected by keyId, and compare with the
+     * expected result.
+     *
+     * @param sessionId the session id the call applies to
+     * @param keyId the ID of the key to use for decryption
+     * @param message the message to compute a hash of
+     * @param signature the signature to verify
+     *
+     * @return true if the signature is verified positively, false otherwise.
+     *     Implicit error codes:
+     *       + ERROR_DRM_SESSION_NOT_OPENED if the session is not opened
+     *       + BAD_VALUE if any parameters are invalid
+     *       + ERROR_DRM_INVALID_STATE if the HAL is in a state where the
+     *             verify operation cannot be performed.
+     */
+    boolean verify(
+            in byte[] sessionId, in byte[] keyId, in byte[] message,
+            in byte[] signature);
+
+}

--- a/drm/current/com/rdk/hal/drm/IDrmPluginListener.aidl
+++ b/drm/current/com/rdk/hal/drm/IDrmPluginListener.aidl
@@ -1,0 +1,89 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.EventType;
+import com.rdk.hal.drm.KeyStatus;
+
+/**
+ * IDrmPluginListener is a listener interface for Drm events sent from an
+ * IDrmPlugin instance.
+ */
+@VintfStability
+interface IDrmPluginListener {
+    /**
+     * Legacy event sending method, it sends events of various types using a
+     * single overloaded set of parameters. This form is deprecated.
+     *
+     * @param eventType the type of the event
+     * @param sessionId identifies the session the event originated from
+     * @param data event-specific data blob
+     */
+    oneway void onEvent(in EventType eventType, in byte[] sessionId, in byte[] data);
+
+    /**
+     * Send a license expiration update to the listener. The expiration
+     * update indicates how long the current keys are valid before they
+     * need to be renewed.
+     *
+     * @param sessionId identifies the session the event originated from
+     * @param expiryTimeInMS the time when the keys need to be renewed.
+     * The time is in milliseconds, relative to the Unix epoch. A time
+     * of 0 indicates that the keys never expire.
+     */
+    oneway void onExpirationUpdate(in byte[] sessionId, in long expiryTimeInMS);
+
+    /**
+     * Send a keys change event to the listener. The keys change event
+     * indicates the status of each key in the session. Keys can be
+     * indicated as being usable, expired, outputnotallowed or statuspending.
+     *
+     * @param sessionId identifies the session the event originated from
+     * @param keyStatusList indicates the status for each key ID in the
+     * session.
+     * @param hasNewUsableKey indicates if the event includes at least one
+     * key that has become usable.
+     */
+    oneway void onKeysChange(
+            in byte[] sessionId, in KeyStatus[] keyStatusList, in boolean hasNewUsableKey);
+
+    /**
+     * Some device crypto hardware is incapable of retaining crypto
+     * session state across suspend and resume cycles. A
+     * SessionLostState event must be signaled when a session has
+     * become invalid for this reason. This event must not be used to
+     * indicate a failure in the crypto system. Closing the session
+     * and opening a new one must allow the application to resume
+     * normal use of the drm hal module.
+     *
+     * @param sessionId identifies the session that has been invalidated
+     */
+    oneway void onSessionLostState(in byte[] sessionId);
+}

--- a/drm/current/com/rdk/hal/drm/KeyRequest.aidl
+++ b/drm/current/com/rdk/hal/drm/KeyRequest.aidl
@@ -1,0 +1,59 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.KeyRequestType;
+
+@VintfStability
+parcelable KeyRequest {
+    /** The opaque key request blob. */
+    byte[] request;
+
+    /**
+     * Enumerated type:
+     *     INITIAL - the first key request for a license
+     *     NONE - indicates that no request is needed because the keys
+     *         are already loaded
+     *     RENEWAL - is a subsequent key request used to refresh the
+     *         keys in a license
+     *     RELEASE - indicates keys are being released
+     *     UPDATE - indicates that the keys need to be refetched after
+     *         the initial license request
+     */
+    KeyRequestType requestType;
+
+    /**
+     * The URL that the request may be sent to,
+     * if provided by the drm HAL. The app can choose to
+     * override this URL. If the HAL implementation does not provide
+     * a defaultUrl, the returned string must be empty.
+     */
+    String defaultUrl;
+}

--- a/drm/current/com/rdk/hal/drm/KeyRequestType.aidl
+++ b/drm/current/com/rdk/hal/drm/KeyRequestType.aidl
@@ -1,0 +1,65 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * An app determines the type of a key request returned from getKeyRequest.
+ */
+@VintfStability
+@Backing(type="int")
+enum KeyRequestType {
+    /**
+     * Key request type is for an initial license request
+     */
+    INITIAL,
+    /**
+     * Key request type is for license renewal. Renewal requests are used
+     * to extend the validity period for streaming keys.
+     */
+    RENEWAL,
+    /**
+     * Key request type is a release. A key release causes offline keys
+     * to become available for streaming.
+     */
+    RELEASE,
+    /**
+     * Key request type is unknown due to some error condition.
+     */
+    UNKNOWN,
+    /**
+     * Keys are already loaded. No key request is needed.
+     */
+    NONE,
+    /**
+     * Keys have previously been loaded. An additional (non-renewal) license
+     * request is needed.
+     */
+    UPDATE,
+}

--- a/drm/current/com/rdk/hal/drm/KeySetId.aidl
+++ b/drm/current/com/rdk/hal/drm/KeySetId.aidl
@@ -1,0 +1,34 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+@VintfStability
+parcelable KeySetId {
+    byte[] keySetId;
+}

--- a/drm/current/com/rdk/hal/drm/KeyStatus.aidl
+++ b/drm/current/com/rdk/hal/drm/KeyStatus.aidl
@@ -1,0 +1,42 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.KeyStatusType;
+
+/**
+ * Used by sendKeysChange to report the usability status of each key
+ * to the app.
+ */
+@VintfStability
+parcelable KeyStatus {
+    byte[] keyId;
+    KeyStatusType type;
+}

--- a/drm/current/com/rdk/hal/drm/KeyStatusType.aidl
+++ b/drm/current/com/rdk/hal/drm/KeyStatusType.aidl
@@ -1,0 +1,64 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+@VintfStability
+@Backing(type="int")
+enum KeyStatusType {
+    /**
+     * The key is currently usable to decrypt media data.
+     */
+    USABLE,
+    /**
+     * The key is no longer usable to decrypt media data because its expiration
+     * time has passed.
+     */
+    EXPIRED,
+    /**
+     * The key is not currently usable to decrypt media data because its output
+     * requirements cannot currently be met.
+     */
+    OUTPUT_NOT_ALLOWED,
+    /**
+     * The status of the key is not yet known and is being determined.
+     */
+    STATUS_PENDING,
+    /**
+     * The key is not currently usable to decrypt media data because of an
+     * internal error in processing unrelated to input parameters.
+     */
+    INTERNAL_ERROR,
+    /**
+     * The key is not yet usable to decrypt media because the start
+     * time is in the future. The key must become usable when
+     * its start time is reached.
+     */
+    USABLE_IN_FUTURE,
+}

--- a/drm/current/com/rdk/hal/drm/KeyType.aidl
+++ b/drm/current/com/rdk/hal/drm/KeyType.aidl
@@ -1,0 +1,51 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+@VintfStability
+@Backing(type="int")
+enum KeyType {
+    /**
+     * Drm keys can be for offline content or for online streaming.
+     * Offline keys are persisted on the device and may be used when the device
+     * is disconnected from the network.
+     */
+    OFFLINE,
+    /**
+     * Keys for streaming are not persisted and require the device to be
+     * connected to the network for periodic renewal.
+     */
+    STREAMING,
+    /**
+     * The Release type is used to request that offline keys be no longer
+     * restricted to offline use.
+     */
+    RELEASE,
+}

--- a/drm/current/com/rdk/hal/drm/KeyValue.aidl
+++ b/drm/current/com/rdk/hal/drm/KeyValue.aidl
@@ -1,0 +1,35 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+@VintfStability
+parcelable KeyValue {
+    String key;
+    String value;
+}

--- a/drm/current/com/rdk/hal/drm/Mode.aidl
+++ b/drm/current/com/rdk/hal/drm/Mode.aidl
@@ -1,0 +1,42 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * Enumerate the supported crypto modes
+ */
+@VintfStability
+@Backing(type="int")
+enum Mode {
+    UNENCRYPTED = 0,
+    AES_CTR = 1,
+    AES_CBC_CTS = 2,
+    AES_CBC = 3,
+}

--- a/drm/current/com/rdk/hal/drm/NumberOfSessions.aidl
+++ b/drm/current/com/rdk/hal/drm/NumberOfSessions.aidl
@@ -1,0 +1,40 @@
+
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+@VintfStability
+parcelable NumberOfSessions {
+    /** The number of currently opened sessions. */
+    int currentSessions;
+
+    /** The maximum number of sessions that the device can support. */
+    int maxSessions;
+}

--- a/drm/current/com/rdk/hal/drm/Pattern.aidl
+++ b/drm/current/com/rdk/hal/drm/Pattern.aidl
@@ -1,0 +1,52 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * A crypto Pattern is a repeating sequence of encrypted and clear blocks
+ * occurring within the bytes indicated by mNumBytesOfEncryptedDatad bytes
+ * of a subsample. Patterns are used to reduce the CPU overhead of
+ * decrypting samples. As an example, HLS uses 1:9 patterns where every
+ * 10th block is encrypted.
+ */
+@VintfStability
+parcelable Pattern {
+    /**
+     * The number of blocks to be encrypted in the pattern. If zero,
+     * pattern encryption is inoperative.
+     */
+    int encryptBlocks;
+
+    /**
+     * The number of blocks to be skipped (left clear) in the pattern. If
+     * zero, pattern encryption is inoperative.
+     */
+    int skipBlocks;
+}

--- a/drm/current/com/rdk/hal/drm/ProvideProvisionResponseResult.aidl
+++ b/drm/current/com/rdk/hal/drm/ProvideProvisionResponseResult.aidl
@@ -1,0 +1,46 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+@VintfStability
+parcelable ProvideProvisionResponseResult {
+    /**
+     * The public certificate resulting from the provisioning
+     * operation, if any. An empty vector indicates that no
+     * certificate was returned.
+     */
+    byte[] certificate;
+
+    /**
+     * An opaque object containing encrypted private key material
+     * to be used by signRSA when computing an RSA signature on a
+     * message, see the signRSA method.
+     */
+    byte[] wrappedKey;
+}

--- a/drm/current/com/rdk/hal/drm/ProvisionRequest.aidl
+++ b/drm/current/com/rdk/hal/drm/ProvisionRequest.aidl
@@ -1,0 +1,43 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+@VintfStability
+parcelable ProvisionRequest {
+    /** The opaque certificate request blob. */
+    byte[] request;
+
+    /**
+     * The URL that the provisioning request may be sent to,
+     * if known by the HAL implementation. An app can choose to
+     * override this URL. If the HAL implementation does not provide
+     * a defaultUrl, the returned string must be empty.
+     */
+    String defaultUrl;
+}

--- a/drm/current/com/rdk/hal/drm/SecurityLevel.aidl
+++ b/drm/current/com/rdk/hal/drm/SecurityLevel.aidl
@@ -1,0 +1,67 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+@VintfStability
+@Backing(type="int")
+enum SecurityLevel {
+    /**
+     * Unable to determine the security level
+     */
+    UNKNOWN,
+    /**
+     * Software-based whitebox crypto
+     */
+    SW_SECURE_CRYPTO,
+    /**
+     * Software-based whitebox crypto and an obfuscated decoder
+     */
+    SW_SECURE_DECODE,
+    /**
+     * DRM key management and crypto operations are performed within a
+     * hardware backed trusted execution environment
+     */
+    HW_SECURE_CRYPTO,
+    /**
+     * DRM key management, crypto operations and decoding of content
+     * are performed within a hardware backed trusted execution environment
+     */
+    HW_SECURE_DECODE,
+    /**
+     * DRM key management, crypto operations, decoding of content and all
+     * handling of the media (compressed and uncompressed) is handled within
+     * a hardware backed trusted execution environment.
+     */
+    HW_SECURE_ALL,
+    /**
+     * The default security level is defined as the highest security level
+     * supported on the device.
+     */
+    DEFAULT,
+}

--- a/drm/current/com/rdk/hal/drm/Status.aidl
+++ b/drm/current/com/rdk/hal/drm/Status.aidl
@@ -1,0 +1,233 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+package com.rdk.hal.drm;
+
+@VintfStability
+@Backing(type="int")
+enum Status {
+    /**
+     * The DRM plugin must return OK when an operation completes without any
+     * errors.
+     */
+    OK,
+    /**
+     * The DRM plugin must return ERROR_DRM_NO_LICENSE, when decryption is
+     * attempted and no license keys have been provided.
+     */
+    ERROR_DRM_NO_LICENSE,
+    /**
+     * ERROR_DRM_LICENSE_EXPIRED must be returned when an attempt is made
+     * to use a license and the keys in that license have expired.
+     */
+    ERROR_DRM_LICENSE_EXPIRED,
+    /**
+     * The DRM plugin must return ERROR_DRM_SESSION_NOT_OPENED when an
+     * attempt is made to use a session that has not been opened.
+     */
+    ERROR_DRM_SESSION_NOT_OPENED,
+    /**
+     * The DRM plugin must return ERROR_DRM_CANNOT_HANDLE when an unsupported
+     * data format or operation is attempted.
+     */
+    ERROR_DRM_CANNOT_HANDLE,
+    /**
+     * ERROR_DRM_INVALID_STATE must be returned when the device is in a state
+     * where it is not able to perform decryption.
+     */
+    ERROR_DRM_INVALID_STATE,
+    /**
+     * The DRM plugin must return BAD_VALUE whenever an illegal parameter is
+     * passed to one of the interface functions.
+     */
+    BAD_VALUE,
+    /**
+     * The DRM plugin must return ERROR_DRM_NOT_PROVISIONED from getKeyRequest,
+     * openSession or provideKeyResponse when the device has not yet been
+     * provisioned.
+     */
+    ERROR_DRM_NOT_PROVISIONED,
+    /**
+     * ERROR_DRM_RESOURCE_BUSY must be returned when resources, such as drm
+     * sessions or secure buffers are not available to perform a requested
+     * operation because they are already in use.
+     */
+    ERROR_DRM_RESOURCE_BUSY,
+    /**
+     * The DRM Plugin must return ERROR_DRM_INSUFFICIENT_OUTPUT_PROTECTION
+     * when the output protection level enabled on the device is not
+     * sufficient to meet the requirements in the license policy.  HDCP is an
+     * example of a form of output protection.
+     */
+    ERROR_DRM_INSUFFICIENT_OUTPUT_PROTECTION,
+    /**
+     * The DRM Plugin must return ERROR_DRM_DEVICE_REVOKED from
+     * provideProvisionResponse and provideKeyResponse if the response indicates
+     * that the device has been revoked. Device revocation means that the device
+     * is no longer permitted to play content.
+     */
+    ERROR_DRM_DEVICE_REVOKED,
+    /**
+     * The DRM Plugin must return ERROR_DRM_DECRYPT if the CryptoPlugin
+     * decrypt operation fails.
+     */
+    ERROR_DRM_DECRYPT,
+    /**
+     * ERROR_DRM_UNKNOWN must be returned when a fatal failure occurs and no
+     * other defined error is appropriate.
+     */
+    ERROR_DRM_UNKNOWN,
+    /**
+     * The drm HAL module must return ERROR_DRM_INSUFFICIENT_SECURITY
+     * from the crypto plugin decrypt method when the security level
+     * of the device is not sufficient to meet the requirements in the
+     * license policy.
+     */
+    ERROR_DRM_INSUFFICIENT_SECURITY,
+    /**
+     * The drm HAL module must return ERROR_FRAME_TOO_LARGE from the
+     * decrypt method when the frame being decrypted into the secure
+     * output buffer exceeds the size of the buffer.
+     */
+    ERROR_DRM_FRAME_TOO_LARGE,
+    /**
+     * This error must be returned from any session method when an
+     * attempt is made to use the session after the crypto hardware
+     * state has been invalidated. Some devices are not able to
+     * retain crypto session state across device suspend/resume which
+     * results in invalid session state.
+     */
+    ERROR_DRM_SESSION_LOST_STATE,
+    /**
+     * The drm HAL module must return this error if client
+     * applications using the hal are temporarily exceeding the
+     * capacity of available crypto resources such that a retry of
+     * the operation is likely to succeed.
+     */
+    ERROR_DRM_RESOURCE_CONTENTION,
+    /**
+     * queueSecureInput buffer called with 0 subsamples.
+     */
+    CANNOT_DECRYPT_ZERO_SUBSAMPLES,
+    /**
+     * An error happened within the crypto library used by the drm plugin.
+     */
+    CRYPTO_LIBRARY_ERROR,
+    /**
+     * Non-specific error reported by the device OEM subsystem.
+     */
+    GENERAL_OEM_ERROR,
+    /**
+     * Unexpected internal failure in the drm/crypto plugin.
+     */
+    GENERAL_PLUGIN_ERROR,
+    /**
+     * The init data parameter passed to getKeyRequest is empty or invalid.
+     */
+    INIT_DATA_INVALID,
+    /**
+     * Either the key was not loaded from the license before attempting the
+     * operation, or the key ID parameter provided by the app is incorrect.
+     */
+    KEY_NOT_LOADED,
+    /**
+     * The license response was empty, fields are missing or otherwise unable
+     * to be parsed.
+     */
+    LICENSE_PARSE_ERROR,
+    /**
+     * The operation (e.g. to renew or persist a license) is prohibited by the
+     * license policy.
+     */
+    LICENSE_POLICY_ERROR,
+    /**
+     * Failed to generate a release request because a field in the stored
+     * license is empty or malformed.
+     */
+    LICENSE_RELEASE_ERROR,
+    /**
+     * The license server detected an error in the license request.
+     */
+    LICENSE_REQUEST_REJECTED,
+    /**
+     * Failed to restore an offline license because a field is empty or
+     * malformed.
+     */
+    LICENSE_RESTORE_ERROR,
+    /**
+     * License is in an invalid state for the attempted operation.
+     */
+    LICENSE_STATE_ERROR,
+    /**
+     * Certificate is malformed or is of the wrong type.
+     */
+    MALFORMED_CERTIFICATE,
+    /**
+     * Failure in the media framework.
+     */
+    MEDIA_FRAMEWORK_ERROR,
+    /**
+     * Certificate has not been set.
+     */
+    MISSING_CERTIFICATE,
+    /**
+     * There was an error loading the provisioned certificate.
+     */
+    PROVISIONING_CERTIFICATE_ERROR,
+    /**
+     * Required steps where not performed before provisioning was attempted.
+     */
+    PROVISIONING_CONFIGURATION_ERROR,
+    /**
+     * The provisioning response was empty, fields are missing or otherwise
+     * unable to be parsed.
+     */
+    PROVISIONING_PARSE_ERROR,
+    /**
+     * The provisioning server detected an error in the provisioning request.
+     */
+    PROVISIONING_REQUEST_REJECTED,
+    /**
+     * Provisioning failed in a way that is likely to succeed on a subsequent
+     * attempt.
+     */
+    RETRYABLE_PROVISIONING_ERROR,
+    /**
+     * Failed to generate a secure stop request because a field in the stored
+     * license is empty or malformed.
+     */
+    SECURE_STOP_RELEASE_ERROR,
+    /**
+     * The plugin was unable to read data from the filesystem.
+     */
+    STORAGE_READ_FAILURE,
+    /**
+     * The plugin was unable to write data to the filesystem.
+     */
+    STORAGE_WRITE_FAILURE,
+}

--- a/drm/current/com/rdk/hal/drm/SubSample.aidl
+++ b/drm/current/com/rdk/hal/drm/SubSample.aidl
@@ -1,0 +1,40 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+/**
+ * A subsample consists of some number of bytes of clear (unencrypted)
+ * data followed by a number of bytes of encrypted data.
+ */
+@VintfStability
+parcelable SubSample {
+    int numBytesOfClearData;
+    int numBytesOfEncryptedData;
+}

--- a/drm/current/com/rdk/hal/drm/SupportedContentType.aidl
+++ b/drm/current/com/rdk/hal/drm/SupportedContentType.aidl
@@ -1,0 +1,44 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+import com.rdk.hal.drm.SecurityLevel;
+
+@VintfStability
+parcelable SupportedContentType {
+    /** Supported mime type. E.g. cenc, video/mp4, etc */
+    String mime;
+
+    /** Minimum supported security level (inclusive) */
+    SecurityLevel minLevel;
+
+    /** Maximum supported security level (inclusive) */
+    SecurityLevel maxLevel;
+}

--- a/drm/current/com/rdk/hal/drm/Uuid.aidl
+++ b/drm/current/com/rdk/hal/drm/Uuid.aidl
@@ -1,0 +1,35 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -------------------------------------------------------------------
+ * This file is derived from Android 16 drm interface definitions:
+ *
+ * https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-16.0.0_r4/drm/aidl/android/hardware/drm
+ *
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * -------------------------------------------------------------------
+ */
+
+package com.rdk.hal.drm;
+
+@VintfStability
+parcelable Uuid {
+    byte[16] uuid;
+}

--- a/drm/current/hfp-drm.yaml
+++ b/drm/current/hfp-drm.yaml
@@ -1,0 +1,122 @@
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2025 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+
+# HAL Feature Profile for drm
+# NOTE: Use the directory name (lowercase) as the top-level key for consistency with file location
+drm:                  # Component object begins (matches directory name)
+    interfaceVersion: current
+
+    serviceName: com.rdk.hal.drm.IDrmFactory # The service name prefix that each drm is registered with. e.g. com.rdk.hal.drm.IDrmFactory/<instanceName>. See instanceName below.
+
+    maxSessions: 4 # This is the maximum total number of concurrent DRM sessions of all schemes that the platform must support. Adjust as needed based on expected use cases and platform capabilities.
+
+    # The VTS must include tests that verify the platform can handle the specified maxTotalBitrate under realistic conditions.
+    maxTotalBitrate: 40000000 # This is the total real-time bitrate in bits per second (bps) that the drm system must handle. Adjust as needed based on platform capabilities.
+    # Example1: For a system that must support (worst case) encrypted streams of 1xUHD at 18Mbps and 1xFHD @ 12Mbps simultaneously the total bitrate would be 30Mbps.
+    # Example2: For a system that must support (worst case) encrypted streams of 4xFHD at 12Mbps the total bitrate would be 48Mbps.
+
+    # Maximum security level supported by the platform.
+    # Values from SecurityLevel enum (SecurityLevel.aidl).
+    # Platform tailors this per device; best-case is HW_SECURE_ALL.
+    supportedSecurityLevels:
+      - SW_SECURE_CRYPTO
+      - SW_SECURE_DECODE
+      - HW_SECURE_CRYPTO
+      - HW_SECURE_DECODE
+      - HW_SECURE_ALL
+
+    # Maximum HDCP output protection level supported.
+    # Values from HdcpLevel enum (HdcpLevel.aidl).
+    supportedHdcpLevels:
+      - HDCP_NONE
+      - HDCP_V1
+      - HDCP_V2
+      - HDCP_V2_1
+      - HDCP_V2_2
+      - HDCP_V2_3
+      - HDCP_NO_OUTPUT
+
+
+    scheme: 
+      - WIDEVINE:
+          instanceName: "widevine" ## The instance name that IDrmFactory is registered with `com.rdk.hal.drm.IDrmFactory/widevine`
+
+          maxBitrate: 20000000 # This is the maximum real-time bitrate in bits per second (bps) that the drm must support per session. Adjust as needed based on platform capabilities and expected use cases.
+
+          maxSchemeSessions: 4 # This is the maximum number of concurrent DRM scheme sessions that the platform must support. Adjust as needed based on expected use cases and platform capabilities.
+          
+          # Supported cipher modes for content decryption.
+          # Values from Mode enum (Mode.aidl).
+          supportedCipherModes:
+            - UNENCRYPTED
+            - AES_CTR
+            - AES_CBC_CTS
+            - AES_CBC
+
+          # Supported key types.
+          # Values from KeyType enum (KeyType.aidl).
+          supportedKeyTypes:
+            - STREAMING   
+
+          # Whether the platform supports a secure decoder component.
+          # Corresponds to ICryptoPlugin.requiresSecureDecoderComponent().
+          supportsSecureDecoder: true
+
+          # The mimeType informs the DRM engine about the type of media container being used. 
+          # This can affect how the DRM system interprets the initData (initialization data), 
+          # which is typically extracted from the media file and contains information needed to generate the license request.
+          # Adjust as needed based on expected use cases and platform capabilities.
+          supportedContainerMimeTypes:
+            - video/mp4
+            - audio/mp4
+            - video/webm
+            - audio/webm
+
+      - PLAYREADY:
+          instanceName: "playready" ## The instance name that IDrmFactory is registered with `com.rdk.hal.drm.IDrmFactory/playready`
+         
+          maxBitrate: 20000000 # This is the maximum real-time bitrate in bits per second (bps) that the drm must support per session. Adjust as needed based on platform capabilities and expected use cases.
+
+          maxSchemeSessions: 4 # This is the maximum number of concurrent DRM scheme sessions that the platform must support. Adjust as needed based on expected use cases and platform capabilities.
+
+          supportedCipherModes:
+            - UNENCRYPTED
+            - AES_CTR
+            - AES_CBC_CTS
+            - AES_CBC
+
+          supportedKeyTypes:
+            - STREAMING   
+
+          supportsSecureDecoder: true
+
+          # The mimeType informs the DRM engine about the type of media container being used. 
+          # This can affect how the DRM system interprets the initData (initialization data), 
+          # which is typically extracted from the media file and contains information needed to generate the license request.
+          # Adjust as needed based on expected use cases and platform capabilities.
+          supportedContainerMimeTypes:
+            - video/mp4
+            - audio/mp4
+            - video/webm
+            - audio/webm
+
+

--- a/drm/metadata.yaml
+++ b/drm/metadata.yaml
@@ -1,0 +1,68 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# component   - Machine-readable component identifier                    [manual]
+# version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
+# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
+# status      - RAG status: GREEN / AMBER / RED                          [manual]
+# description - One-line human-readable summary                          [manual]
+# type        - Responsibility: SOC or OEM                                [manual]
+component: drm
+version: 0.1.0.0
+generation: 1
+status: RED
+description: "DRM plugin and crypto plugin interfaces for content protection"
+type: SOC
+
+# lifecycle - 14+5 review cycle dates                                    [pr_cycle.sh]
+#   review_started    - Date the review window opened
+#   review_deadline   - review_started + 14 calendar days
+#   target_green_date - review_deadline + 5 business days
+lifecycle:
+  review_started: ~
+  review_deadline: ~
+  target_green_date: ~
+
+# scope - High-level architectural responsibilities                       [manual]
+scope:
+  - DRM factory and plugin interfaces (IDrmFactory, IDrmPlugin, ICryptoPlugin)
+  - DRM session lifecycle and key management
+  - Content decryption with secure buffer handling
+  - DRM scheme support (Widevine, PlayReady)
+  - HDCP output protection level reporting
+  - DRM metrics and event reporting
+
+# notes - Tracking metadata                                              [manual]
+#   priority      - Numeric priority (lower = higher)
+#   status_detail - Short current state description
+#   action        - Required action to progress
+#   risk          - Risk notes (appears as watch item on dashboard)
+#   owners        - Responsible architecture teams
+notes:
+  priority: 1
+  status_detail: "Initial interface definition — under review"
+  action: "Architecture review and vendor alignment"
+  owners: "Architecture + AV_Architecture"
+
+# reviewers - Sign-off status per stakeholder team                       [manual]
+#   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
+reviewers:
+    RTAB_Group: pending
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    VTS_Team: pending

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: ffv
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Far-field voice capture and mic array processing"
 type: OEM

--- a/ffv/metadata.yaml
+++ b/ffv/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     AV_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: pending
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -65,5 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: pending
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/flash/metadata.yaml
+++ b/flash/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: flash
 version: 0.1.0.0
-generation: 0
 status: AMBER
 description: "Firmware image storage and update management"
 type: OEM

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: hdmicec
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "HDMI CEC protocol messaging and device control"
 type: SOC

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/hdmicec/metadata.yaml
+++ b/hdmicec/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
+    Vendor_Layer_Team: pending
 

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: recheck
     Vendor_Layer_Team: recheck
 

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: hdmiinput
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "HDMI input port management and signal detection"
 type: SOC

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/hdmiinput/metadata.yaml
+++ b/hdmiinput/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: recheck
 

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
+    Vendor_Layer_Team: pending
 

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: recheck
     Vendor_Layer_Team: recheck
 

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: hdmioutput
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "HDMI output port configuration and display control"
 type: SOC

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/hdmioutput/metadata.yaml
+++ b/hdmioutput/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: recheck
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: recheck
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: reviewed

--- a/indicator/metadata.yaml
+++ b/indicator/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: indicator
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "LED and visual indicator state management"
 type: OEM

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - Boot: halif/boot/current/boot.md
     - Broadcast: halif/broadcast/current/broadcast.md
     - CDM: halif/cdm/current/cdm.md
+    - DRM: halif/drm/current/drm.md
     - HDMI:
       - HDMI CEC: halif/hdmi_cec/current/hdmi_cec.md
       - HDMI Input: halif/hdmi_input/current/hdmi_input.md

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: panel
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Front panel display and button control"
 type: OEM

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: reviewed
     Graphics_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Graphics_Architecture: pending

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     AV_Architecture: pending

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -66,4 +66,5 @@ reviewers:
     AV_Architecture: pending
     Graphics_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: planecontrol
 version: 0.1.0.0
-generation: 1
 status: AMBER
 description: "Graphics and video plane composition control"
 type: SOC

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -65,6 +65,5 @@ reviewers:
     Product_Architecture: pending
     AV_Architecture: pending
     Graphics_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -65,4 +65,5 @@ reviewers:
     Product_Architecture: pending
     Control_Manager_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -58,7 +58,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Control_Manager_Architecture: pending

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: r4ce
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "RF4CE remote control protocol and pairing"
 type: OEM

--- a/r4ce/metadata.yaml
+++ b/r4ce/metadata.yaml
@@ -64,6 +64,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Control_Manager_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -106,7 +106,7 @@ review_icon() {
 }
 
 # All teams (column order)
-ALL_TEAMS="RTAB_Group Architecture Product_Architecture VTS_Team AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture"
+ALL_TEAMS="RTAB_Group Architecture Product_Architecture VTS_Team AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
 
 # Derive component path label (e.g. "vsi/kernel" or "boot")
 component_path() {
@@ -337,8 +337,8 @@ RED_SHARED
 echo -e "$RED_SHARED_ROWS" >> "$OUTPUT"
 fi
 
-REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|"
+REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|"
 
 cat >> "$OUTPUT" << 'REVIEW_SECTION'
 
@@ -420,6 +420,7 @@ cat >> "$OUTPUT" << 'FOOTER'
 | Graphics_Architecture | Graphics, display & composition |
 | Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity |
 | Kernel_Architecture | System, kernel, boot & platform |
+| Vendor_Layer_Team | Vendor HAL implementation review |
 
 ---
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -106,7 +106,7 @@ review_icon() {
 }
 
 # All teams (column order)
-ALL_TEAMS="RTAB_Group Architecture Product_Architecture VTS_Team AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
+ALL_TEAMS="RTAB_Group Architecture Product_Architecture AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
 
 # Derive component path label (e.g. "vsi/kernel" or "boot")
 component_path() {
@@ -337,8 +337,8 @@ RED_SHARED
 echo -e "$RED_SHARED_ROWS" >> "$OUTPUT"
 fi
 
-REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | VTS | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----|-----------|----------|----------|--------------|--------|--------|"
+REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|"
 
 cat >> "$OUTPUT" << 'REVIEW_SECTION'
 
@@ -413,7 +413,6 @@ cat >> "$OUTPUT" << 'FOOTER'
 | RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
-| VTS_Team | All components |
 | AV_Architecture | Audio/Video pipeline components |
 | Broadcast_Team | Broadcast/tuner components |
 | Control_Manager_Architecture | Remote control & input management |

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -106,7 +106,7 @@ review_icon() {
 }
 
 # All teams (column order)
-ALL_TEAMS="RTAB_Group Architecture Product_Architecture AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
+ALL_TEAMS="Architecture Product_Architecture AV_Architecture Broadcast_Team Control_Manager_Architecture Graphics_Architecture Connectivity_Architecture Kernel_Architecture Vendor_Layer_Team"
 
 # Derive component path label (e.g. "vsi/kernel" or "boot")
 component_path() {
@@ -337,8 +337,8 @@ RED_SHARED
 echo -e "$RED_SHARED_ROWS" >> "$OUTPUT"
 fi
 
-REVIEW_HEADER="| | Component | Progress | RTAB | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
-|---|-----------|----------|------|------|------|-----|-----------|----------|----------|--------------|--------|--------|"
+REVIEW_HEADER="| | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
+|---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|"
 
 cat >> "$OUTPUT" << 'REVIEW_SECTION'
 
@@ -410,7 +410,6 @@ cat >> "$OUTPUT" << 'FOOTER'
 
 | Team | Role |
 |------|------|
-| RTAB_Group | All components |
 | Architecture | All components |
 | Product_Architecture | All components |
 | AV_Architecture | Audio/Video pipeline components |

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,7 +31,7 @@ Usage:
 
 Options:
   --since <ref>  Base reference to diff from (default: nearest reachable tag).
-  --apply        Apply computed version/generation updates to metadata.yaml.
+  --apply        Apply computed version updates to metadata.yaml.
   --no-gh        Disable GitHub label lookup and use local heuristics only.
   --verbose      Print extra diagnostics.
   --help         Show this help.
@@ -276,11 +276,9 @@ fi
 
 compute_next_versions() {
     local current_version="$1"
-    local current_generation="$2"
-    local bump="$3"
+    local bump="$2"
 
     NEXT_VERSION="${current_version}"
-    NEXT_GENERATION="${current_generation}"
     NEXT_NOTE=""
 
     if [[ "${bump}" == "none" ]]; then
@@ -305,7 +303,6 @@ compute_next_versions() {
         fi
 
         NEXT_VERSION="0.${gen}.${minor}.${patch}"
-        NEXT_GENERATION="${gen}"
         return 0
     fi
 
@@ -328,12 +325,8 @@ compute_next_versions() {
 update_metadata() {
     local file="$1"
     local new_version="$2"
-    local new_generation="$3"
 
     sed -i -E "s/^version:.*/version: ${new_version}/" "${file}"
-    if grep -q '^generation:' "${file}"; then
-        sed -i -E "s/^generation:.*/generation: ${new_generation}/" "${file}"
-    fi
 }
 
 MODE="DRY-RUN"
@@ -367,8 +360,6 @@ for comp in "${TOUCHED_COMPONENTS[@]}"; do
     fi
 
     current_version="$(awk -F': *' '$1=="version"{print $2; exit}' "${meta}")"
-    current_generation="$(awk -F': *' '$1=="generation"{print $2; exit}' "${meta}")"
-    [[ -n "${current_generation}" ]] || current_generation="0"
 
     bump="none"
     if [[ "${COMP_BREAKING[$comp]:-0}" -eq 1 ]]; then
@@ -379,7 +370,7 @@ for comp in "${TOUCHED_COMPONENTS[@]}"; do
         bump="patch"
     fi
 
-    compute_next_versions "${current_version}" "${current_generation}" "${bump}"
+    compute_next_versions "${current_version}" "${bump}"
 
     status="ok"
     if [[ "${NEXT_NOTE}" == "breaking change on frozen interface: create new component instead" ]]; then
@@ -400,14 +391,14 @@ for comp in "${TOUCHED_COMPONENTS[@]}"; do
     fi
 
     if [[ "${APPLY}" -eq 1 ]]; then
-        if [[ "${current_version}" != "${NEXT_VERSION}" || "${current_generation}" != "${NEXT_GENERATION}" ]]; then
+        if [[ "${current_version}" != "${NEXT_VERSION}" ]]; then
             if [[ "${status}" == "ok" ]]; then
-                update_metadata "${meta}" "${NEXT_VERSION}" "${NEXT_GENERATION}"
+                update_metadata "${meta}" "${NEXT_VERSION}"
                 changed_count=$((changed_count + 1))
             fi
         fi
     else
-        if [[ "${current_version}" != "${NEXT_VERSION}" || "${current_generation}" != "${NEXT_GENERATION}" ]]; then
+        if [[ "${current_version}" != "${NEXT_VERSION}" ]]; then
             changed_count=$((changed_count + 1))
         fi
     fi

--- a/scripts/request_reviews.sh
+++ b/scripts/request_reviews.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2025 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+#
+# Reads the metadata.yaml reviewers for components affected by a PR,
+# maps internal team names to GitHub team slugs, and requests reviews
+# from teams that have not yet completed their review.
+#
+# Usage: bash scripts/request_reviews.sh <PR_NUMBER> [--dry-run]
+#
+# Requires: gh CLI authenticated with access to rdkcentral org
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAPPING_FILE="${REPO_ROOT}/scripts/team_mapping.yaml"
+REPO="rdkcentral/rdk-halif-aidl"
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <PR_NUMBER> [--dry-run]"
+    exit 1
+fi
+
+PR_NUMBER="$1"
+DRY_RUN="${2:-}"
+
+# --- Load team mapping ---
+declare -A TEAM_MAP
+while IFS=': ' read -r key value; do
+    # Skip comments and blank lines
+    [[ "$key" =~ ^#.*$ || -z "$key" ]] && continue
+    TEAM_MAP["$key"]="$value"
+done < "$MAPPING_FILE"
+
+echo "Loaded ${#TEAM_MAP[@]} team mappings"
+
+# --- Get changed files from the PR ---
+echo "Fetching changed files for PR #${PR_NUMBER}..."
+CHANGED_FILES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
+
+# --- Derive affected components from file paths ---
+declare -A COMPONENTS
+for file in $CHANGED_FILES; do
+    # Match top-level component dirs (e.g. audiodecoder/..., boot/...)
+    # or nested ones (e.g. vsi/kernel/...)
+    component=""
+    if [[ "$file" =~ ^(vsi/[^/]+)/ ]]; then
+        component="${BASH_REMATCH[1]}"
+    elif [[ "$file" =~ ^([^/]+)/ ]]; then
+        candidate="${BASH_REMATCH[1]}"
+        # Only count as component if it has a metadata.yaml
+        if [ -f "${REPO_ROOT}/${candidate}/metadata.yaml" ]; then
+            component="$candidate"
+        fi
+    fi
+    if [ -n "$component" ]; then
+        COMPONENTS["$component"]=1
+    fi
+done
+
+if [ ${#COMPONENTS[@]} -eq 0 ]; then
+    echo "No component metadata.yaml found for changed files. Nothing to do."
+    exit 0
+fi
+
+echo "Affected components: ${!COMPONENTS[*]}"
+
+# --- Collect teams that need to review ---
+declare -A REVIEW_TEAMS
+
+for component in "${!COMPONENTS[@]}"; do
+    metadata="${REPO_ROOT}/${component}/metadata.yaml"
+    if [ ! -f "$metadata" ]; then
+        echo "  WARN: ${metadata} not found, skipping"
+        continue
+    fi
+
+    echo "  Reading ${component}/metadata.yaml..."
+    in_reviewers=false
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^reviewers: ]]; then
+            in_reviewers=true
+            continue
+        fi
+        # Exit reviewers block on next top-level key
+        if $in_reviewers && [[ "$line" =~ ^[a-zA-Z] ]]; then
+            break
+        fi
+        if $in_reviewers; then
+            # Parse "    Team_Name: status"
+            if [[ "$line" =~ ^[[:space:]]+([A-Za-z_]+):[[:space:]]+(.+) ]]; then
+                team="${BASH_REMATCH[1]}"
+                status="${BASH_REMATCH[2]}"
+                # Request review from teams that haven't completed review
+                if [ "$status" != "reviewed" ] && [ "$status" != "abstained" ]; then
+                    if [ -n "${TEAM_MAP[$team]:-}" ]; then
+                        REVIEW_TEAMS["${TEAM_MAP[$team]}"]="$team ($status) [${component}]"
+                    else
+                        echo "    WARN: No GitHub team mapping for '${team}'"
+                    fi
+                fi
+            fi
+        fi
+    done < "$metadata"
+done
+
+if [ ${#REVIEW_TEAMS[@]} -eq 0 ]; then
+    echo "All reviewer teams have completed their reviews. No requests needed."
+    exit 0
+fi
+
+# --- Request reviews ---
+echo ""
+echo "Teams to request review from:"
+for slug in "${!REVIEW_TEAMS[@]}"; do
+    echo "  ${slug} ← ${REVIEW_TEAMS[$slug]}"
+done
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo ""
+    echo "[DRY RUN] Would run:"
+    for slug in "${!REVIEW_TEAMS[@]}"; do
+        echo "  gh pr edit ${PR_NUMBER} --repo ${REPO} --add-reviewer rdkcentral/${slug}"
+    done
+else
+    echo ""
+    for slug in "${!REVIEW_TEAMS[@]}"; do
+        echo "Requesting review from rdkcentral/${slug}..."
+        gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "rdkcentral/${slug}" 2>&1 || echo "  WARN: Failed to add ${slug}"
+    done
+    echo "Done."
+fi

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -108,7 +108,7 @@ echo ""
 # ---------------------------------------------------------------------------
 
 echo "Workflow labels:"
-create_label "breaking-change"      "b60205" "Breaking interface change — bumps generation"
+create_label "breaking-change"      "b60205" "Breaking interface change — bumps version generation segment"
 create_label "documentation"        "0075ca" "Documentation-only change — no interface change"
 
 echo ""

--- a/scripts/team_mapping.yaml
+++ b/scripts/team_mapping.yaml
@@ -4,7 +4,6 @@
 #
 # To find team slugs: gh api orgs/rdkcentral/teams --paginate --jq '.[].slug'
 
-RTAB_Group: hal-rtab-reviewers
 Architecture: hal-arch-reviewers
 Product_Architecture: hal-product-arch-reviewers
 AV_Architecture: hal-av-arch-reviewers

--- a/scripts/team_mapping.yaml
+++ b/scripts/team_mapping.yaml
@@ -1,0 +1,16 @@
+# Mapping from metadata.yaml reviewer names to GitHub team slugs (rdkcentral org)
+#
+# Format: <metadata_name>: <github_team_slug>
+#
+# To find team slugs: gh api orgs/rdkcentral/teams --paginate --jq '.[].slug'
+
+RTAB_Group: hal-rtab-reviewers
+Architecture: hal-arch-reviewers
+Product_Architecture: hal-product-arch-reviewers
+AV_Architecture: hal-av-arch-reviewers
+Broadcast_Team: hal-broadcast-reviewers
+Control_Manager_Architecture: hal-control-manager-reviewers
+Graphics_Architecture: hal-graphics-arch-reviewers
+Connectivity_Architecture: hal-connectivity-arch-reviewers
+Kernel_Architecture: hal-kernel-arch-reviewers
+Vendor_Layer_Team: rdk-halif-aidl-pr-review-team

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -1,0 +1,71 @@
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+cmake_minimum_required(VERSION 3.8)
+
+project(Sensor
+	LANGUAGES NONE
+	VERSION 1.0)
+
+if (NOT COMMAND compile_aidl)
+	message(FATAL_ERROR "Do not invoke module level CMake directly!\nInvoke CMake at root level instead!")
+endif()
+
+set(MOTION_SRC_DIR com/rdk/hal/sensor/motion)
+set(THERMAL_SRC_DIR com/rdk/hal/sensor/thermal)
+
+set(SRC
+	${MOTION_SRC_DIR}/Capabilities.aidl
+	${MOTION_SRC_DIR}/IMotionSensor.aidl
+	${MOTION_SRC_DIR}/IMotionSensorController.aidl
+	${MOTION_SRC_DIR}/IMotionSensorControllerListener.aidl
+	${MOTION_SRC_DIR}/IMotionSensorEventListener.aidl
+	${MOTION_SRC_DIR}/IMotionSensorManager.aidl
+	${MOTION_SRC_DIR}/LastEventInfo.aidl
+	${MOTION_SRC_DIR}/OperationalMode.aidl
+	${MOTION_SRC_DIR}/StartConfig.aidl
+	${MOTION_SRC_DIR}/State.aidl
+	${MOTION_SRC_DIR}/TimeWindow.aidl
+	${THERMAL_SRC_DIR}/ActionEvent.aidl
+	${THERMAL_SRC_DIR}/IThermalEventListener.aidl
+	${THERMAL_SRC_DIR}/IThermalSensor.aidl
+	${THERMAL_SRC_DIR}/State.aidl
+	${THERMAL_SRC_DIR}/TemperatureReading.aidl
+)
+
+set(INCLUDE_DIRECTORY
+	.
+)
+
+set(COMPILE_AIDL_ARGV "")
+
+if (DEFINED AIDL_GEN_DIR)
+	list(APPEND COMPILE_AIDL_ARGV TARGET_DIRECTORY ${AIDL_GEN_DIR})
+endif()
+
+if (DEFINED AIDL_BIN)
+	list(APPEND COMPILE_AIDL_ARGV AIDL_BIN ${AIDL_BIN})
+endif()
+
+compile_aidl(${SRC}
+	INCLUDE_DIRECTORY ${INCLUDE_DIRECTORY}
+	${COMPILE_AIDL_ARGV}
+)

--- a/sensor/current/com/rdk/hal/sensor/thermal/IThermalEventListener.aidl
+++ b/sensor/current/com/rdk/hal/sensor/thermal/IThermalEventListener.aidl
@@ -25,6 +25,7 @@ package com.rdk.hal.sensor.thermal;
 
 import com.rdk.hal.sensor.thermal.ActionEvent;
 
+@VintfStability
 oneway interface IThermalEventListener {
     /**
      * @brief Called when the vendor thermal policy signals a thermal state change.

--- a/sensor/current/com/rdk/hal/sensor/thermal/IThermalSensor.aidl
+++ b/sensor/current/com/rdk/hal/sensor/thermal/IThermalSensor.aidl
@@ -31,6 +31,7 @@ import com.rdk.hal.sensor.thermal.IThermalEventListener;
 import com.rdk.hal.sensor.thermal.State;
 import com.rdk.hal.sensor.thermal.TemperatureReading;
 
+@VintfStability
 interface IThermalSensor {
     /** @brief Binder service registration name. */
     const @utf8InCpp String serviceName = "sensor.thermal";

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: sensor
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Hardware sensor data acquisition and monitoring"
 type: OEM

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     Kernel_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoder.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoder.aidl
@@ -144,6 +144,8 @@ interface IVideoDecoder
      * If the client that opened the `IVideoDecoderController` crashes,
      * then the `IVideoDecoderController` has `stop()` and `close()` implicitly called to perform clean up.
      *
+     * The decoder will be opened expecting frames with a resolution up to the maximum specified in `CodecCapabilities`.
+     *
      * @param[in] codec                             The codec to configure the Video Decoder for.
      * @param[in] secure                            The Video Decoder secure mode.
      * @param[in] videoDecoderControllerListener    Listener object for controller callbacks.
@@ -160,6 +162,45 @@ interface IVideoDecoder
      * @see IVideoDecoderController, IVideoDecoderController.close(), registerEventListener()
      */
     @nullable IVideoDecoderController open(in Codec codec, in boolean secure, in IVideoDecoderControllerListener videoDecoderControllerListener);
+
+    /**
+	 * Opens the Video Decoder to decode the specified codec with a specified maximum resolution.
+     * 
+     * If successful the Video Decoder transitions to an `OPENING` state and then a `READY` state
+     * which is notified to any registered `IVideoDecoderEventListener` interfaces.
+     * 
+     * Controller related callbacks are made through the `IVideoDecoderControllerListener`
+     * passed into the call.
+     * 
+     * The returned `IVideoDecoderController` interface is used by the client to feed data buffers
+     * for decode and manage the decoding flow.
+     *
+     * If the client that opened the `IVideoDecoderController` crashes,
+     * then the `IVideoDecoderController` has `stop()` and `close()` implicitly called to perform clean up.
+     *
+     * The decoder will be opened expecting frames up to a maximum of `maxWidth` and `maxHeight'. 
+     * If `maxWidth` and `maxHeight' exceed that specified in the `CodecCapabilities` then binder::Status::Exception::EX_ILLEGAL_ARGUMENT
+     * will be returned.
+     *
+     * @param[in] codec                             The codec to configure the Video Decoder for.
+     * @param[in] secure                            The Video Decoder secure mode.
+     * @param[in] videoDecoderControllerListener    Listener object for controller callbacks.
+     * @param[in] maxWidth                          maximum width of the decoded frame.
+     * @param[in] maxHeight                         maximum height of the decoded frame.
+     *
+     * @returns IVideoDecoderController or null if the codec or the requested secure mode is not supported.
+     * 
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE If the resource is not in the CLOSED state.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT for invalid parameters.
+     * @exception binder::Status::Exception::EX_NULL_POINTER for Null object.
+     * 
+     * @pre The resource must be in State::CLOSED.
+     * 
+     * @see IVideoDecoderController, IVideoDecoderController.close(), registerEventListener()
+     */
+    @nullable IVideoDecoderController openWithResolution(in Codec codec, in boolean secure, in IVideoDecoderControllerListener videoDecoderControllerListener, in int maxWidth, in int maxHeight);
+
 
     /**
      * Closes the Video Decoder.

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videodecoder
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Video decoder resource management and codec support"
 type: SOC

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -62,5 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
-    Vendor_Layer_Team: pending
+    Vendor_Layer_Team: reviewed
 

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -61,6 +61,5 @@ reviewers:
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed
-    VTS_Team: reviewed
     Vendor_Layer_Team: reviewed
 

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -55,7 +55,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: reviewed
     Architecture: reviewed
     Product_Architecture: reviewed
     AV_Architecture: reviewed

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -62,4 +62,5 @@ reviewers:
     Product_Architecture: reviewed
     AV_Architecture: reviewed
     VTS_Team: reviewed
+    Vendor_Layer_Team: pending
 

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videosink
 version: 0.1.0.0
-generation: 1
 status: GREEN
 description: "Video output rendering and display sink management"
 type: SOC

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/abstractfilesystem/metadata.yaml
+++ b/vsi/abstractfilesystem/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: abstractfilesystem
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Abstract file system interface and storage abstraction"
 type: OEM

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Connectivity_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending

--- a/vsi/bluetooth/metadata.yaml
+++ b/vsi/bluetooth/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: bluetooth
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Bluetooth stack integration and profile support"
 type: OEM

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: crypto
 version: 0.0.0.1
-generation: 0
 status: RED
 description: "HAL lower-layer cryptography and security API requirements"
 type: SOC

--- a/vsi/crypto/metadata.yaml
+++ b/vsi/crypto/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/filesystem/metadata.yaml
+++ b/vsi/filesystem/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: filesystem
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "File system layout standards and partition management"
 type: OEM

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: graphics
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Graphics subsystem and display pipeline interface"
 type: SOC

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Graphics_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Graphics_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/graphics/metadata.yaml
+++ b/vsi/graphics/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Graphics_Architecture: pending

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: kernel
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Kernel interface strategy and system abstraction"
 type: SOC

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/kernel/metadata.yaml
+++ b/vsi/kernel/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/keyvault/metadata.yaml
+++ b/vsi/keyvault/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: keyvault
 version: 0.0.0.1
-generation: 0
 status: RED
 description: "HAL lower-layer key vault and encrypted storage requirements"
 type: SOC

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Kernel_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: linuxinput
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Linux input subsystem and event handling"
 type: OEM

--- a/vsi/linuxinput/metadata.yaml
+++ b/vsi/linuxinput/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Kernel_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -63,6 +63,5 @@ reviewers:
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending
-    VTS_Team: pending
     Vendor_Layer_Team: pending
 

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -17,13 +17,11 @@
 
 # component   - Machine-readable component identifier                    [manual]
 # version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
-# generation  - Architectural era (0 = initial, 1+ = full design cycle)   [release.sh]
 # status      - RAG status: GREEN / AMBER / RED                          [manual]
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: wifi
 version: 0.0.0.1
-generation: 0
 status: AMBER
 description: "Wi-Fi driver integration and network management"
 type: OEM

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -64,4 +64,5 @@ reviewers:
     Product_Architecture: pending
     Connectivity_Architecture: pending
     VTS_Team: pending
+    Vendor_Layer_Team: pending
 

--- a/vsi/wifi/metadata.yaml
+++ b/vsi/wifi/metadata.yaml
@@ -57,7 +57,6 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    RTAB_Group: pending
     Architecture: pending
     Product_Architecture: pending
     Connectivity_Architecture: pending


### PR DESCRIPTION
sensor: Add missing CMakeLists.txt and @VintfStability annotations
Add sensor/current/CMakeLists.txt, which was missing and caused CMake to abort with "sensor does not have version `current`" when building the vcomponent. The file lists all motion and thermal AIDL sources and invokes compile_aidl().

Add missing @VintfStability annotations to IThermalSensor.aidl and IThermalEventListener.aidl. The AIDL compiler requires this annotation for interfaces compiled with --stability=vintf.