### PR TITLE
docs(audiodecoder): clarify trimStartNs/trimEndNs semantics (#444)

### DIFF
--- a/audiodecoder/current/com/rdk/hal/audiodecoder/FrameMetadata.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/FrameMetadata.aidl
@@ -48,7 +48,28 @@ parcelable FrameMetadata {
 	boolean isDolbyAtmos;
 	
 	/**
-	 * Audio trimming to use on presentation.
+	 * Audio trim durations to apply when presenting this decoded frame.
+	 *
+	 * `trimStartNs` is the duration to discard from the start of the decoded
+	 * audio frame; `trimEndNs` from the end. Both are durations in nanoseconds,
+	 * relative to the frame's own boundaries (not absolute timestamps).
+	 *
+	 * Per-frame — applies only to this decoded frame, not to the stream as a
+	 * whole. Set to 0 (the common case) for no trim.
+	 *
+	 * Carried through unchanged from `InputBufferMetadata.trimStartNs` and
+	 * `trimEndNs` on the corresponding `decodeBufferWithMetadata()` call. The
+	 * AudioSink uses these to trim the PCM before presenting to the mixer.
+	 *
+	 * Used for codec priming / encoder delay (AAC LC/HE, Opus pre-skip), AAC
+	 * SBR padding, and gapless playback across track boundaries.
+	 *
+	 * Type rationale: `int` (not `long`) — at nanosecond precision, max value
+	 * is ~2.1 seconds, sufficient for any per-frame priming/padding trim.
+	 *
+	 * @see IAudioDecoderController.decodeBufferWithMetadata()
+	 * @see InputBufferMetadata.trimStartNs
+	 * @see InputBufferMetadata.trimEndNs
 	 */
 	int trimStartNs;
 	int trimEndNs;

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/InputBufferMetadata.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/InputBufferMetadata.aidl
@@ -80,18 +80,49 @@ parcelable InputBufferMetadata {
     boolean discontinuity;
 
     /**
-     * The time to trim from the start of the decoded audio in nanoseconds.
+     * Duration to trim from the start of the decoded audio frame, in nanoseconds.
      *
-     * Applies only to the buffer of the current `decodeBufferWithMetadata()`
-     * call; not carried forward.
+     * Per-frame trim — applied to the single decoded frame produced from this
+     * input buffer, not to the stream as a whole. Relative to the frame's own
+     * boundaries (a duration to discard from the leading edge), not an absolute
+     * timestamp. Applies only to the buffer of the current
+     * `decodeBufferWithMetadata()` call; not carried forward across calls.
+     *
+     * Set to 0 (the common case) to apply no trim to this frame's start.
+     *
+     * Primary use cases:
+     * - Codec priming / encoder delay (e.g. AAC LC/HE prepended silence)
+     * - Opus pre-skip
+     * - AAC SBR padding
+     * - Gapless playback across track boundaries
+     *
+     * Data flow: the middleware sets this here on each
+     * `decodeBufferWithMetadata()` call; the HAL carries it through unchanged to
+     * the matching `FrameMetadata.trimStartNs` on the corresponding
+     * `IAudioDecoderControllerListener.onFrameOutput()` callback; the AudioSink
+     * applies the trim when presenting PCM to the mixer.
+     *
+     * Type rationale: `int` (not `long`) — at nanosecond precision, max value is
+     * ~2.1 seconds, sufficient for any per-frame priming/padding trim.
+     *
+     * @see FrameMetadata.trimStartNs
      */
     int trimStartNs;
 
     /**
-     * The time to trim from the end of the decoded audio in nanoseconds.
+     * Duration to trim from the end of the decoded audio frame, in nanoseconds.
      *
-     * Applies only to the buffer of the current `decodeBufferWithMetadata()`
-     * call; not carried forward.
+     * Per-frame trim — applied to the single decoded frame produced from this
+     * input buffer, not to the stream as a whole. Relative to the frame's own
+     * boundaries (a duration to discard from the trailing edge), not an
+     * absolute timestamp. Applies only to the buffer of the current
+     * `decodeBufferWithMetadata()` call; not carried forward across calls.
+     *
+     * Set to 0 (the common case) to apply no trim to this frame's end.
+     *
+     * Use cases, data flow, and type rationale as for `trimStartNs` above.
+     *
+     * @see FrameMetadata.trimEndNs
      */
     int trimEndNs;
 }


### PR DESCRIPTION
## Summary

Closes #444. Expands the Doxygen on the audio trim fields with the semantics requested in #444 (originally raised in discussion #443):

- **Per-frame** (not per-stream): applied to the single decoded frame produced from one `decodeBufferWithMetadata()` call.
- **Relative** to the frame boundaries (durations to discard from the leading/trailing edge), not absolute timestamps.
- **0 = no trim** (the common case).
- **Primary use cases**: codec priming / encoder delay (AAC LC/HE, Opus pre-skip), AAC SBR padding, gapless playback across track boundaries.
- **Data flow**: middleware sets on `InputBufferMetadata` via `decodeBufferWithMetadata()` → HAL carries through unchanged to `FrameMetadata` on `onFrameOutput()` → AudioSink applies the trim when presenting PCM to the mixer.
- **Type rationale**: `int` (not `long`) — ~2.1s max at nanosecond precision is sufficient for any per-frame priming/padding trim.

## Note on scope

#444 originally referenced the now-removed `IAudioDecoderController.decodeBuffer()` and its `trimStartNs`/`trimEndNs` parameters. After [PR #435](https://github.com/rdkcentral/rdk-halif-aidl/pull/435) (merged 2026-04-29) those parameters live on `InputBufferMetadata.trimStartNs`/`trimEndNs` of the new `decodeBufferWithMetadata()` input path.

The semantic clarification has been applied to:
- **Input side**: `audiodecoder/.../InputBufferMetadata.aidl` — `trimStartNs` and `trimEndNs` field Doxygen
- **Output side**: `audiodecoder/.../FrameMetadata.aidl` — `trimStartNs` and `trimEndNs` field Doxygen

## Test plan

- [ ] Doxygen render check on `audiodecoder` package; confirm cross-references between `InputBufferMetadata.trimStartNs` ↔ `FrameMetadata.trimStartNs` resolve cleanly
- [ ] Self-review: each of the questions in #444 (per-frame? relative? zero? data flow? use cases? int vs long?) is now explicitly answered in the file Doxygen
