### PR TITLE
feat(avclock)!: define primed sub-state, onPrimed() callback, @nullable getCurrentClockTime() (#471)

### DIFF
--- a/avclock/current/com/rdk/hal/avclock/IAVClockController.aidl
+++ b/avclock/current/com/rdk/hal/avclock/IAVClockController.aidl
@@ -250,20 +250,38 @@ interface IAVClockController {
 
 	/**
 	 * Gets the current AV Clock time.
-     * 
+     *
 	 * For `ClockMode::PCR` driven clocks this returns the equivalent of the MPEG system time clock (STC) in nanoseconds units.
-     * 
+     *
 	 * For other clock modes this returns the clock used for presentation of AV frames in the system.
+     *
+     * Priming: the AV Clock has a primed/unprimed sub-state inside `STARTED`.
+     * Until the clock receives its first priming event for the configured
+     * `ClockMode`, it is `STARTED` but unprimed and `getCurrentClockTime()`
+     * returns `null`. Once primed, it returns a valid `ClockTime`. Clients
+     * that need to react to the priming transition without polling can
+     * register for the `IAVClockControllerListener.onPrimed()` callback.
+     *
+     * Priming source per `ClockMode`:
+     * - `ClockMode::PCR`          → first call to `notifyPCRSample()`
+     * - `ClockMode::AUDIO_MASTER` → first audio frame PTS received by the linked audio sink
+     * - `ClockMode::VIDEO_MASTER` → first video frame PTS received by the linked video sink
+     * - `ClockMode::AUTO`         → whichever of the above arrives first, given the configured sources
+     *
+     * The unprimed → primed transition is one-way per started session;
+     * re-priming requires `stop()` followed by `start()`.
 	 *
-  	 * @returns ClockTime
+  	 * @returns ClockTime, or `null` if the clock is `STARTED` but not yet primed.
 	 *
      * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the clock is not in `STARTED`.
      *
-     * 
+     *
      * @pre AV Clock is in State::STARTED state.
-     */  
- 	ClockTime getCurrentClockTime();
+     *
+     * @see IAVClockControllerListener.onPrimed()
+     */
+ 	@nullable ClockTime getCurrentClockTime();
 
 	/**
 	 * Sets the playback rate for the AV Clock.

--- a/avclock/current/com/rdk/hal/avclock/IAVClockControllerListener.aidl
+++ b/avclock/current/com/rdk/hal/avclock/IAVClockControllerListener.aidl
@@ -18,6 +18,7 @@
  */
 package com.rdk.hal.avclock;
 import com.rdk.hal.State;
+import com.rdk.hal.avclock.ClockTime;
 
 /** 
  *  @brief     Controller callbacks listener interface from AV Clock.
@@ -36,4 +37,30 @@ oneway interface IAVClockControllerListener {
      * @param[in] newState              The new state transitioned to.
      */
     void onStateChanged(in State oldState, in State newState);
+
+    /**
+     * Callback delivered when the AV Clock transitions from `STARTED`-but-unprimed
+     * to primed — the first valid clock value is now available. Fires exactly
+     * once per started session, ordered after the configured `ClockMode`'s
+     * priming event arrives:
+     *
+     * - `ClockMode::PCR`          → after the first `notifyPCRSample()` call
+     * - `ClockMode::AUDIO_MASTER` → after the first audio frame PTS from the linked audio sink
+     * - `ClockMode::VIDEO_MASTER` → after the first video frame PTS from the linked video sink
+     * - `ClockMode::AUTO`         → after whichever of the above arrives first
+     *
+     * Until this callback fires, `IAVClockController.getCurrentClockTime()`
+     * returns `null`. After it fires, `getCurrentClockTime()` returns valid
+     * times for the remainder of the started session. The unprimed → primed
+     * transition is one-way per session; re-priming requires `stop()` + `start()`.
+     *
+     * @param[in] currentClockTime  The first valid clock value, so clients do
+     *                              not need to immediately call `getCurrentClockTime()`
+     *                              after the callback.
+     *
+     * @see IAVClockController.getCurrentClockTime()
+     * @see IAVClockController.notifyPCRSample()
+     * @see ClockMode
+     */
+    void onPrimed(in ClockTime currentClockTime);
  }

--- a/docs/halif/av_clock/current/av_clock.md
+++ b/docs/halif/av_clock/current/av_clock.md
@@ -81,6 +81,21 @@ Each AV pipeline utilises its own instance of an AV clock which operates indepen
 
 Clients can access their AV clock time by calling `getCurrentClockTime()` to synchronise data streams such as closed captions and subtitles.
 
+### Priming
+
+An AV Clock has a primed/unprimed sub-state inside `STARTED`. Until the clock receives its first priming event for the configured `ClockMode`, it is `STARTED` but unprimed and `getCurrentClockTime()` returns `null`. Once primed, it returns valid `ClockTime` values for the remainder of the started session.
+
+| `ClockMode` | Priming event |
+|---|---|
+| `PCR` | First call to `IAVClockController.notifyPCRSample()` |
+| `AUDIO_MASTER` | First audio frame PTS received by the linked audio sink |
+| `VIDEO_MASTER` | First video frame PTS received by the linked video sink |
+| `AUTO` | Whichever of the above arrives first, given the configured sources |
+
+The unprimed → primed transition is one-way per started session — `stop()` followed by `start()` is required to re-prime.
+
+Clients that need to react to the priming transition without polling `getCurrentClockTime()` register for `IAVClockControllerListener.onPrimed(ClockTime currentClockTime)`. The callback fires exactly once per started session, ordered after the priming event arrives, and carries the first valid clock value so callers do not need an immediate follow-up `getCurrentClockTime()` call.
+
 The AV clock is always linked to the timebase source it has been configured to use (PCR, audio master or video master).
 
 A PCR driven AV clock may wrap or jump at PCR discontinuities.
@@ -107,7 +122,7 @@ flowchart TD
     RDKClientComponent -- setAudioSink() <br> getAudioSink() setSupplementaryAudioSink() setSupplementaryAudioSink() <br> setVideoSink() <br> getVideoSink() <br> start() <br> stop() <br> setClockMode() <br> getClockMode() <br> notifyPCRSample() <br> getCurrentClockTime() <br> setPlaybackRate() <br> getPlaybackRate() --> IAVClockController
     IAVClockManager --> IAVClock --> IAVClockController
     IAVClock -- onStateChanged() --> IAVClockEventListener
-    IAVClockController -- onStateChanged() --> IAVClockControllerListener
+    IAVClockController -- onStateChanged() <br> onPrimed() --> IAVClockControllerListener
     IAVClockEventListener --> RDKClientComponent
     IAVClockControllerListener --> RDKClientComponent
     IAVClockController --> platformAVSync


### PR DESCRIPTION
## Summary

Closes #471. Resolves the `STARTED`-but-not-primed ambiguity raised in [discussion #446](https://github.com/rdkcentral/rdk-halif-aidl/discussions/446).

Three changes land together so the contract is atomically defined on both sides of the interface:

1. **`IAVClockController.getCurrentClockTime()` is now `@nullable`.** Returns `null` while the clock is `STARTED` but has not yet received its first priming event for the configured `ClockMode`; returns a valid `ClockTime` once primed. Throws `EX_ILLEGAL_STATE` when not in `STARTED` (unchanged).

2. **`IAVClockControllerListener.onPrimed(ClockTime currentClockTime)` added.** Fires exactly once per started session, ordered after the priming event. Carries the first valid clock value so clients do not need a follow-up `getCurrentClockTime()`.

3. **HAL doc gains an explicit "Priming" subsection.** `ClockMode` → priming-event table, the one-way unprimed→primed transition rule, and the contract that re-priming requires `stop()` + `start()`. Mermaid class diagram updated to show `onPrimed()` on the controller listener edge.

## Priming source per ClockMode

Now authoritative on the priming sub-state:

| `ClockMode` | Priming event |
|---|---|
| `PCR` | First call to `notifyPCRSample()` |
| `AUDIO_MASTER` | First audio frame PTS received by the linked audio sink |
| `VIDEO_MASTER` | First video frame PTS received by the linked video sink |
| `AUTO` | Whichever of the above arrives first, given the configured sources |

## Files changed

- `avclock/current/com/rdk/hal/avclock/IAVClockController.aidl` — `@nullable` on `getCurrentClockTime()`; expanded Doxygen with priming contract
- `avclock/current/com/rdk/hal/avclock/IAVClockControllerListener.aidl` — added `onPrimed(ClockTime)`; imports `ClockTime`
- `docs/halif/av_clock/current/av_clock.md` — new "Priming" subsection; mermaid class-diagram label updated

## Versioning

Marked breaking-ish via `feat!:` prefix. The `@nullable` change is a contract change for clients that assumed non-null — easy for them to find: AIDL codegen surfaces it as a Kotlin/Java compile error or a C++ optional unwrap. The new `onPrimed()` listener callback is purely additive.

Pre-freeze HAL, no compatibility shim required.

## Refs

- Closes #471
- Refs #446 (raised by @shafi12, design confirmed by @outdooruseonly)
