### PR TITLE
docs(audiodecoder): document codec priming, padding, and gapless playback via trim metadata (#488)

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-05-01 |
+| **Generated** | 2026-05-12 |
 | **Components** | 33 |
 | 🟢 **GREEN** | 14 |
 | 🟡 **AMBER** | 15 |
@@ -26,7 +26,7 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
-| 🟢 | audiodecoder | 0.1.0.0 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
+| 🟢 | audiodecoder | 0.1.0.1 | Audio decoder resource management and codec format support | 4/4 | Architecture + AV_Architecture |
 | 🟢 | audiomixer | 0.1.0.1 | Audio mixing and routing for multi-stream output | 4/4 | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟢 | audiosink | 0.1.0.0 | Audio output rendering and sink device management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.1.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiodecoder
-version: 0.1.0.0
+version: 0.1.0.1
 status: GREEN
 description: "Audio decoder resource management and codec format support"
 type: SOC

--- a/docs/halif/audio_decoder/current/audio_decoder.md
+++ b/docs/halif/audio_decoder/current/audio_decoder.md
@@ -320,6 +320,101 @@ EOS rides entirely on the framework metadata parcelables on both sides of the in
 
 After the EOS callback the decoder remains in `State::STARTED` but is drained. No further `onFrameOutput()` is delivered until `flush()` or `stop()` + `start()`.
 
+## Codec Priming, Padding, and Gapless Playback
+
+Modern lossy audio codecs (AAC, MP3, Vorbis, Opus) do not encode a stream sample-for-sample. The encoded form contains **more samples than the original media** because of two unavoidable artefacts of how block-transform codecs work:
+
+- **Encoder priming** — leading samples at the start of the stream, used by the encoder's overlap/window analysis. The first decoded frame is not the first sample of the original audio; the leading priming samples are silence (or noise) and must be discarded on playback.
+- **Final padding** — trailing samples at the end, used to round the original media duration up to a whole number of encoded frames. The last decoded frame contains real audio followed by encoder-generated padding that must be discarded on playback.
+
+Typical priming amounts:
+
+| Codec | Encoder priming (typical) |
+|---|---|
+| AAC-LC | 2048 samples (one full frame) |
+| HE-AAC v1/v2 | 2048 + extra SBR latency |
+| MP3 | 529–1105 samples (LAME default 576) |
+| Vorbis | Variable per stream, signalled in headers |
+| Opus | Variable, signalled in `OpusHead.pre_skip` |
+
+**Resampling adds another layer.** When the source media is resampled before encoding (or re-encoded at a different rate from the original), the resampled sample count rarely divides evenly into the codec's frame size. The leftover samples land in a final frame padded out to the full frame size with encoder-generated silence. For example, 1 s at 44.1 kHz resampled to 48 kHz produces 48,000 samples, which doesn't divide evenly into AAC's 1024-samples/frame, so the last AAC frame contains real PCM plus padding to fill the frame.
+
+This is correct behaviour — **the decoder is expected to emit the full encoded sample count, padding included.** What removes the padding is the trim metadata described below.
+
+### `trimStartNs` and `trimEndNs`
+
+`InputBufferMetadata.trimStartNs` and `trimEndNs` (described in [the AIDL Doxygen for `InputBufferMetadata`](https://github.com/rdkcentral/rdk-halif-aidl/blob/develop/audiodecoder/current/com/rdk/hal/audiodecoder/InputBufferMetadata.aidl)) carry per-frame trim durations on each `decodeBufferWithMetadata()` call. The HAL carries these unchanged through to the corresponding `FrameMetadata.trimStartNs` / `trimEndNs` on `onFrameOutput()`. The AudioSink applies the trim when presenting PCM to the mixer.
+
+End-to-end data flow:
+
+```mermaid
+sequenceDiagram
+    participant MW as Middleware
+    participant Demux as Demuxer / Parser
+    participant Dec as IAudioDecoderController
+    participant Listener as IAudioDecoderControllerListener
+    participant Sink as IAudioSinkController
+    Note over MW,Demux: Container parsed — priming and padding values extracted
+    MW->>Dec: decodeBufferWithMetadata(handle₁, {pts, trimStartNs=42_666_667, trimEndNs=0, endOfStream=false, ...})
+    Note right of Dec: First frame — trim leading priming
+    Dec-->>Listener: onFrameOutput(pts, handle₁_pcm, {trimStartNs=42_666_667, trimEndNs=0, ...})
+    Listener->>Sink: queueAudioFrame(handle₁_pcm, {trimStartNs=42_666_667, ...})
+    Note over Sink: Sink discards first 42.67 ms of PCM before mixing
+    MW->>Dec: decodeBufferWithMetadata(handle₂, {pts, trimStartNs=0, trimEndNs=0, ...})
+    Dec-->>Listener: onFrameOutput(pts, handle₂_pcm, {trimStartNs=0, trimEndNs=0, ...})
+    Note over MW,Dec: ... middle of stream, no trim ...
+    MW->>Dec: decodeBufferWithMetadata(handleN, {pts, trimStartNs=0, trimEndNs=18_666_667, endOfStream=true, ...})
+    Note right of Dec: Final frame — trim trailing padding + EOS
+    Dec-->>Listener: onFrameOutput(pts, handleN_pcm, {trimStartNs=0, trimEndNs=18_666_667, endOfStream=true, ...})
+    Listener->>Sink: queueAudioFrame(handleN_pcm, {trimEndNs=18_666_667, ...})
+    Note over Sink: Sink discards last 18.67 ms; emits onEndOfStream once played
+```
+
+After the trim is applied, the audible output matches the original source duration sample-accurately, regardless of priming/padding inflation.
+
+### Where the values come from — container metadata sources
+
+Middleware extracts priming/padding from the container and translates to nanosecond durations:
+
+| Container | Source | Translation to trim |
+|---|---|---|
+| **MP4 / ISOBMFF** | `edts/elst` edit list | `media_time` (samples) → first frame `trimStartNs` ; `(segment_duration × media_rate) - track_duration` shortfall → last frame `trimEndNs` |
+| **MP4 (iTunes-style)** | `iTunSMPB` text in `udta` | First whitespace-separated value = priming samples; second = padding samples |
+| **WebM / Matroska** | `CodecDelay` element on the audio track | Decoder delay in nanoseconds → first frame `trimStartNs` directly |
+| **Ogg Opus / Opus-in-MP4** | `OpusHead.pre_skip` | `pre_skip / 48000 × 1_000_000_000` → first frame `trimStartNs` (Opus pre-skip is always in 48 kHz units regardless of stream rate) |
+| **ADTS AAC** (no container) | None | No priming/padding metadata available; first/last frame trims unknown; output will contain priming/padding |
+
+**Worked example** — AAC-LC at 48 kHz with 2048-sample priming:
+
+```text
+priming = 2048 samples
+trimStartNs (first frame) = 2048 / 48000 × 1_000_000_000
+                          = 42_666_666 ns
+                          ≈ 42.67 ms
+```
+
+If the same stream was originally 44.1 kHz with a 1-second source duration and was resampled to 48 kHz before encoding, the encoder produces 48,000 + 2048 = 50,048 samples → 49 AAC frames (50,176 samples) with `50,176 − 50,048 = 128 samples` of padding in the final frame:
+
+```text
+trimEndNs (final frame) = 128 / 48000 × 1_000_000_000
+                        = 2_666_666 ns
+                        ≈ 2.67 ms
+```
+
+### What to validate in tests
+
+The right metric for "did the decoder behave correctly" is **total post-trim audio data**, not frame count:
+
+| Validation | Valid? | Why |
+|---|---|---|
+| Input AAC frame count == output PCM frame count | ❌ | Resampling and encoder framing change the count; not a HAL conformance signal |
+| `Σ(output_frame_pts_deltas)` matches input media duration | ✅ | PTS-based; immune to frame repacking |
+| Total post-trim PCM sample count == `(source_duration × output_sample_rate)` | ✅ | Sample-accurate; the right check for whether priming/padding was handled correctly |
+
+If a test reports "extra output frames after resampling" or similar frame-count mismatches, the decoder is almost certainly behaving correctly and the test logic needs to switch to one of the post-trim validations above. The HAL contract guarantees the decoder emits the full encoded sample count; the trim metadata is the mechanism that makes the audible output sample-accurate to the source.
+
+If a test pipeline produces resampled audio without the container priming/padding metadata (some FFmpeg paths don't emit `edts/elst` or `iTunSMPB` on resampled output), middleware has no source for `trimStartNs` / `trimEndNs` and the padding leaks through. The fix is in the test pipeline (preserve or compute the priming/padding values), not the HAL.
+
 ## Decoded Audio Frame Buffers
 
 Decoded audio frame buffers are only passed from the audio decoder to the client when operating in non-tunnelled mode.


### PR DESCRIPTION
## Summary

Closes #488. Resolves discussion #461 (raised by @shafi12, correct diagnosis by @bhanucbp).

Documentation-only change. No AIDL changes. Adds a "Codec Priming, Padding, and Gapless Playback" section to `docs/halif/audio_decoder/current/audio_decoder.md` that explains the contract for `InputBufferMetadata.trimStartNs` / `trimEndNs` end-to-end.

## What's in the new section

- **Why priming and padding exist**: encoder window/overlap analysis at the start, frame-size rounding at the end. Typical priming counts per codec (AAC-LC 2048, MP3 529–1105, Opus variable via `pre_skip`, etc.).
- **Why resampling adds another layer**: leftover samples after rate conversion get padded into a final frame. Worked arithmetic for the 44.1 → 48 kHz case from #461.
- **Container metadata sources**: MP4 `edts/elst`, MP4 `iTunSMPB`, WebM `CodecDelay`, Opus `OpusHead.pre_skip`, and the ADTS-AAC case where the container carries nothing.
- **End-to-end mermaid sequence diagram**: `decodeBufferWithMetadata()` → carries trim → `onFrameOutput()` → `queueAudioFrame()` → sink applies trim before mixing.
- **Worked examples**: AAC-LC 2048-sample priming → `trimStartNs = 42_666_666 ns`. Resampled padding case → `trimEndNs = 2_666_666 ns`.
- **Test-validation guidance** — the gap that caused the original confusion in #461. Explicit: validate via post-trim sample count or PTS-delta sum, **not** frame count (which is expected to differ after resampling).

## Why this is needed

Discussion #461 demonstrated that even experienced engineers can mistake correct decoder behaviour for a bug when frame counts differ between input and output after resampling. The AIDL Doxygen on `trimStartNs` / `trimEndNs` is good but doesn't explain the conceptual story or where the values come from. This PR makes the canonical reference for the priming/padding lifecycle.

## Metadata

| Field | Before | After |
|---|---|---|
| `audiodecoder/metadata.yaml::version` | `0.1.0.0` | `0.1.0.1` (doc-only patch) |
| `status` | `GREEN` | `GREEN` (no interface change) |
| Reviewers | all `reviewed` | all `reviewed` (no interface change) |

## Test plan

- [ ] CI passes (Signature, Fossid, blackduck, copyright)
- [ ] mkdocs site renders the new section, mermaid sequence diagram, and tables correctly
- [ ] Reviewer sign-off

## References

- Tracking: #488
- Discussion: #461 (closes on merge)
- Discussion: #443 (where the per-frame trim semantics were originally clarified)
- AIDL (unchanged): `audiodecoder/current/com/rdk/hal/audiodecoder/InputBufferMetadata.aidl`