### PR TITLE
docs(motion_sensor): fix stale serviceName reference

### DIFF
--- a/docs/halif/sensor/current/motion/motion_sensor.md
+++ b/docs/halif/sensor/current/motion/motion_sensor.md
@@ -93,7 +93,7 @@ Each sensor type has different characteristics (range, field-of-view, sensitivit
 ## Initialization
 
 Vendors shall provide a `hal-sensor-motion.service` systemd unit to launch the Motion HAL.  
-The service shall register `IMotionSensorManager` with the Service Manager using `serviceName = "MotionSensorManager"`.
+The service shall register `IMotionSensorManager` with the Service Manager using `serviceName = "sensor.motion"` (matches `IMotionSensorManager.serviceName` in the AIDL).
 
 Dependencies on drivers or low-level services must be expressed using systemd `Requires=` or `Wants=`.
 


### PR DESCRIPTION
## Summary

motion_sensor.md Initialization section still said \`serviceName = \"MotionSensorManager\"\` while the requirements table (HAL.MOTION.10) already uses the correct \`\"sensor.motion\"\` matching the AIDL constant. This PR brings the two references into agreement.

Found in Copilot post-merge review on PR #430. Tracked in #474.

The other items in #474 are design-question replies (start/stop boolean rationale, LastEventInfo naming) that can be addressed separately or as comments on the original PR.

## Test plan

- [ ] Doc text matches \`IMotionSensorManager.serviceName = \"sensor.motion\"\`