### PR TITLE
fix(sensor): land CMakeLists.txt + @VintfStability fix on develop (#452)

### DIFF
--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -1,0 +1,71 @@
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2025 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+cmake_minimum_required(VERSION 3.8)
+
+project(Sensor
+	LANGUAGES NONE
+	VERSION 1.0)
+
+if (NOT COMMAND compile_aidl)
+	message(FATAL_ERROR "Do not invoke module level CMake directly!\nInvoke CMake at root level instead!")
+endif()
+
+set(MOTION_SRC_DIR com/rdk/hal/sensor/motion)
+set(THERMAL_SRC_DIR com/rdk/hal/sensor/thermal)
+
+set(SRC
+	${MOTION_SRC_DIR}/Capabilities.aidl
+	${MOTION_SRC_DIR}/IMotionSensor.aidl
+	${MOTION_SRC_DIR}/IMotionSensorController.aidl
+	${MOTION_SRC_DIR}/IMotionSensorControllerListener.aidl
+	${MOTION_SRC_DIR}/IMotionSensorEventListener.aidl
+	${MOTION_SRC_DIR}/IMotionSensorManager.aidl
+	${MOTION_SRC_DIR}/LastEventInfo.aidl
+	${MOTION_SRC_DIR}/OperationalMode.aidl
+	${MOTION_SRC_DIR}/StartConfig.aidl
+	${MOTION_SRC_DIR}/State.aidl
+	${MOTION_SRC_DIR}/TimeWindow.aidl
+	${THERMAL_SRC_DIR}/ActionEvent.aidl
+	${THERMAL_SRC_DIR}/IThermalEventListener.aidl
+	${THERMAL_SRC_DIR}/IThermalSensor.aidl
+	${THERMAL_SRC_DIR}/State.aidl
+	${THERMAL_SRC_DIR}/TemperatureReading.aidl
+)
+
+set(INCLUDE_DIRECTORY
+	.
+)
+
+set(COMPILE_AIDL_ARGV "")
+
+if (DEFINED AIDL_GEN_DIR)
+	list(APPEND COMPILE_AIDL_ARGV TARGET_DIRECTORY ${AIDL_GEN_DIR})
+endif()
+
+if (DEFINED AIDL_BIN)
+	list(APPEND COMPILE_AIDL_ARGV AIDL_BIN ${AIDL_BIN})
+endif()
+
+compile_aidl(${SRC}
+	INCLUDE_DIRECTORY ${INCLUDE_DIRECTORY}
+	${COMPILE_AIDL_ARGV}
+)

--- a/sensor/current/com/rdk/hal/sensor/thermal/IThermalEventListener.aidl
+++ b/sensor/current/com/rdk/hal/sensor/thermal/IThermalEventListener.aidl
@@ -25,6 +25,7 @@ package com.rdk.hal.sensor.thermal;
 
 import com.rdk.hal.sensor.thermal.ActionEvent;
 
+@VintfStability
 oneway interface IThermalEventListener {
     /**
      * @brief Called when the vendor thermal policy signals a thermal state change.

--- a/sensor/current/com/rdk/hal/sensor/thermal/IThermalSensor.aidl
+++ b/sensor/current/com/rdk/hal/sensor/thermal/IThermalSensor.aidl
@@ -31,6 +31,7 @@ import com.rdk.hal.sensor.thermal.IThermalEventListener;
 import com.rdk.hal.sensor.thermal.State;
 import com.rdk.hal.sensor.thermal.TemperatureReading;
 
+@VintfStability
 interface IThermalSensor {
     /** @brief Binder service registration name. */
     const @utf8InCpp String serviceName = "sensor.thermal";


### PR DESCRIPTION
Cherry-pick of e6d0020e9521859a19885498e5e973bd540bb302 (originally @jfreeda's PR #455). PR #455's base was `feature/427-motion-sensor-controller-pattern` (PR #430's branch), not `develop` — so when it merged, the fix landed on the stacked feature branch and never reached develop. PR #430 is currently BEHIND and quiet, so cherry-picking the fix onto develop directly to actually close #452. When #430 eventually rebases, git will dedupe the duplicate commit.

Closes #452.