### PR TITLE
fix(videodecoder): add profile and level to HFP YAML per codec — #171

### DIFF
--- a/videodecoder/current/hfp-videodecoder.yaml
+++ b/videodecoder/current/hfp-videodecoder.yaml
@@ -28,32 +28,73 @@ videodecoder:                   # Component object begins
     - NON_TUNNELLED
   IVideoDecoder:                # Resource list
     - 0:                        # Resource object begins
-      supportedCodecs:          # Array of codec capabilities
+      supportedCodecs:          # CodecCapabilities[] — see CodecCapabilities.aidl
         - MPEG:
+            profiles:                                  # CodecCapabilities.profiles[] (see #528)
+              - profile: MPEG2_SIMPLE
+                maxLevel: MPEG2_LEVEL_HIGH
+                maxBitrateInBps: 50000000
+              - profile: MPEG2_MAIN
+                maxLevel: MPEG2_LEVEL_HIGH
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - H264:
+            profiles:
+              - profile: H264_BASELINE
+                maxLevel: H264_LEVEL_5_2
+                maxBitrateInBps: 50000000
+              - profile: H264_MAIN
+                maxLevel: H264_LEVEL_5_2
+                maxBitrateInBps: 50000000
+              - profile: H264_HIGH
+                maxLevel: H264_LEVEL_5_2
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - H265:
+            profiles:
+              - profile: H265_MAIN
+                maxLevel: H265_LEVEL_5_2
+                maxBitrateInBps: 150000000
+              - profile: H265_MAIN_10
+                maxLevel: H265_LEVEL_5_2
+                maxBitrateInBps: 150000000
+              - profile: H265_MAIN_10_HDR10
+                maxLevel: H265_LEVEL_5_2
+                maxBitrateInBps: 150000000
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
             supportedOutputPixelFormats:
               - YCBCR420
         - VP9:
+            profiles:
+              - profile: VP9_PROFILE_0
+                maxLevel: VP9_LEVEL_5_2
+                maxBitrateInBps: 50000000
+              - profile: VP9_PROFILE_2
+                maxLevel: VP9_LEVEL_5_2
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
             supportedOutputPixelFormats:
               - YCBCR420
         - AV1:
+            profiles:
+              - profile: AV1_MAIN
+                maxLevel: AV1_LEVEL_5_1
+                maxBitrateInBps: 50000000
+              - profile: AV1_HIGH
+                maxLevel: AV1_LEVEL_5_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
@@ -72,32 +113,64 @@ videodecoder:                   # Component object begins
         - BT2020
       supportsSecure: true
     - 1:                          # Resource object begins
-      supportedCodecs:          # Array of codec capabilities
+      supportedCodecs:          # CodecCapabilities[] — see CodecCapabilities.aidl
         - MPEG:
+            profiles:
+              - profile: MPEG2_SIMPLE
+                maxLevel: MPEG2_LEVEL_HIGH
+                maxBitrateInBps: 50000000
+              - profile: MPEG2_MAIN
+                maxLevel: MPEG2_LEVEL_HIGH
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - H264:
+            profiles:
+              - profile: H264_BASELINE
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H264_MAIN
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H264_HIGH
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - H265:
+            profiles:
+              - profile: H265_MAIN
+                maxLevel: H265_LEVEL_4
+                maxBitrateInBps: 100000000
+              - profile: H265_MAIN_10
+                maxLevel: H265_LEVEL_4
+                maxBitrateInBps: 100000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - VP9:
+            profiles:
+              - profile: VP9_PROFILE_0
+                maxLevel: VP9_LEVEL_4
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - AV1:
+            profiles:
+              - profile: AV1_MAIN
+                maxLevel: AV1_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080


### PR DESCRIPTION
## Summary
- HFP YAML now carries the **profile**, **level**, and **bitrate** capabilities each codec actually supports, in a shape closely aligned with [`rdk-hpk-documentation/hfp-reference/videodecoder/hfp-videodecoder.yaml`](https://github.com/rdkcentral/rdk-hpk-documentation/blob/main/hfp-reference/videodecoder/hfp-videodecoder.yaml).
- Each codec entry now contains a `profiles:` array. Each profile carries `maxLevel` + `maxBitrateInBps`. All lower profiles/levels are implicitly supported.

Closes #171. **Depends on #528** (extend `CodecCapabilities.aidl` with matching `Profile[]` field).

### Shape applied per codec

```yaml
- H265:
    profiles:
      - profile: H265_MAIN
        maxLevel: H265_LEVEL_5_2
        maxBitrateInBps: 150000000
      - profile: H265_MAIN_10
        maxLevel: H265_LEVEL_5_2
        maxBitrateInBps: 150000000
      - profile: H265_MAIN_10_HDR10
        maxLevel: H265_LEVEL_5_2
        maxBitrateInBps: 150000000
    maxFrameRate: 60
    maxFrameWidth: 3840
    maxFrameHeight: 2160
    supportedOutputPixelFormats:
      - YCBCR420
```

These are reference-HFP defaults; SOC vendors override per platform.

### Why this shape vs the previous incremental fix
- The previous version added a single `profile` + `level` per codec — sufficient to close the bug as written, but unable to express the common case where hardware supports multiple profiles per codec (e.g. H.265 MAIN, MAIN_10, MAIN_10_HDR10 all at the same level).
- The `profiles:` array matches the hfp-reference layout and the platform reality. The AIDL `CodecCapabilities` parcelable will be extended to match (#528) — accepting a temporary mismatch where HFP leads AIDL while #528 lands.

### Out of scope
- Repo-wide HFP harmonisation (move `audiosink` / `audiodecoder` off interface-name keys to mirror `hdmiinput`'s `Capabilities.<x>` pattern) — separate concern.
- The `0.1.0.0/hfp-videodecoder.yaml` frozen snapshot is intentionally untouched.

## Test plan
- [ ] AIDL parsers / HFP validators tolerate the new fields once #528 lands
- [ ] Vendors confirm the per-codec profile/level/bitrate defaults are reasonable reference values (override expected per platform)
- [ ] #528 lands first, or this PR is held until it does