### PR TITLE
PR : gh457 - Fix compilation breaks in aidl develop branch

### DIFF
--- a/hdmioutput/current/com/rdk/hal/hdmioutput/IHDMIOutput.aidl
+++ b/hdmioutput/current/com/rdk/hal/hdmioutput/IHDMIOutput.aidl
@@ -37,7 +37,7 @@ import com.rdk.hal.PropertyValue;
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
  *  @author    Gerald Weatherup
- */
+ *
  *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
@@ -45,6 +45,7 @@ import com.rdk.hal.PropertyValue;
  *  - <b>Failure (Exception)</b>: The method returns a service-specific exception (e.g., `EX_SERVICE_SPECIFIC`, `EX_ILLEGAL_ARGUMENT`).
  *    In this case, output parameters and return values contain undefined (garbage) memory and must not be used.
  *    The caller must ignore any output variables.
+ */
 @VintfStability
 interface IHDMIOutput
 {

--- a/hdmioutput/current/com/rdk/hal/hdmioutput/IHDMIOutputController.aidl
+++ b/hdmioutput/current/com/rdk/hal/hdmioutput/IHDMIOutputController.aidl
@@ -36,7 +36,7 @@ import com.rdk.hal.PropertyValue;
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
  *  @author    Gerald Weatherup
- */
+ *
  *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
@@ -44,6 +44,7 @@ import com.rdk.hal.PropertyValue;
  *  - <b>Failure (Exception)</b>: The method returns a service-specific exception (e.g., `EX_SERVICE_SPECIFIC`, `EX_ILLEGAL_ARGUMENT`).
  *    In this case, output parameters and return values contain undefined (garbage) memory and must not be used.
  *    The caller must ignore any output variables.
+ */
 @VintfStability
 interface IHDMIOutputController
 {

--- a/hdmioutput/current/com/rdk/hal/hdmioutput/IHDMIOutputManager.aidl
+++ b/hdmioutput/current/com/rdk/hal/hdmioutput/IHDMIOutputManager.aidl
@@ -34,7 +34,7 @@ import com.rdk.hal.hdmioutput.IHDMIOutput;
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
  *  @author    Gerald Weatherup
- */
+ *
  *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
@@ -42,6 +42,7 @@ import com.rdk.hal.hdmioutput.IHDMIOutput;
  *  - <b>Failure (Exception)</b>: The method returns a service-specific exception (e.g., `EX_SERVICE_SPECIFIC`, `EX_ILLEGAL_ARGUMENT`).
  *    In this case, output parameters and return values contain undefined (garbage) memory and must not be used.
  *    The caller must ignore any output variables.
+ */
 @VintfStability
 interface IHDMIOutputManager
 {

--- a/indicator/current/com/rdk/hal/indicator/IIndicator.aidl
+++ b/indicator/current/com/rdk/hal/indicator/IIndicator.aidl
@@ -58,8 +58,6 @@ import com.rdk.hal.indicator.Capabilities;
  * @author Peter Stieglitz
  * @author Douglas Adler
  * @author Gerald Weatherup
- */
-
  *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
@@ -67,6 +65,7 @@ import com.rdk.hal.indicator.Capabilities;
  *  - <b>Failure (Exception)</b>: The method returns a service-specific exception (e.g., `EX_SERVICE_SPECIFIC`, `EX_ILLEGAL_ARGUMENT`).
  *    In this case, output parameters and return values contain undefined (garbage) memory and must not be used.
  *    The caller must ignore any output variables.
+ */
 @VintfStability
 interface IIndicator
 {

--- a/panel/current/com/rdk/hal/panel/IPanelOutput.aidl
+++ b/panel/current/com/rdk/hal/panel/IPanelOutput.aidl
@@ -31,8 +31,8 @@ import com.rdk.hal.AVSource;
 /** 
  *  @brief     Display Panel Output Control HAL interface.
  *  @authors   Luc Kennedy-Lamb, Peter Stieglitz, Douglas Adler, Ramkumar Pattabiraman
- */
-
+ *
+ *
  *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
@@ -40,6 +40,7 @@ import com.rdk.hal.AVSource;
  *  - <b>Failure (Exception)</b>: The method returns a service-specific exception (e.g., `EX_SERVICE_SPECIFIC`, `EX_ILLEGAL_ARGUMENT`).
  *    In this case, output parameters and return values contain undefined (garbage) memory and must not be used.
  *    The caller must ignore any output variables.
+ */
 @VintfStability
 interface IPanelOutput
 {


### PR DESCRIPTION
Fixes AIDL compilation breaks by correcting/moving doc-comment terminators so interface annotations (@VintfStability) are not parsed as being outside/inside an unterminated comment block.