### PR TITLE
feat(videodecoder): declare supportedOutputPixelFormats per CodecCapabilities (#469)

### DIFF
--- a/docs/halif/video_decoder/current/video_decoder.md
+++ b/docs/halif/video_decoder/current/video_decoder.md
@@ -85,6 +85,8 @@ The `IVideoDecoderManager.getVideoDecoderIds()` should return an array of `IV
 
 The Capabilities parcelable returned by the IVideoDecoder.getCapabilities() function lists all of the Codec types and DynamicRange types supported by this video decoder instance and indicates if the secure audio path can be used.
 
+Each entry in `supportedCodecs[]` (a `CodecCapabilities` parcelable) declares an explicit `supportedOutputPixelFormats[]` list — the chroma formats the decoder hardware can produce on its output for that codec/profile/level. The middleware uses this at capability-discovery time to reject incompatible streams before binding the decoder, rather than failing inside `decodeBufferWithMetadata()` after start. Hardware support typically varies per codec block (e.g. a SoC's VP9 path may produce 4:4:4 on the same silicon where the H.264 path is 4:2:0 only), so the list is per-codec entry rather than a single global list.
+
 A video decoder instance may support any number of video codecs, but can only operate on one compressed video stream in an open session.  Concurrent video decode requires multiple video decoder instances to be opened.
 
 ## System Context

--- a/videodecoder/current/com/rdk/hal/videodecoder/CodecCapabilities.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/CodecCapabilities.aidl
@@ -20,6 +20,7 @@ package com.rdk.hal.videodecoder;
 import com.rdk.hal.videodecoder.Codec;
 import com.rdk.hal.videodecoder.CodecProfile;
 import com.rdk.hal.videodecoder.CodecLevel;
+import com.rdk.hal.videodecoder.PixelFormat;
 
 /**
  *  @brief     Codec capability definition.
@@ -61,4 +62,28 @@ parcelable CodecCapabilities
 	 * The maximum frame height (pixels) supported for decode for this Codec.
 	 */
     int maxFrameHeight;
+
+    /**
+     * Pixel formats the decoder can produce on its output for this
+     * codec/profile/level entry.
+     *
+     * Captures the chroma format constraint at the level where it physically
+     * lives — the decoder. For example, a SoC whose H.264 hardware is profile-
+     * locked at silicon and only outputs 4:2:0 advertises
+     * `[YCBCR420]` here; a part that decodes the High profile bitstream but
+     * downsamples to 4:2:0 on output also advertises `[YCBCR420]`. A SoC
+     * supporting both 4:2:0 and 4:4:4 advertises `[YCBCR420, YCBCR444]`.
+     *
+     * Hardware support typically varies per codec block — a SoC's VP9 path
+     * might do 4:4:4 on the same silicon where the H.264 path does not — so
+     * the list is per-codec/profile/level entry rather than a single global
+     * list on `Capabilities`.
+     *
+     * Used by the middleware at capability-discovery time to reject
+     * incompatible streams before binding the decoder, rather than failing
+     * inside `decodeBufferWithMetadata()` after start.
+     *
+     * @see PixelFormat
+     */
+    PixelFormat[] supportedOutputPixelFormats;
 }

--- a/videodecoder/current/hfp-videodecoder.yaml
+++ b/videodecoder/current/hfp-videodecoder.yaml
@@ -33,22 +33,32 @@ videodecoder:                   # Component object begins
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
         - H264:
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
         - H265:
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
+            supportedOutputPixelFormats:
+              - YCBCR420
         - VP9:
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
+            supportedOutputPixelFormats:
+              - YCBCR420
         - AV1:
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
+            supportedOutputPixelFormats:
+              - YCBCR420
       supportedDynamicRanges:
         - SDR
         - HLG
@@ -67,22 +77,32 @@ videodecoder:                   # Component object begins
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
         - H264:
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
         - H265:
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
         - VP9:
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
         - AV1:
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
+            supportedOutputPixelFormats:
+              - YCBCR420
       supportedDynamicRanges:
         - SDR
       supportedColorimetries:


### PR DESCRIPTION
## Summary

Closes #469. Adds an explicit `PixelFormat[] supportedOutputPixelFormats` field to `videodecoder/CodecCapabilities` so a SoC can advertise the chroma formats its decoder hardware can produce on output, per codec/profile/level entry.

Captures the constraint at the level where it physically lives — the decoder hardware — rather than the sink (per the discussion at #450). A profile-locked H.264-Main-only part advertises `[YCBCR420]`; a SoC that decodes the High profile bitstream but downsamples to 4:2:0 also advertises `[YCBCR420]`; a part supporting both 4:2:0 and 4:4:4 advertises `[YCBCR420, YCBCR444]`.

Hardware support typically varies per codec block (a SoC's VP9 path may produce 4:4:4 on the same silicon where the H.264 path is 4:2:0 only) so the list is per-codec/profile/level entry rather than a single global list on `Capabilities`.

The middleware uses this at capability-discovery time to reject incompatible streams before binding the decoder, rather than failing inside `decodeBufferWithMetadata()` after start.

## Files changed

- `videodecoder/current/com/rdk/hal/videodecoder/CodecCapabilities.aidl` — new field with full Doxygen; adds `PixelFormat` import
- `videodecoder/current/hfp-videodecoder.yaml` — per-codec entries gain `supportedOutputPixelFormats:` list (defaulting to `[YCBCR420]` as the typical baseline; vendors override for higher chroma support)
- `docs/halif/video_decoder/current/video_decoder.md` — short note in the Product Customization section

## Versioning

Additive change. No removal, no rename. Pre-freeze HAL, no compatibility shim required. Existing clients ignoring the field continue to work; clients that read it gain capability discovery.

## Refs

- Closes #469
- Refs discussion #450 (raised by @shafi12)
