### PR TITLE
fix(release.sh): discover nested component paths via globstar (#515)

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -44,14 +44,18 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
 fi
 
 # Resolve the component list: explicit args, or every component with an
-# interface definition under <module>/current/.
+# interface definition under <module>/current/. Uses globstar so nested
+# component paths (e.g. vsi/<x>/current/interface.yaml) are picked up,
+# not just top-level components.
 if [ "$#" -gt 0 ]; then
     COMPONENTS=("$@")
 else
     COMPONENTS=()
-    for f in */current/interface.yaml; do
+    shopt -s globstar nullglob
+    for f in **/current/interface.yaml; do
         COMPONENTS+=("${f%/current/interface.yaml}")
     done
+    shopt -u globstar nullglob
 fi
 
 released=0


### PR DESCRIPTION
## Summary

The component auto-discovery in \`release.sh\` was top-level-only:

\`\`\`bash
for f in */current/interface.yaml; do
    COMPONENTS+=("\${f%/current/interface.yaml}")
done
\`\`\`

A future nested component (\`vsi/<x>/current/interface.yaml\`, or any other namespaced path) would be silently dropped — no snapshot created, no warning, no error. The first time anyone added a nested component, their release would just not happen.

## Fix

One change: switch the glob to \`**/current/interface.yaml\` with \`shopt -s globstar nullglob\`. The existing \`\${f%/current/interface.yaml}\` strip already handles arbitrary depth.

\`\`\`bash
shopt -s globstar nullglob
for f in **/current/interface.yaml; do
    COMPONENTS+=("\${f%/current/interface.yaml}")
done
shopt -u globstar nullglob
\`\`\`

## Verification

\`./release.sh\` (no-op smoke test on develop) — all 21 existing top-level components still discovered, all correctly skipped (already at their metadata.yaml version), exits clean:

\`\`\`
release.sh: 0 released, 21 skipped.
\`\`\`

Backwards-compatible; no behaviour change for the current catalogue.

## Closes

Closes #515.