### PR TITLE
fix(hdmiinput): correct misplaced doc-comment terminator (#466)

### DIFF
--- a/hdmiinput/current/com/rdk/hal/hdmiinput/IHDMIInput.aidl
+++ b/hdmiinput/current/com/rdk/hal/hdmiinput/IHDMIInput.aidl
@@ -36,8 +36,6 @@ import com.rdk.hal.PropertyValue;
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
  *  @author    Gerald Weatherup
- */
-
  *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
@@ -45,6 +43,7 @@ import com.rdk.hal.PropertyValue;
  *  - <b>Failure (Exception)</b>: The method returns a service-specific exception (e.g., `EX_SERVICE_SPECIFIC`, `EX_ILLEGAL_ARGUMENT`).
  *    In this case, output parameters and return values contain undefined (garbage) memory and must not be used.
  *    The caller must ignore any output variables.
+ */
 @VintfStability
 interface IHDMIInput 
 {


### PR DESCRIPTION
## Summary

Closes #466. Companion to PR #458 — same compilation-break bug, missed file.

PR #458 fixed the misplaced doc-comment terminator pattern in 5 AIDL files (hdmioutput x3, indicator, panel) but missed `hdmiinput/current/com/rdk/hal/hdmiinput/IHDMIInput.aidl` which has the identical issue. This PR applies the same one-line fix.

## The bug

Before:
```
 *  @author    Gerald Weatherup
 */                                  ← comment closes here
                                      ← blank line
 *
 *  <h3>Exception Handling</h3>      ← outside any comment
 *  ...
 *    The caller must ignore any output variables.
@VintfStability                      ← compilation break
```

After:
```
 *  @author    Gerald Weatherup
 *
 *  <h3>Exception Handling</h3>
 *  ...
 *    The caller must ignore any output variables.
 */                                  ← comment closes after the block
@VintfStability                      ← properly attached
```

Same fix style as the `IIndicator.aidl` change in #458 (no extra blank `*` lines).

## Diff

```
 *  @author    Gerald Weatherup
- */
-
  *
  *  <h3>Exception Handling</h3>
  *  ...
  *    The caller must ignore any output variables.
+ */
 @VintfStability
```

## Test plan

- [ ] CI passes (Signature, Fossid, blackduck, copyright)
- [ ] AIDL build succeeds: \`cmake -DAIDL_TARGET=hdmiinput .\`