### PR TITLE
feat(audiosink,videosink,avclock): add attachClock/detachClock to sinks, deprecate AVClock setters (#355)

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,11 +2,11 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-04-23 |
-| **Components** | 32 |
-| 🟢 **GREEN** | 14 |
-| 🟡 **AMBER** | 15 |
-| 🔴 **RED** | 3 |
+| **Generated** | 2026-04-30 |
+| **Components** | 33 |
+| 🟢 **GREEN** | 11 |
+| 🟡 **AMBER** | 18 |
+| 🔴 **RED** | 4 |
 
 ---
 
@@ -14,9 +14,9 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **14** | Reviewed & Approved — Interface stable on develop |
-| 🟡 AMBER | **15** | Under Active Ingestion — Will enter sprint review when ready |
-| 🔴 RED | **3** | Not Started / Blocked — Strategy or definition required |
+| 🟢 GREEN | **11** | Reviewed & Approved — Interface stable on develop |
+| 🟡 AMBER | **18** | Under Active Ingestion — Will enter sprint review when ready |
+| 🔴 RED | **4** | Not Started / Blocked — Strategy or definition required |
 
 ---
 
@@ -28,14 +28,11 @@
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
 | 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + Vendor_Layer_Team + AV_Architecture |
-| 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.1.0.0 | Audio/video clock synchronization and timing control | 4/4 | Architecture + AV_Architecture |
 | 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
 | 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 4/4 | Architecture + AV_Architecture |
-| 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 4/4 | Architecture + AV_Architecture |
 
 
 ### OEM Components
@@ -56,6 +53,9 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
+| 🟡 | audiosink | 0.1.1.0 | — | — | — | — | — | Architecture + AV_Architecture |
+| 🟡 | avclock | 0.1.0.1 | — | — | — | — | — | Architecture + AV_Architecture |
+| 🟡 | videosink | 0.1.1.0 | — | — | — | — | — | Architecture + AV_Architecture |
 | 🟡 | avbuffer *(SVP risk)* | 0.1.0.0 | 1 | Encrypted buffer (DRM/SVP) - Pending on DRM strategy | May change due to SVP changes from DRM which is being worked on | — | — | Architecture + AV_Architecture |
 | 🟡 | vsi/kernel | 0.0.0.1 | 1 | Strategy required | Not blocking progress - Architecture Strategy | — | — | Architecture |
 | 🟡 | planecontrol | 0.1.0.0 | 3 | Re-review required | Discussions with MW team - Simplify design. Architecture requires simplified design and restructured review. | — | — | Architecture + Graphics_Architecture |
@@ -88,6 +88,7 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
+| 🔴 | drm | 0.1.0.0 | 1 | Initial interface definition — under review | Architecture review and vendor alignment | — | — | Architecture + AV_Architecture |
 | 🔴 | vsi/crypto | 0.0.0.1 | 1 | Security API definition required | HAL lower-layer requirement - define Security API contracts and integration boundaries | — | — | Architecture + Kernel_Architecture |
 | 🔴 | vsi/keyvault | 0.0.0.1 | 1 | Encrypted storage architecture required | HAL lower-layer requirement - define Key Vault interface for encrypted storage | — | — | Architecture + Kernel_Architecture |
 
@@ -111,14 +112,11 @@
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟢 | audiodecoder | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | audiomixer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | audiosink | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | avbuffer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | avclock | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | hdmicec | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | hdmiinput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
 | 🟢 | hdmioutput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
 | 🟢 | videodecoder | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
-| 🟢 | videosink | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 
 ### SOC — 🟡 AMBER
 
@@ -127,11 +125,15 @@
 | 🟡 | vsi/kernel | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 | 🟡 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟡 | vsi/graphics | 0/4 | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | audiosink | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | avclock | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟡 | videosink | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🔴 | drm | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | N/A |
 | 🔴 | vsi/crypto | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 | 🔴 | vsi/keyvault | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 

--- a/audiosink/current/CMakeLists.txt
+++ b/audiosink/current/CMakeLists.txt
@@ -37,7 +37,6 @@ set(COMMON_VERSION "current")
 set(SRC_DIR com/rdk/hal/audiosink)
 set(COMMON_SRC_DIR ${COMMON_MODULE_PATH}/${COMMON_VERSION}/com/rdk/hal)
 set(AUDIO_DECODER_SRC_DIR ${AUDIO_DECODER_MODULE_PATH}/${AUDIO_DECODER_VERSION}/com/rdk/hal/audiodecoder)
-set(AVCLOCK_SRC_DIR ${AVCLOCK_MODULE_PATH}/${AVCLOCK_VERSION}/com/rdk/hal/avclock)
 
 set(SRC
 	${SRC_DIR}/Capabilities.aidl

--- a/audiosink/current/CMakeLists.txt
+++ b/audiosink/current/CMakeLists.txt
@@ -31,11 +31,13 @@ endif()
 
 # version of other modules that `audiosink` depends on
 set(AUDIO_DECODER_VERSION "current")
+set(AVCLOCK_VERSION "current")
 set(COMMON_VERSION "current")
 
 set(SRC_DIR com/rdk/hal/audiosink)
 set(COMMON_SRC_DIR ${COMMON_MODULE_PATH}/${COMMON_VERSION}/com/rdk/hal)
 set(AUDIO_DECODER_SRC_DIR ${AUDIO_DECODER_MODULE_PATH}/${AUDIO_DECODER_VERSION}/com/rdk/hal/audiodecoder)
+set(AVCLOCK_SRC_DIR ${AVCLOCK_MODULE_PATH}/${AVCLOCK_VERSION}/com/rdk/hal/avclock)
 
 set(SRC
 	${SRC_DIR}/Capabilities.aidl
@@ -59,6 +61,7 @@ set(INCLUDE_DIRECTORY
 	.
 	${COMMON_MODULE_PATH}/${COMMON_VERSION}
 	${AUDIO_DECODER_MODULE_PATH}/${AUDIO_DECODER_VERSION}
+	${AVCLOCK_MODULE_PATH}/${AVCLOCK_VERSION}
 )
 
 set(COMPILE_AIDL_ARGV "")

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
@@ -29,6 +29,28 @@ import com.rdk.hal.avclock.IAVClock;
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
  *
+ *  <h3>AVClock association and audio output</h3>
+ *  An audio sink presents output only when an AVClock is attached and started.
+ *  The clock association is owned by the sink — clients call `attachClock()` /
+ *  `detachClock()` / `getClock()` on this controller to manage it. The AVClock
+ *  itself does not need to be made aware of which sinks present against it.
+ *  <ul>
+ *  <li><b>No AVClock attached</b> (the default after `open()`, or after
+ *      `detachClock()`): the sink does NOT produce audio output. Frames passed
+ *      to `queueAudioFrame()` accumulate in the internal queue until the queue
+ *      fills, after which `queueAudioFrame()` returns `false` until queue
+ *      space becomes available again. Frames remain in the queue across the
+ *      no-clock period.</li>
+ *  <li><b>AVClock attached and started</b>: the sink consumes queued frames
+ *      at the rate dictated by the clock — AV synchronisation is in effect.
+ *      If the clock is paused, consumption pauses with it and the queue will
+ *      eventually fill in the same way as the no-clock state.</li>
+ *  </ul>
+ *  `attachClock()` / `detachClock()` are callable in `READY` or `STARTED` and
+ *  do not change the sink's state-machine state. Detaching during `STARTED`
+ *  suspends consumption but does not flush the queue or stop the sink; the
+ *  same is true of attaching to a clock that is paused.
+ *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
  *  - <b>Success</b>: The method returns `binder::Status::Exception::EX_NONE` and all output parameters/return values are valid.
@@ -76,10 +98,10 @@ interface IAudioSinkController {
     /**
      * Attaches an AVClock to this audio sink for AV synchronisation.
      *
-     * When an AVClock is attached, the sink consumes queued frames at the rate
-     * dictated by the clock. When no clock is attached the sink operates in
-     * <b>freerun</b> mode — see the IAudioSinkController interface header for
-     * the no-clock behaviour contract.
+     * The sink consumes and presents queued frames only while the attached
+     * clock is started. With no clock attached, frames queued via
+     * `queueAudioFrame()` accumulate but are not consumed. See the interface
+     * @brief for the full AVClock-association contract.
      *
      * The same AVClock may be attached to multiple sinks (typically one audio
      * sink and one video sink for AV-synchronised playback). The sink owns its
@@ -89,41 +111,43 @@ interface IAudioSinkController {
      * attachment. Calling with `IAVClock.Id.UNDEFINED` is equivalent to
      * `detachClock()`.
      *
-     * Can be called in `READY` or `STARTED` state. Attaching a clock during
-     * `STARTED` causes the sink to begin clock-paced consumption from the next
-     * frame; detaching transitions to freerun without stopping playback.
+     * Can be called in `READY` or `STARTED` state. Attaching during `STARTED`
+     * causes the sink to begin clock-paced consumption from the next frame
+     * once the clock is started; the call does not change the sink's
+     * state-machine state.
      *
      * @param[in] clockId   The ID of the AVClock to attach, or
      *                      `IAVClock.Id.UNDEFINED` to detach.
      *
-     * @returns boolean
-     * @retval true     The clock was attached (or detached when UNDEFINED).
-     * @retval false    The clock ID is invalid or the AVClock is not in a
-     *                  state that permits attachment.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if `clockId`
+     *            does not refer to an existing AVClock instance.
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the sink is
+     *            not in `READY` or `STARTED`.
      *
      * @pre The resource must be in State::READY or State::STARTED.
      *
      * @see detachClock(), getClock(), IAVClockManager.getAVClockIds()
      */
-    boolean attachClock(in IAVClock.Id clockId);
+    void attachClock(in IAVClock.Id clockId);
 
     /**
      * Detaches the currently attached AVClock from this audio sink.
      *
-     * After this call, the sink operates in <b>freerun</b> mode — frames are
-     * consumed without AV synchronisation. Equivalent to calling
-     * `attachClock(IAVClock.Id.UNDEFINED)`.
+     * After this call the sink does NOT consume or present further frames
+     * until a clock is attached again. Equivalent to calling
+     * `attachClock(IAVClock.Id.UNDEFINED)`. See the interface @brief for the
+     * full AVClock-association contract.
      *
      * Idempotent: calling when no clock is attached is a no-op.
      *
-     * Does not stop playback — the sink continues to consume queued frames at
-     * its native rate.
+     * Does not change the sink's state-machine state and does not flush the
+     * internal queue — frames already queued remain queued and will be
+     * consumed once a clock is attached and started.
      *
      * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the sink is
+     *            not in `READY` or `STARTED`.
      *
      * @pre The resource must be in State::READY or State::STARTED.
      *
@@ -135,10 +159,12 @@ interface IAudioSinkController {
      * Gets the AVClock ID currently attached to this audio sink.
      *
      * @returns IAVClock.Id, which is `IAVClock.Id.UNDEFINED` when no clock is
-     *          attached (sink is in freerun mode).
+     *          attached. With no clock attached the sink does not consume or
+     *          present output — see the interface @brief.
      *
      * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the sink is
+     *            not in `READY` or `STARTED`.
      *
      * @pre The resource must be in State::READY or State::STARTED.
      *
@@ -181,13 +207,16 @@ interface IAudioSinkController {
      * The audio sink must be in the `STARTED` state.
      * Buffers can be either non-secure or secure to support SAP (Secure Audio Path).
      * Each call shall reference a single audio frame with a presentation timestamp.
-     * The sink will not consume queued frames until an AVClock has been linked to this sink
-     * (via `IAVClockController.setAudioSink()`) and the clock has been started. Until then,
-     * depending on the implementation, the internal queue will fill and the method will return
-     * `false`. If the hardware does not support clockless queuing, the method returns `false`
-     * immediately. Pausing the clock has the same effect: data cannot be consumed out of the
-     * sink, so the queue will eventually fill.
-     * The audio sink may refuse the buffer if its internal resource usage prevents it from accepting it at that time.
+     *
+     * Consumption is gated by the AVClock attachment — see the interface
+     * @brief for the full contract. Summary: the sink consumes queued frames
+     * only while an AVClock attached via `attachClock()` is started. With no
+     * clock attached (default after `open()` or after `detachClock()`), or
+     * with the clock paused, this method accepts frames into the internal
+     * queue but the sink does NOT consume them; once the queue fills, the
+     * method returns `false` until queue space becomes available again.
+     *
+     * The audio sink may also refuse the buffer if its internal resource usage prevents it from accepting it at that time.
      *
      * Buffer Ownership: Ownership of the buffer transfers to the Audio Sink HAL only
      * when `queueAudioFrame()` accepts the buffer (returns true). Once accepted, the HAL is

--- a/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
+++ b/audiosink/current/com/rdk/hal/audiosink/IAudioSinkController.aidl
@@ -21,6 +21,7 @@ import com.rdk.hal.audiosink.Volume;
 import com.rdk.hal.audiosink.VolumeRamp;
 import com.rdk.hal.audiodecoder.IAudioDecoder;
 import com.rdk.hal.audiodecoder.FrameMetadata;
+import com.rdk.hal.avclock.IAVClock;
 
 /**
  *  @brief     Audio Sink Controller HAL interface.
@@ -71,6 +72,79 @@ interface IAudioSinkController {
      * @see setAudioDecoder()
 	 */
     IAudioDecoder.Id getAudioDecoder();
+
+    /**
+     * Attaches an AVClock to this audio sink for AV synchronisation.
+     *
+     * When an AVClock is attached, the sink consumes queued frames at the rate
+     * dictated by the clock. When no clock is attached the sink operates in
+     * <b>freerun</b> mode — see the IAudioSinkController interface header for
+     * the no-clock behaviour contract.
+     *
+     * The same AVClock may be attached to multiple sinks (typically one audio
+     * sink and one video sink for AV-synchronised playback). The sink owns its
+     * clock relationship; the AVClock does not need to be made aware.
+     *
+     * If a different clock is already attached, this call replaces the
+     * attachment. Calling with `IAVClock.Id.UNDEFINED` is equivalent to
+     * `detachClock()`.
+     *
+     * Can be called in `READY` or `STARTED` state. Attaching a clock during
+     * `STARTED` causes the sink to begin clock-paced consumption from the next
+     * frame; detaching transitions to freerun without stopping playback.
+     *
+     * @param[in] clockId   The ID of the AVClock to attach, or
+     *                      `IAVClock.Id.UNDEFINED` to detach.
+     *
+     * @returns boolean
+     * @retval true     The clock was attached (or detached when UNDEFINED).
+     * @retval false    The clock ID is invalid or the AVClock is not in a
+     *                  state that permits attachment.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     *
+     * @pre The resource must be in State::READY or State::STARTED.
+     *
+     * @see detachClock(), getClock(), IAVClockManager.getAVClockIds()
+     */
+    boolean attachClock(in IAVClock.Id clockId);
+
+    /**
+     * Detaches the currently attached AVClock from this audio sink.
+     *
+     * After this call, the sink operates in <b>freerun</b> mode — frames are
+     * consumed without AV synchronisation. Equivalent to calling
+     * `attachClock(IAVClock.Id.UNDEFINED)`.
+     *
+     * Idempotent: calling when no clock is attached is a no-op.
+     *
+     * Does not stop playback — the sink continues to consume queued frames at
+     * its native rate.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     *
+     * @pre The resource must be in State::READY or State::STARTED.
+     *
+     * @see attachClock(), getClock()
+     */
+    void detachClock();
+
+    /**
+     * Gets the AVClock ID currently attached to this audio sink.
+     *
+     * @returns IAVClock.Id, which is `IAVClock.Id.UNDEFINED` when no clock is
+     *          attached (sink is in freerun mode).
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     *
+     * @pre The resource must be in State::READY or State::STARTED.
+     *
+     * @see attachClock(), detachClock()
+     */
+    IAVClock.Id getClock();
 
     /**
 	 * Starts the audio sink.

--- a/audiosink/metadata.yaml
+++ b/audiosink/metadata.yaml
@@ -21,8 +21,8 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiosink
-version: 0.1.0.0
-status: GREEN
+version: 0.1.1.0
+status: AMBER
 description: "Audio output rendering and sink device management"
 type: SOC
 
@@ -55,8 +55,8 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    Architecture: reviewed
-    Product_Architecture: reviewed
-    AV_Architecture: reviewed
-    Vendor_Layer_Team: reviewed
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    Vendor_Layer_Team: pending
 

--- a/avclock/current/com/rdk/hal/avclock/IAVClockController.aidl
+++ b/avclock/current/com/rdk/hal/avclock/IAVClockController.aidl
@@ -85,23 +85,34 @@ interface IAVClockController {
      *
      * 
      * @pre AV Clock is in State::READY or State::STARTED state.
-     * 
-     * @see getAudioSink()
+     *
+     * @deprecated Use `IAudioSinkController.attachClock()` on the sink side
+     *             instead. This setter is retained for backward compatibility
+     *             and will be removed in the next major version. If both this
+     *             setter and the sink-side `attachClock()` are used, the
+     *             sink-side attachment takes precedence.
+     *
+     * @see getAudioSink(), IAudioSinkController.attachClock()
 	 */
 	boolean setAudioSink(in IAudioSink.Id audioSinkId);
 
     /**
      * Gets the primary Audio Sink ID for presentation against the AV Clock.
-     * 
+     *
      * @returns IAudioSink.Id which can be `IAudioSink.Id.UNDEFINED`.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE
      *
-     * 
+     *
      * @pre AV Clock is in State::READY or State::STARTED state.
-     * 
-     * @see setAudioSink()
+     *
+     * @deprecated Use `IAudioSinkController.getClock()` on the sink side
+     *             instead. This getter is retained for backward compatibility
+     *             and will be removed in the next major version. It does not
+     *             reflect attachments made via the sink-side `attachClock()`.
+     *
+     * @see setAudioSink(), IAudioSinkController.getClock()
      */
     IAudioSink.Id getAudioSink();
     
@@ -126,23 +137,36 @@ interface IAVClockController {
      *
      * 
      * @pre AV Clock is in State::READY or State::STARTED state.
-     * 
-     * @see getSupplementaryAudioSink()
+     *
+     * @deprecated Use `IAudioSinkController.attachClock()` on the supplementary
+     *             sink itself instead. This setter is retained for backward
+     *             compatibility and will be removed in the next major version.
+     *             For receiver-side mixing scenarios, attach the same AVClock
+     *             to both the primary and supplementary audio sinks via their
+     *             respective sink-side `attachClock()` calls.
+     *
+     * @see getSupplementaryAudioSink(), IAudioSinkController.attachClock()
 	 */
     boolean setSupplementaryAudioSink(in IAudioSink.Id supplementaryAudioSinkId);
 
     /**
      * Gets the supplementary Audio Sink ID for presentation against the AV Clock.
-     * 
+     *
      * @returns IAudioSink.Id which can be `IAudioSink.Id.UNDEFINED`.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE
      *
-     * 
+     *
      * @pre AV Clock is in State::READY or State::STARTED state.
-     * 
-     * @see setSupplementaryAudioSink()
+     *
+     * @deprecated Use `IAudioSinkController.getClock()` on the supplementary
+     *             sink itself instead. This getter is retained for backward
+     *             compatibility and will be removed in the next major version.
+     *             It does not reflect attachments made via the sink-side
+     *             `attachClock()`.
+     *
+     * @see setSupplementaryAudioSink(), IAudioSinkController.getClock()
      */
     IAudioSink.Id getSupplementaryAudioSink();
 
@@ -163,23 +187,34 @@ interface IAVClockController {
      *
      * 
      * @pre AV Clock is in State::READY or State::STARTED state.
-     * 
-     * @see getVideoSink()
+     *
+     * @deprecated Use `IVideoSinkController.attachClock()` on the sink side
+     *             instead. This setter is retained for backward compatibility
+     *             and will be removed in the next major version. If both this
+     *             setter and the sink-side `attachClock()` are used, the
+     *             sink-side attachment takes precedence.
+     *
+     * @see getVideoSink(), IVideoSinkController.attachClock()
 	 */
 	boolean setVideoSink(in IVideoSink.Id videoSinkId);
 
     /**
      * Gets the Video Sink ID for presentation against the AV Clock.
-     * 
+     *
      * @returns IVideoSink.Id which can be `IVideoSink.Id.UNDEFINED`.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE
      *
-     * 
+     *
      * @pre AV Clock is in State::READY or State::STARTED state.
-     * 
-     * @see setVideoSink()
+     *
+     * @deprecated Use `IVideoSinkController.getClock()` on the sink side
+     *             instead. This getter is retained for backward compatibility
+     *             and will be removed in the next major version. It does not
+     *             reflect attachments made via the sink-side `attachClock()`.
+     *
+     * @see setVideoSink(), IVideoSinkController.getClock()
      */
     IVideoSink.Id getVideoSink();
 

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -21,8 +21,8 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avclock
-version: 0.1.0.0
-status: GREEN
+version: 0.1.0.1
+status: AMBER
 description: "Audio/video clock synchronization and timing control"
 type: SOC
 
@@ -55,8 +55,8 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    Architecture: reviewed
-    Product_Architecture: reviewed
-    AV_Architecture: reviewed
-    Vendor_Layer_Team: reviewed
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    Vendor_Layer_Team: pending
 

--- a/videosink/current/CMakeLists.txt
+++ b/videosink/current/CMakeLists.txt
@@ -37,7 +37,6 @@ set(VIDEO_DECODER_VERSION "current")
 set(SRC_DIR com/rdk/hal/videosink)
 set(COMMON_SRC_DIR ${COMMON_MODULE_PATH}/${COMMON_VERSION}/com/rdk/hal)
 set(VIDEO_DECODER_SRC_DIR ${VIDEO_DECODER_MODULE_PATH}/${VIDEO_DECODER_VERSION}/com/rdk/hal/videodecoder)
-set(AVCLOCK_SRC_DIR ${AVCLOCK_MODULE_PATH}/${AVCLOCK_VERSION}/com/rdk/hal/avclock)
 
 set(SRC
 	${SRC_DIR}/Capabilities.aidl

--- a/videosink/current/CMakeLists.txt
+++ b/videosink/current/CMakeLists.txt
@@ -30,12 +30,14 @@ if (NOT COMMAND compile_aidl)
 endif()
 
 # version of other modules that `videosink` depends on
+set(AVCLOCK_VERSION "current")
 set(COMMON_VERSION "current")
 set(VIDEO_DECODER_VERSION "current")
 
 set(SRC_DIR com/rdk/hal/videosink)
 set(COMMON_SRC_DIR ${COMMON_MODULE_PATH}/${COMMON_VERSION}/com/rdk/hal)
 set(VIDEO_DECODER_SRC_DIR ${VIDEO_DECODER_MODULE_PATH}/${VIDEO_DECODER_VERSION}/com/rdk/hal/videodecoder)
+set(AVCLOCK_SRC_DIR ${AVCLOCK_MODULE_PATH}/${AVCLOCK_VERSION}/com/rdk/hal/avclock)
 
 set(SRC
 	${SRC_DIR}/Capabilities.aidl
@@ -54,6 +56,7 @@ set(INCLUDE_DIRECTORY
 	.
 	${COMMON_MODULE_PATH}/${COMMON_VERSION}
 	${VIDEO_DECODER_MODULE_PATH}/${VIDEO_DECODER_VERSION}
+	${AVCLOCK_MODULE_PATH}/${AVCLOCK_VERSION}
 )
 
 set(COMPILE_AIDL_ARGV "")

--- a/videosink/current/com/rdk/hal/videosink/IVideoSinkController.aidl
+++ b/videosink/current/com/rdk/hal/videosink/IVideoSinkController.aidl
@@ -29,6 +29,28 @@ import com.rdk.hal.avclock.IAVClock;
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
  *
+ *  <h3>AVClock association and video output</h3>
+ *  A video sink presents output only when an AVClock is attached and started.
+ *  The clock association is owned by the sink — clients call `attachClock()` /
+ *  `detachClock()` / `getClock()` on this controller to manage it. The AVClock
+ *  itself does not need to be made aware of which sinks present against it.
+ *  <ul>
+ *  <li><b>No AVClock attached</b> (the default after `open()`, or after
+ *      `detachClock()`): the sink does NOT consume frames and does NOT
+ *      present output. Frames passed to `queueVideoFrame()` accumulate in the
+ *      internal queue until the queue fills, after which `queueVideoFrame()`
+ *      returns `false` until queue space becomes available again. Frames
+ *      remain in the queue across the no-clock period.</li>
+ *  <li><b>AVClock attached and started</b>: the sink consumes queued frames
+ *      at the rate dictated by the clock and renders them on the mapped video
+ *      plane — AV synchronisation is in effect (lip-synced with any audio
+ *      sink presenting against the same clock). If the clock is paused,
+ *      consumption pauses with it and the queue will eventually fill.</li>
+ *  </ul>
+ *  `attachClock()` / `detachClock()` are callable in `READY` or `STARTED` and
+ *  do not change the sink's state-machine state. Detaching during `STARTED`
+ *  suspends consumption but does not flush the queue or stop the sink.
+ *
  *  <h3>Exception Handling</h3>
  *  Unless otherwise specified, this interface follows standard Android Binder semantics:
  *  - <b>Success</b>: The method returns `binder::Status::Exception::EX_NONE` and all output parameters/return values are valid.
@@ -97,10 +119,11 @@ interface IVideoSinkController
     /**
      * Attaches an AVClock to this video sink for AV synchronisation.
      *
-     * When an AVClock is attached, the sink presents queued frames at the
-     * presentation times dictated by the clock. When no clock is attached the
-     * sink operates in <b>freerun</b> mode — frames are presented in queue
-     * order at the native vsync cadence without AV synchronisation.
+     * The sink consumes queued frames and renders them on the mapped video
+     * plane only while the attached clock is started. With no clock attached,
+     * frames queued via `queueVideoFrame()` accumulate but are not consumed
+     * or rendered. See the interface @brief for the full AVClock-association
+     * contract.
      *
      * The same AVClock may be attached to multiple sinks (typically one audio
      * sink and one video sink for AV-synchronised playback). The sink owns its
@@ -110,42 +133,43 @@ interface IVideoSinkController
      * attachment. Calling with `IAVClock.Id.UNDEFINED` is equivalent to
      * `detachClock()`.
      *
-     * Can be called in `READY` or `STARTED` state. Attaching a clock during
-     * `STARTED` causes the sink to begin clock-paced presentation from the
-     * next frame; detaching transitions to freerun without stopping playback.
+     * Can be called in `READY` or `STARTED` state. Attaching during `STARTED`
+     * causes the sink to begin clock-paced presentation from the next frame
+     * once the clock is started; the call does not change the sink's
+     * state-machine state.
      *
      * @param[in] clockId   The ID of the AVClock to attach, or
      *                      `IAVClock.Id.UNDEFINED` to detach.
      *
-     * @returns boolean
-     * @retval true     The clock was attached (or detached when UNDEFINED).
-     * @retval false    The clock ID is invalid or the AVClock is not in a
-     *                  state that permits attachment.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if `clockId`
+     *            does not refer to an existing AVClock instance.
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the sink is
+     *            not in `READY` or `STARTED`.
      *
      * @pre The resource must be in State::READY or State::STARTED.
      *
      * @see detachClock(), getClock(), IAVClockManager.getAVClockIds()
      */
-    boolean attachClock(in IAVClock.Id clockId);
+    void attachClock(in IAVClock.Id clockId);
 
     /**
      * Detaches the currently attached AVClock from this video sink.
      *
-     * After this call, the sink operates in <b>freerun</b> mode — frames are
-     * presented in queue order at the native vsync cadence without AV
-     * synchronisation. Equivalent to calling
-     * `attachClock(IAVClock.Id.UNDEFINED)`.
+     * After this call the sink does NOT consume or render further frames
+     * until a clock is attached again. Equivalent to calling
+     * `attachClock(IAVClock.Id.UNDEFINED)`. See the interface @brief for the
+     * full AVClock-association contract.
      *
      * Idempotent: calling when no clock is attached is a no-op.
      *
-     * Does not stop playback — the sink continues to present queued frames at
-     * its native rate.
+     * Does not change the sink's state-machine state and does not flush the
+     * internal queue — frames already queued remain queued and will be
+     * presented once a clock is attached and started.
      *
      * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the sink is
+     *            not in `READY` or `STARTED`.
      *
      * @pre The resource must be in State::READY or State::STARTED.
      *
@@ -157,10 +181,12 @@ interface IVideoSinkController
      * Gets the AVClock ID currently attached to this video sink.
      *
      * @returns IAVClock.Id, which is `IAVClock.Id.UNDEFINED` when no clock is
-     *          attached (sink is in freerun mode).
+     *          attached. With no clock attached the sink does not consume or
+     *          render output — see the interface @brief.
      *
      * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the sink is
+     *            not in `READY` or `STARTED`.
      *
      * @pre The resource must be in State::READY or State::STARTED.
      *
@@ -203,8 +229,18 @@ interface IVideoSinkController
      * When the presentation time occurs for the video frame the current mapped video plane is used
      * to render the video frame.
      *
-     * The presentation time of the video frame is controlled by the AV Clock
-     * and will be lip synced with an Audio Sink delivered stream if linked.
+     * Consumption is gated by the AVClock attachment — see the interface
+     * @brief for the full contract. Summary: the sink consumes queued frames
+     * and renders them on the mapped video plane only while an AVClock
+     * attached via `attachClock()` is started. With no clock attached (default
+     * after `open()` or after `detachClock()`), or with the clock paused, this
+     * method accepts frames into the internal queue but the sink does NOT
+     * consume or render them; once the queue fills, the method returns `false`
+     * until queue space becomes available again.
+     *
+     * When an AVClock is attached and started, the presentation time of the
+     * video frame is controlled by the clock and will be lip-synced with an
+     * audio sink presenting against the same clock.
      *
      *
      * Buffer Ownership: Ownership of the buffer transfers to the Video Sink HAL only

--- a/videosink/current/com/rdk/hal/videosink/IVideoSinkController.aidl
+++ b/videosink/current/com/rdk/hal/videosink/IVideoSinkController.aidl
@@ -21,6 +21,7 @@ import com.rdk.hal.videodecoder.IVideoDecoder;
 import com.rdk.hal.videodecoder.FrameMetadata;
 import com.rdk.hal.videosink.Property;
 import com.rdk.hal.PropertyValue;
+import com.rdk.hal.avclock.IAVClock;
 
 /**
  *  @brief     Video Sink Controller HAL interface.
@@ -92,6 +93,80 @@ interface IVideoSinkController
      * @see setVideoDecoder()
      */
     IVideoDecoder.Id getVideoDecoder();
+
+    /**
+     * Attaches an AVClock to this video sink for AV synchronisation.
+     *
+     * When an AVClock is attached, the sink presents queued frames at the
+     * presentation times dictated by the clock. When no clock is attached the
+     * sink operates in <b>freerun</b> mode — frames are presented in queue
+     * order at the native vsync cadence without AV synchronisation.
+     *
+     * The same AVClock may be attached to multiple sinks (typically one audio
+     * sink and one video sink for AV-synchronised playback). The sink owns its
+     * clock relationship; the AVClock does not need to be made aware.
+     *
+     * If a different clock is already attached, this call replaces the
+     * attachment. Calling with `IAVClock.Id.UNDEFINED` is equivalent to
+     * `detachClock()`.
+     *
+     * Can be called in `READY` or `STARTED` state. Attaching a clock during
+     * `STARTED` causes the sink to begin clock-paced presentation from the
+     * next frame; detaching transitions to freerun without stopping playback.
+     *
+     * @param[in] clockId   The ID of the AVClock to attach, or
+     *                      `IAVClock.Id.UNDEFINED` to detach.
+     *
+     * @returns boolean
+     * @retval true     The clock was attached (or detached when UNDEFINED).
+     * @retval false    The clock ID is invalid or the AVClock is not in a
+     *                  state that permits attachment.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     *
+     * @pre The resource must be in State::READY or State::STARTED.
+     *
+     * @see detachClock(), getClock(), IAVClockManager.getAVClockIds()
+     */
+    boolean attachClock(in IAVClock.Id clockId);
+
+    /**
+     * Detaches the currently attached AVClock from this video sink.
+     *
+     * After this call, the sink operates in <b>freerun</b> mode — frames are
+     * presented in queue order at the native vsync cadence without AV
+     * synchronisation. Equivalent to calling
+     * `attachClock(IAVClock.Id.UNDEFINED)`.
+     *
+     * Idempotent: calling when no clock is attached is a no-op.
+     *
+     * Does not stop playback — the sink continues to present queued frames at
+     * its native rate.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     *
+     * @pre The resource must be in State::READY or State::STARTED.
+     *
+     * @see attachClock(), getClock()
+     */
+    void detachClock();
+
+    /**
+     * Gets the AVClock ID currently attached to this video sink.
+     *
+     * @returns IAVClock.Id, which is `IAVClock.Id.UNDEFINED` when no clock is
+     *          attached (sink is in freerun mode).
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     *
+     * @pre The resource must be in State::READY or State::STARTED.
+     *
+     * @see attachClock(), detachClock()
+     */
+    IAVClock.Id getClock();
 
     /**
 	 * Starts the Video Sink.

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -21,8 +21,8 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videosink
-version: 0.1.0.0
-status: GREEN
+version: 0.1.1.0
+status: AMBER
 description: "Video output rendering and display sink management"
 type: SOC
 
@@ -55,8 +55,8 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    Architecture: reviewed
-    Product_Architecture: reviewed
-    AV_Architecture: reviewed
-    Vendor_Layer_Team: reviewed
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    Vendor_Layer_Team: pending
 


### PR DESCRIPTION
> ### ⚠️ Superseded by #476 (reverted on develop)
>
> This PR was merged into develop as `8056d1cd` and then **reverted** as `f734999f` so the change could go through proper review before re-landing. The fixup (no-clock contract corrections, `attachClock()` → `void` convention alignment, dead `AVCLOCK_SRC_DIR` removal) was applied without an inline review pass first; reverting and reopening on **#476** restores the review trail.
>
> The redo PR also drops the unwarranted `metadata.yaml` bumps (`audiosink`/`videosink`/`avclock` stay at their pre-PR `GREEN` / `reviewed` state — the team had already reviewed these components and the change doesn't justify resetting sign-off).
>
> **Replacement: #476** — same code minus the metadata bumps, with proper inline review comments posted.

---

## Summary

Closes #355.

Inverts the sink/clock association direction. Currently the AVClock has to know about and enumerate every sink it serves (`setAudioSink`, `setSupplementaryAudioSink`, `setVideoSink`). After this PR each sink owns its clock relationship via `attachClock()` / `detachClock()` / `getClock()`, and the AVClock-side setters are deprecated.

## AIDL changes

### Additive on sinks (3 new methods each)

```aidl
// IAudioSinkController.aidl  AND  IVideoSinkController.aidl
void        attachClock(in IAVClock.Id clockId);
void        detachClock();
IAVClock.Id getClock();
```

* **No clock attached = no output.** With no AVClock attached (the default after `open()`, or after `detachClock()`), the sink does NOT consume or present frames. Frames passed to `queueAudioFrame()` / `queueVideoFrame()` accumulate in the queue; once full, the queue method returns `false` until space becomes available. Frames remain in the queue across the no-clock period — `detachClock()` does not flush.
* **Clock attached and started = consumption.** The sink consumes queued frames at the rate dictated by the clock and presents them. Pausing the clock pauses consumption.
* The same AVClock can be attached to multiple sinks — typical AV-synced playback uses one audio sink + one video sink against a shared clock.
* `attachClock()` / `detachClock()` are callable in `READY` or `STARTED` and do not change the sink's state-machine state.
* `attachClock(IAVClock.Id.UNDEFINED)` is equivalent to `detachClock()`.
* If both the deprecated AVClock-side setter and the new sink-side attach are used, sink-side wins.

The full contract is documented in the `@brief` block on each controller interface (`IAudioSinkController` / `IVideoSinkController`). All per-method Doxygen references that block as the single source of truth.

### Doc-only on avclock (`@deprecated` on 6 methods)

* `IAVClockController.setAudioSink()` / `getAudioSink()`
* `IAVClockController.setSupplementaryAudioSink()` / `getSupplementaryAudioSink()`
* `IAVClockController.setVideoSink()` / `getVideoSink()`

All 6 retained for backward compatibility, slated for removal in the next major version. Each `@deprecated` block points at the new sink-side equivalent.

## Build

`audiosink` and `videosink` CMakeLists gain `AVCLOCK_VERSION`, `AVCLOCK_SRC_DIR`, and the avclock module path in `INCLUDE_DIRECTORY` so the new `import com.rdk.hal.avclock.IAVClock` resolves.

## Metadata

| Module | Version | Status | Reason |
|---|---|---|---|
| audiosink | 0.1.0.0 → **0.1.1.0** | GREEN → AMBER | Additive minor (3 new methods) |
| videosink | 0.1.0.0 → **0.1.1.0** | GREEN → AMBER | Additive minor (3 new methods) |
| avclock | 0.1.0.0 → **0.1.0.1** | GREEN → AMBER | Doc-only patch (`@deprecated` annotations) |

All four reviewer teams (Architecture, Product_Architecture, AV_Architecture, Vendor_Layer_Team) move from `reviewed` → `pending` for re-review.

## Test plan

- [ ] CI passes (Signature, Fossid, blackduck, copyright)
- [ ] AIDL build succeeds: `cmake -DAIDL_TARGET=audiosink .` and `cmake -DAIDL_TARGET=videosink .`
- [ ] AVClock-side build still succeeds: `cmake -DAIDL_TARGET=avclock .`
- [ ] Reviewer sign-off from Architecture, Product_Architecture, AV_Architecture, Vendor_Layer_Team

## References

- Issue: #355
- Related: #352 (audiosink: AVClock not a precondition for sink operation)

