### PR TITLE
feat(videodecoder): add setPixelAspectRatio() and clarify hint precedence + persistence (#486)

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-05-01 |
+| **Generated** | 2026-05-12 |
 | **Components** | 33 |
 | 🟢 **GREEN** | 14 |
 | 🟡 **AMBER** | 15 |
@@ -34,7 +34,7 @@
 | 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.1.0.0 | Video decoder resource management and codec support | 4/4 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.1.1.0 | Video decoder resource management and codec support | 4/4 | Architecture + AV_Architecture |
 | 🟢 | videosink | 0.1.0.0 | Video output rendering and display sink management | 4/4 | Architecture + AV_Architecture |
 
 

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
@@ -231,6 +231,13 @@ interface IVideoDecoderController
      *
      * Pass null to clear any previously set value and revert to stream-signalled metadata.
      *
+     * <h4>Hint precedence and persistence</h4>
+     * Bitstream-derived metadata (HEVC SEI type 137) takes precedence over this hint
+     * when present; the hint is the fallback used only when the bitstream is silent.
+     * The value the decoder actually used is reported via
+     * `FrameMetadata.masteringDisplayInfo`. The hint persists across `flush()` and
+     * is cleared on `close()`.
+     *
      * @param[in] info  Mastering display metadata, or null to clear.
      *
      * @exception binder::Status::Exception::EX_NONE for success
@@ -251,6 +258,13 @@ interface IVideoDecoderController
      *
      * Pass null to clear any previously set value and revert to stream-signalled metadata.
      *
+     * <h4>Hint precedence and persistence</h4>
+     * Bitstream-derived metadata (HEVC SEI type 144) takes precedence over this hint
+     * when present; the hint is the fallback used only when the bitstream is silent.
+     * The value the decoder actually used is reported via
+     * `FrameMetadata.contentLightLevel`. The hint persists across `flush()` and
+     * is cleared on `close()`.
+     *
      * @param[in] info  Content light level metadata, or null to clear.
      *
      * @exception binder::Status::Exception::EX_NONE for success
@@ -268,6 +282,13 @@ interface IVideoDecoderController
      * Identifies the colour space of the video content. This is typically derived
      * from container or manifest metadata and used to configure the downstream
      * display pipeline before decoding begins.
+     *
+     * <h4>Hint precedence and persistence</h4>
+     * Bitstream-derived colorimetry (H.264/HEVC VUI `colour_description_present_flag`
+     * and friends) takes precedence over this hint when present; the hint is the
+     * fallback used only when the bitstream is silent. The value the decoder actually
+     * used is reported via `FrameMetadata.colorimetry`. The hint persists across
+     * `flush()` and is cleared on `close()`.
      *
      * @param[in] colorimetry  The colorimetry of the stream. Use Colorimetry::UNKNOWN
      *                         if not signalled.
@@ -289,9 +310,11 @@ interface IVideoDecoderController
      * pre-allocate frame buffers at the correct size before the first frame
      * is decoded.
      *
-     * The decoder will use the actual coded dimensions from the bitstream once
-     * decoding starts. If those differ, FrameMetadata.codedWidth/codedHeight
-     * reflects the true decoded dimensions.
+     * <h4>Hint precedence and persistence</h4>
+     * The decoder uses the actual coded dimensions from the bitstream once
+     * decoding starts; this hint is only the pre-allocation seed. If they differ,
+     * `FrameMetadata.codedWidth`/`codedHeight` reflects the true decoded dimensions.
+     * The hint persists across `flush()` and is cleared on `close()`.
      *
      * @param[in] width   Coded frame width in pixels. Must be > 0.
      * @param[in] height  Coded frame height in pixels. Must be > 0.
@@ -315,8 +338,12 @@ interface IVideoDecoderController
      *
      * e.g. 24fps = 24/1, 29.97fps = 30000/1001, 59.94fps = 60000/1001
      *
-     * The decoder reports the frame rate detected from the bitstream in
-     * FrameMetadata.frameRateNumerator / frameRateDenominator.
+     * <h4>Hint precedence and persistence</h4>
+     * Bitstream-derived frame rate (H.264/HEVC VUI `vui_timing_info_present_flag`)
+     * takes precedence over this hint when present; the hint is the fallback used
+     * only when the bitstream is silent. The decoder reports the value it actually
+     * used in `FrameMetadata.frameRateNumerator` / `frameRateDenominator`. The hint
+     * persists across `flush()` and is cleared on `close()`.
      *
      * @param[in] numerator    Frame rate numerator. Must be >= 0. Use 0/0 if unknown.
      * @param[in] denominator  Frame rate denominator. Must be > 0 unless numerator is 0.
@@ -345,6 +372,11 @@ interface IVideoDecoderController
      *
      * Only applicable when the stream DynamicRange is DOLBY_VISION.
      *
+     * <h4>Hint precedence and persistence</h4>
+     * Bitstream-derived layer signalling (DV RPU SEI) takes precedence over this hint
+     * when present; the hint is the fallback used only when the bitstream is silent.
+     * The hint persists across `flush()` and is cleared on `close()`.
+     *
      * @param[in] blPresent  true if a Dolby Vision Base Layer is present.
      * @param[in] elPresent  true if a Dolby Vision Enhancement Layer is present.
      *
@@ -356,4 +388,43 @@ interface IVideoDecoderController
      * @see DynamicRange::DOLBY_VISION
      */
     void setDolbyVisionLayerFlags(in boolean blPresent, in boolean elPresent);
+
+    /**
+     * Sets the pixel aspect ratio (PAR) hint before decoding begins.
+     *
+     * Provides the pixel aspect ratio as a rational number (parX/parY)
+     * sourced from container metadata or GstCaps (`pixel-aspect-ratio` field,
+     * MP4/ISOBMFF `pasp` box). This allows the decoder and downstream
+     * pipeline (HAL / display) to correctly derive the Display Aspect Ratio
+     * (DAR) for streams that don't carry PAR in the bitstream VUI (legacy
+     * SD MPEG-2, some packagers' H.264 output, etc.).
+     *
+     * Examples:
+     *   - Square pixels        : 1/1
+     *   - NTSC 480i (Rec.601)  : 10/11
+     *   - PAL 576i (Rec.601)   : 59/54
+     *
+     * If the pixel aspect ratio is unknown or not present, callers should
+     * pass 0/0.
+     *
+     * <h4>Hint precedence and persistence</h4>
+     * Bitstream-derived PAR (H.264/HEVC VUI `aspect_ratio_info_present_flag`)
+     * takes precedence over this hint when present; the hint is the fallback
+     * used only when the bitstream is silent. The decoder reports the value it
+     * actually used in `FrameMetadata.parX` / `FrameMetadata.parY`. The hint
+     * persists across `flush()` and is cleared on `close()`.
+     *
+     * @param[in] parX  Pixel aspect ratio numerator. Must be >= 0.
+     * @param[in] parY  Pixel aspect ratio denominator. Must be > 0 unless parX is 0.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if parY is 0 and parX is non-zero,
+     *            or if either parameter is negative.
+     *
+     * @pre The resource must be in State::READY.
+     *
+     * @see FrameMetadata.parX, FrameMetadata.parY
+     */
+    void setPixelAspectRatio(in int parX, in int parY);
 }

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
@@ -232,8 +232,9 @@ interface IVideoDecoderController
      * Pass null to clear any previously set value and revert to stream-signalled metadata.
      *
      * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived metadata (HEVC SEI type 137) takes precedence over this hint
-     * when present; the hint is the fallback used only when the bitstream is silent.
+     * Bitstream-derived metadata (H.264/HEVC SEI payload type 137 — "mastering display
+     * colour volume") takes precedence over this hint when present; the hint is the
+     * fallback used only when the bitstream is silent.
      * The value the decoder actually used is reported via
      * `FrameMetadata.masteringDisplayInfo`. The hint persists across `flush()` and
      * is cleared on `close()`.
@@ -250,7 +251,8 @@ interface IVideoDecoderController
     void setMasteringDisplayInfo(in @nullable MasteringDisplayInfo info);
 
     /**
-     * Sets the content light level metadata for the stream (CTA-861.3 / HEVC SEI type 144).
+     * Sets the content light level metadata for the stream (CTA-861.3 / H.264/HEVC SEI
+     * payload type 144 — "content light level information").
      *
      * Provides the MaxCLL and MaxFALL values as CTA-861.3 static metadata. This is typically
      * sourced from container-level metadata (e.g. MP4/ISOBMFF 'clli' box, DASH MPD) before
@@ -259,8 +261,9 @@ interface IVideoDecoderController
      * Pass null to clear any previously set value and revert to stream-signalled metadata.
      *
      * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived metadata (HEVC SEI type 144) takes precedence over this hint
-     * when present; the hint is the fallback used only when the bitstream is silent.
+     * Bitstream-derived metadata (H.264/HEVC SEI payload type 144 — "content light level
+     * information") takes precedence over this hint when present; the hint is the fallback
+     * used only when the bitstream is silent.
      * The value the decoder actually used is reported via
      * `FrameMetadata.contentLightLevel`. The hint persists across `flush()` and
      * is cleared on `close()`.
@@ -404,8 +407,11 @@ interface IVideoDecoderController
      *   - NTSC 480i (Rec.601)  : 10/11
      *   - PAL 576i (Rec.601)   : 59/54
      *
-     * If the pixel aspect ratio is unknown or not present, callers should
-     * pass 0/0.
+     * If the pixel aspect ratio is unknown or not present, callers MUST
+     * pass 0/0. This is the only valid "unknown" encoding — `parX == 0` with
+     * `parY != 0` is rejected as an illegal argument. The decoder treats
+     * 0/0 identically to "hint not set" and falls back to bitstream VUI or
+     * the decoder default (square pixels) per the precedence rules below.
      *
      * <h4>Hint precedence and persistence</h4>
      * Bitstream-derived PAR (H.264/HEVC VUI `aspect_ratio_info_present_flag`)
@@ -414,13 +420,13 @@ interface IVideoDecoderController
      * actually used in `FrameMetadata.parX` / `FrameMetadata.parY`. The hint
      * persists across `flush()` and is cleared on `close()`.
      *
-     * @param[in] parX  Pixel aspect ratio numerator. Must be >= 0.
-     * @param[in] parY  Pixel aspect ratio denominator. Must be > 0 unless parX is 0.
+     * @param[in] parX  Pixel aspect ratio numerator. Must be >= 0. Use 0 (with parY = 0) if unknown.
+     * @param[in] parY  Pixel aspect ratio denominator. Must be > 0 unless parX is also 0.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if parY is 0 and parX is non-zero,
-     *            or if either parameter is negative.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if either parameter is negative,
+     *            or if exactly one of parX / parY is 0 (the only valid "unknown" encoding is 0/0).
      *
      * @pre The resource must be in State::READY.
      *

--- a/videodecoder/current/docs/video_decoder.md
+++ b/videodecoder/current/docs/video_decoder.md
@@ -290,7 +290,7 @@ When the decoder later finds an explicit value in the bitstream (H.264/HEVC VUI 
 
 This matters for legacy or partial streams where the bitstream omits VUI / SEI metadata that the container carries (e.g. SD MPEG-2 with PAR only in `pasp`, some packagers' H.264 output with no VUI colour_description). In those cases the hint is the only source of the value, and downstream display configuration would otherwise be incorrect.
 
-The decoder reports the value it actually used — bitstream-derived or hint-derived — in `FrameMetadata`:
+For hints whose contract is "tell the decoder what to render, and the decoder echoes back what it actually used", the decoder reports the value it actually used — bitstream-derived or hint-derived — in `FrameMetadata`:
 
 | Hint setter | Reported in FrameMetadata as |
 |---|---|
@@ -299,8 +299,9 @@ The decoder reports the value it actually used — bitstream-derived or hint-der
 | `setColorimetry` | `colorimetry` |
 | `setMasteringDisplayInfo` | `masteringDisplayInfo` |
 | `setContentLightLevel` | `contentLightLevel` |
-| `setDolbyVisionLayerFlags` | (decoder-internal; reflected in decode behaviour) |
 | `setPixelAspectRatio` | `parX`, `parY` |
+
+`setDolbyVisionLayerFlags` is the one exception: it is a decoder-configuration hint (selects single-layer vs dual-layer DV decode mode) and is **not** mirrored into a `FrameMetadata` field. The bitstream-precedence rule still applies — DV RPU signalling overrides the hint when present — but the result is observable only as a change in decode behaviour, not as a readback field.
 
 ### Persistence
 
@@ -327,7 +328,7 @@ Secure Video Path (SVP) makes the hint setters more important, not less. Under S
 **Implications:**
 
 * **Hints are the only reliable middleware-visible source** of stream description under SVP. The middleware path (demuxer → parser → caps) extracts everything it can from clear container + codec-config data and must push it via the hint setters because the bitstream slices are opaque to it.
-* **Decoder is the only place** that has clear access to in-band SEI under SVP (mastering display SEI 137, content light level SEI 144, ATC tone mapping SEI 147, DV RPU SEI 4). For these fields:
+* **Decoder is the only place** that has clear access to in-band SEI under SVP (H.264/HEVC SEI payload type 137 "mastering display colour volume", type 144 "content light level information", type 147 "alternative transfer characteristics", DV RPU SEI type 4). For these fields:
   - If middleware can derive them from the container (e.g. `mdcv` / `cclv` MP4 boxes), the hint setter is the path.
   - If the value only exists in encrypted in-band SEI, the decoder parses internally and reports via `FrameMetadata` — middleware cannot pre-set them.
 * **Bitstream-precedence still applies.** Even under SVP, when the decoder finds a value in the (decrypted) bitstream it overrides the hint and is reported via `FrameMetadata`.

--- a/videodecoder/current/docs/video_decoder.md
+++ b/videodecoder/current/docs/video_decoder.md
@@ -270,6 +270,71 @@ The same rules for frame metadata apply to all operational modes.
 
 When operating exclusively in tunnelled mode, if there is no frame metadata to be passed, then no call to `onFrameOutput()` should be made because there is no frame buffer handle or frame metadata to return to the client.
 
+## Stream Hints vs Bitstream Truth
+
+The video decoder accepts a set of **stream-description hints** before decoding begins, via setters on `IVideoDecoderController`:
+
+* `setStreamResolution(width, height)` — coded frame dimensions
+* `setFrameRate(numerator, denominator)` — frame rate as a rational
+* `setColorimetry(colorimetry)` — colour primaries / matrix
+* `setMasteringDisplayInfo(info)` — HDR mastering display volume (SMPTE ST 2086)
+* `setContentLightLevel(info)` — HDR MaxCLL / MaxFALL (CTA-861.3)
+* `setDolbyVisionLayerFlags(blPresent, elPresent)` — DV layer configuration
+* `setPixelAspectRatio(parX, parY)` — pixel aspect ratio (e.g. 10:11 for NTSC SD)
+
+These hints are sourced from **container or codec-config metadata** (MP4 boxes, DASH MPD, HLS playlist, GstCaps from upstream parser elements). They are always available in the clear — even under SVP — because the container and codec-config (`avcC` / `hvcC`) are never encrypted.
+
+### Precedence — bitstream wins
+
+When the decoder later finds an explicit value in the bitstream (H.264/HEVC VUI parameters, in-stream SEI, DV RPU), the bitstream value **takes precedence over the hint**. The hint is only used as a fallback when the bitstream is silent on that field.
+
+This matters for legacy or partial streams where the bitstream omits VUI / SEI metadata that the container carries (e.g. SD MPEG-2 with PAR only in `pasp`, some packagers' H.264 output with no VUI colour_description). In those cases the hint is the only source of the value, and downstream display configuration would otherwise be incorrect.
+
+The decoder reports the value it actually used — bitstream-derived or hint-derived — in `FrameMetadata`:
+
+| Hint setter | Reported in FrameMetadata as |
+|---|---|
+| `setStreamResolution` | `codedWidth`, `codedHeight` |
+| `setFrameRate` | `frameRateNumerator`, `frameRateDenominator` |
+| `setColorimetry` | `colorimetry` |
+| `setMasteringDisplayInfo` | `masteringDisplayInfo` |
+| `setContentLightLevel` | `contentLightLevel` |
+| `setDolbyVisionLayerFlags` | (decoder-internal; reflected in decode behaviour) |
+| `setPixelAspectRatio` | `parX`, `parY` |
+
+### Persistence
+
+Hints describe the stream, not the playback session. They:
+
+* **Persist across `flush()`** — middleware does not need to re-set them after every flush; the same stream description still applies.
+* **Are cleared on `close()`** — when the decoder instance is closed and re-opened against a different stream, the new caller is responsible for re-seeding the hints from the new container metadata.
+
+### State precondition
+
+All hint setters require `State::READY`. They are setup-time configuration, not runtime reconfiguration. Bitstream-derived changes mid-playback (e.g. ABR rep switch carrying new SPS) flow through the bitstream automatically and surface via `FrameMetadata` without middleware action.
+
+### Behaviour under SVP / encrypted pipeline
+
+Secure Video Path (SVP) makes the hint setters more important, not less. Under SVP the input pipeline splits cleanly between what middleware can read and what only the decoder can read after decryption:
+
+| Data | Always clear? | Visible to middleware? | Visible to decoder (after decrypt)? |
+|---|---|---|---|
+| Container metadata (MP4 `colr`/`mdcv`/`pasp`, DASH MPD, HLS playlist) | Yes | Yes — passed via hint setters | Not directly |
+| Codec config (`avcC` / `hvcC` SPS/PPS array) | Yes (CENC requires) | Yes — `h264parse` / `h265parse` extract VUI fields, also surfaced via hints | Yes — same data passed by middleware on init |
+| Non-VCL NAL units (SPS / PPS / SEI / AUD) in stream | Implementation-defined per packager (typically clear, can be encrypted) | Only if packager left them clear | Yes — after decrypt |
+| VCL NAL units (slices) | Encrypted | No | Yes — after decrypt |
+
+**Implications:**
+
+* **Hints are the only reliable middleware-visible source** of stream description under SVP. The middleware path (demuxer → parser → caps) extracts everything it can from clear container + codec-config data and must push it via the hint setters because the bitstream slices are opaque to it.
+* **Decoder is the only place** that has clear access to in-band SEI under SVP (mastering display SEI 137, content light level SEI 144, ATC tone mapping SEI 147, DV RPU SEI 4). For these fields:
+  - If middleware can derive them from the container (e.g. `mdcv` / `cclv` MP4 boxes), the hint setter is the path.
+  - If the value only exists in encrypted in-band SEI, the decoder parses internally and reports via `FrameMetadata` — middleware cannot pre-set them.
+* **Bitstream-precedence still applies.** Even under SVP, when the decoder finds a value in the (decrypted) bitstream it overrides the hint and is reported via `FrameMetadata`.
+* **No information is leaked** by the hint flow — hints carry only data the middleware already has from the always-clear container / codec-config; they don't expose anything from the encrypted slice payload.
+
+This is also why the decoder must own a "secure parser" path for any metadata that can only be recovered from encrypted in-band SEI — middleware cannot substitute for it. See discussion #367 for the broader secure-parser design conversation.
+
 ## Low Latency Mode
 
 A media pipeline is operating in low latency mode when the video decoder and audio decoder (if present) are set with a `LOW_LATENCY_MODE` property to 1 (enabled).

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnVideoDecoderController.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnVideoDecoderController.h
@@ -22,6 +22,7 @@ public:
   static constexpr uint32_t TRANSACTION_setStreamResolution = ::android::IBinder::FIRST_CALL_TRANSACTION + 10;
   static constexpr uint32_t TRANSACTION_setFrameRate = ::android::IBinder::FIRST_CALL_TRANSACTION + 11;
   static constexpr uint32_t TRANSACTION_setDolbyVisionLayerFlags = ::android::IBinder::FIRST_CALL_TRANSACTION + 12;
+  static constexpr uint32_t TRANSACTION_setPixelAspectRatio = ::android::IBinder::FIRST_CALL_TRANSACTION + 13;
   static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
   static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
   explicit BnVideoDecoderController();
@@ -72,6 +73,9 @@ public:
   }
   ::android::binder::Status setDolbyVisionLayerFlags(bool blPresent, bool elPresent) override {
     return _aidl_delegate->setDolbyVisionLayerFlags(blPresent, elPresent);
+  }
+  ::android::binder::Status setPixelAspectRatio(int32_t parX, int32_t parY) override {
+    return _aidl_delegate->setPixelAspectRatio(parX, parY);
   }
   int32_t getInterfaceVersion() override {
     int32_t _delegator_ver = BnVideoDecoderController::getInterfaceVersion();

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpVideoDecoderController.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpVideoDecoderController.h
@@ -27,6 +27,7 @@ public:
   ::android::binder::Status setStreamResolution(int32_t width, int32_t height) override;
   ::android::binder::Status setFrameRate(int32_t numerator, int32_t denominator) override;
   ::android::binder::Status setDolbyVisionLayerFlags(bool blPresent, bool elPresent) override;
+  ::android::binder::Status setPixelAspectRatio(int32_t parX, int32_t parY) override;
   int32_t getInterfaceVersion() override;
   std::string getInterfaceHash() override;
 private:

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/IVideoDecoderController.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/IVideoDecoderController.h
@@ -39,6 +39,7 @@ public:
   virtual ::android::binder::Status setStreamResolution(int32_t width, int32_t height) = 0;
   virtual ::android::binder::Status setFrameRate(int32_t numerator, int32_t denominator) = 0;
   virtual ::android::binder::Status setDolbyVisionLayerFlags(bool blPresent, bool elPresent) = 0;
+  virtual ::android::binder::Status setPixelAspectRatio(int32_t parX, int32_t parY) = 0;
   virtual int32_t getInterfaceVersion() = 0;
   virtual std::string getInterfaceHash() = 0;
 };  // class IVideoDecoderController
@@ -85,6 +86,9 @@ public:
     return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
   }
   ::android::binder::Status setDolbyVisionLayerFlags(bool /*blPresent*/, bool /*elPresent*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status setPixelAspectRatio(int32_t /*parX*/, int32_t /*parY*/) override {
     return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
   }
   int32_t getInterfaceVersion() override {

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/IVideoDecoderController.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/IVideoDecoderController.cpp
@@ -476,6 +476,43 @@ BpVideoDecoderController::BpVideoDecoderController(const ::android::sp<::android
   return _aidl_status;
 }
 
+::android::binder::Status BpVideoDecoderController::setPixelAspectRatio(int32_t parX, int32_t parY) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(parX);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(parY);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setPixelAspectRatio, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
+     return IVideoDecoderController::getDefaultImpl()->setPixelAspectRatio(parX, parY);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
 int32_t BpVideoDecoderController::getInterfaceVersion() {
   if (cached_version_ == -1) {
     ::android::Parcel data;
@@ -867,6 +904,36 @@ BnVideoDecoderController::BnVideoDecoderController()
       break;
     }
     ::android::binder::Status _aidl_status(setDolbyVisionLayerFlags(in_blPresent, in_elPresent));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnVideoDecoderController::TRANSACTION_setPixelAspectRatio:
+  {
+    int32_t in_parX;
+    int32_t in_parY;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_parX);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_parY);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(setPixelAspectRatio(in_parX, in_parY));
     _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
     if (((_aidl_ret_status) != (::android::OK))) {
       break;

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videodecoder
-version: 0.1.0.0
+version: 0.1.1.0
 status: GREEN
 description: "Video decoder resource management and codec support"
 type: SOC
@@ -55,8 +55,8 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    Architecture: reviewed
-    Product_Architecture: reviewed
-    AV_Architecture: reviewed
-    Vendor_Layer_Team: reviewed
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    Vendor_Layer_Team: pending
 


### PR DESCRIPTION
## Summary

Closes #486. Implements discussion #441 (proposal by @shafi12) and tightens the related Doxygen on the existing 6 stream-hint setters which had the same precedence / persistence contracts undocumented.

## Background

GstCaps carries `pixel-aspect-ratio` from container metadata (e.g. MP4 `pasp` box). The HAL had no API to propagate it — for streams that omit PAR in the bitstream VUI (legacy SD MPEG-2, some packagers' H.264 output), `FrameMetadata.parX`/`parY` defaulted to 1:1 and downstream Display Aspect Ratio went wrong.

This is the exact gap `setStreamResolution()` and `setFrameRate()` already close for resolution and frame rate. `setPixelAspectRatio()` follows the same pattern.

## AIDL changes

### New method on `IVideoDecoderController`

```aidl
void setPixelAspectRatio(in int parX, in int parY);
```

Signature, exception set, `@pre State::READY` precondition mirror `setFrameRate()` exactly. Use `0/0` when PAR is unknown.

### Doxygen tightening on 6 existing setters

Each of `setMasteringDisplayInfo`, `setContentLightLevel`, `setColorimetry`, `setStreamResolution`, `setFrameRate`, `setDolbyVisionLayerFlags` now documents:

1. **Bitstream wins.** When the decoder finds an explicit value in the bitstream (VUI / SEI), the bitstream value takes precedence over the hint. The decoder reports what it actually used via `FrameMetadata`. `setStreamResolution()` already documented this — bringing the others into line.
2. **Hints persist across `flush()`, cleared on `close()`.** Hints describe the stream, not the playback session; middleware doesn't need to re-set them after every flush.

## Documentation

New "Stream Hints vs Bitstream Truth" section in `docs/halif/video_decoder/current/video_decoder.md`. Covers:
- Full list of hint setters and the `FrameMetadata` fields they report into
- Precedence and persistence rules
- State precondition (READY only)
- **Behaviour under SVP / encrypted pipeline** — hints are the only middleware-visible source for non-bitstream-derivable fields; in-band SEI under SVP is decoder-only territory (cross-links discussion #367 for the broader secure-parser conversation)

## Metadata

| Field | Before | After | Reason |
|---|---|---|---|
| `version` | `0.1.0.0` | `0.1.1.0` | Additive minor (1 new method, doc-only elsewhere) |
| `status` | `GREEN` | `AMBER` | Re-review needed |
| Reviewers | all `reviewed` | all `pending` | Re-review needed |

## Files

| File | Change |
|---|---|
| `videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl` | New method + 6 setters Doxygen tightening |
| `docs/halif/video_decoder/current/video_decoder.md` | New "Stream Hints vs Bitstream Truth" section |
| `videodecoder/metadata.yaml` | Version, status, reviewers bumps |
| `RAG_STATUS_REPORT.md` | Regenerated |

## Test plan

- [ ] CI passes (Signature, Fossid, blackduck, copyright)
- [ ] AIDL build succeeds: `cmake -DAIDL_TARGET=videodecoder .`
- [ ] mkdocs site renders the new section without errors
- [ ] Reviewer sign-off from Architecture, Product_Architecture, AV_Architecture, Vendor_Layer_Team

## References

- Tracking: #486
- Discussion: #441 (now answerable — both questions baked into the Doxygen)
- Related SVP / secure parser design conversation: #367