### PR TITLE
fix(docs): exclude generated python_venv from mkdocs scan (#482)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,11 @@ site_url: https://www.github.com/rdkcentral/rdk-halif-aidl
 site_dir: site # Site directory
 docs_dir: docs
 
+exclude_docs: |
+  python_venv/
+  scripts/
+  external_content/*/.git/
+
 repo_name: rdkcentral/rdk-halif-aidl
 repo_url: https://github.com/rdkcentral/rdk-halif-aidl
 


### PR DESCRIPTION
Closes #482.

## Problem

`docs/build_docs.sh` provisions a Python venv at `docs/python_venv/`. Without an `exclude_docs:` directive, mkdocs scans the venv and copies `site-packages/` files into the built site. The first 0.15.0 docs deploy was rejected by GitHub push protection because `.pem` and `.tar.gz` files (from `certifi`, `dateutil`, `pip/_vendor/certifi`) are restricted file extensions on `gh-pages`:

```
remote: error: GH013: Repository rule violations found for refs/heads/gh-pages.
remote:     - Files cannot include restricted file extensions.
remote:       Found 6 violations:
remote:       0.15.0/python_venv/lib/python3.12/site-packages/certifi/cacert.pem
remote:       0.15.0/python_venv/lib/python3.12/site-packages/dateutil/zoneinfo/dateutil-zoneinfo.tar.gz
remote:       0.15.0/python_venv/lib/python3.12/site-packages/pip/_vendor/certifi/cacert.pem
remote:       (+3 lib64 mirrors)
```

## Fix

Add `exclude_docs:` to `mkdocs.yml`:

```yaml
exclude_docs: |
  python_venv/
  scripts/
  external_content/*/.git/
```

`exclude_docs` is supported in mkdocs 1.5+; the repo venv ships 1.6.1 — confirmed.

## Verified

The same patch unblocked the 0.15.0 docs deploy (currently live on `gh-pages` at `c9ccf14d` / `ba337b34`). Without it, the next release will need the same manual workaround.

## Test plan

- [ ] `cd docs && bash build_docs.sh build` — `site/` contains no `python_venv/` paths.
- [ ] Next release deploy (`bash build_docs.sh deploy <version>`) runs to a clean push without manual intervention.