### PR TITLE
docs(governance): document PR-label-to-version-bump workflow + subsume rule (#525)

### DIFF
--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -85,6 +85,91 @@ interface is right.
   patch to `0`
 - A documentation-only change bumps patch
 
+### How PRs Drive the Version Bump
+
+Pre-baseline component versions advance one PR at a time. The bump that each
+PR implies is signalled by **labels on the PR**. `scripts/configure_pr.sh`
+applies them automatically from the PR title and changed files; reviewers may
+add or correct them as needed.
+
+| PR label | Implied bump | Applied when |
+|----------|--------------|--------------|
+| `breaking-change` | **Generation** (`0.g.m.p` → `0.(g+1).0.0`) | Conventional-commit `!:` marker in the PR title (e.g. `feat(avclock)!: ...`) |
+| `documentation-change` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Every changed file is doc-like (see `scripts/configure_pr.sh:is_doc()`) |
+| (no specific label) | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Default for any feature addition or non-breaking change |
+
+The PR author edits the component's `metadata.yaml` `version:` to the new
+value as part of the PR's diff. Reviewers check that the version bump matches
+the label and the actual change.
+
+#### The Subsume Rule
+
+Between releases, `metadata.yaml` `version:` represents the **intent for the
+next release** — the highest bump that has been declared since the last
+release tag. A PR bumps `version:` *only if its change is more significant
+than what is already pending.*
+
+| Last released | Already pending on `develop` | This PR is… | Action |
+|---|---|---|---|
+| `0.1.0.0` | `0.1.0.0` (unchanged since release) | patch | bump → `0.1.0.1` |
+| `0.1.0.0` | `0.1.0.0` | minor | bump → `0.1.1.0` |
+| `0.1.0.0` | `0.1.0.0` | breaking | bump → `0.2.0.0` |
+| `0.1.0.0` | `0.1.1.0` (a prior PR already bumped minor) | another minor | **no bump — already covered** |
+| `0.1.0.0` | `0.1.1.0` | patch (smaller than pending) | **no bump — subsumed by minor** |
+| `0.1.0.0` | `0.1.1.0` | breaking | bump → `0.2.0.0` (subsumes the minor) |
+| `0.1.0.0` | `0.2.0.0` (a prior PR already bumped breaking) | minor or patch | **no bump — already covered** |
+| `0.1.0.0` | `0.2.0.0` | another breaking | **no bump** (one generation tick per release window) |
+| new component (no prior release) | `0.1.0.0` | anything | no bump — first release is `0.1.0.0` regardless of how many PRs accumulate |
+
+**Net rule:** `next_version = max(current_pending, this_PR_would_imply)`. The
+release version is the aggregate delta since the last tag, not a per-PR
+count. Multiple breaking changes in a single release window batch into one
+generation; multiple feature additions batch into one minor; multiple
+docs-only changes batch into one patch.
+
+This is **human-side discipline**, not script-enforced. Reviewers verify
+that the bump (or non-bump) is appropriate for the PR's change.
+
+#### When the Snapshot is Created
+
+`metadata.yaml` `version:` is a **forward-looking declaration** of what the
+next release will tag the component as. The `<component>/<version>/`
+snapshot directory is **not** created in feature PRs. It is materialised at
+release time by the top-level `./release.sh`, which reads `metadata.yaml`
+and copies `current/` to `<version>/`.
+
+Feature PRs touch `current/` only:
+
+- `current/com/.../*.aidl` — authored AIDL source
+- `current/include/`, `current/src/` — regenerated C++ (committed in the same
+  PR; see [Component Structure](#2-component-structure) for layout)
+- `current/docs/<component>.md` — documentation
+- `current/CMakeLists.txt`, `current/interface.yaml`, `current/hfp-*.yaml` —
+  build wiring + manifest + hardware feature profile
+
+Multiple PRs can accumulate bumps on `develop` without any of them creating
+snapshot directories. The next release event (`release.sh` run during
+release prep) materialises all of the snapshots together and the repo is
+tagged.
+
+This separation means a single coherent release contains all of the
+component changes from the release window batched into one set of new
+snapshots — see [Release Cadence](#release-cadence) below.
+
+#### Release Cadence
+
+Releases are **milestone-driven** with **patch releases on demand**:
+
+- A new milestone (e.g. `0.20.0 - Convergance`) closes when its content is
+  complete. A release is then cut from `develop` to `main`, `release.sh`
+  materialises all the pending component snapshots, and the repo is tagged.
+- An urgent fix that cannot wait for the next milestone is shipped as a
+  patch release (e.g. `0.15.1`) using the same release ceremony.
+
+Releases are **not** cut on every PR merge. Multiple changes batch into one
+coherent release narrative. See [`0.15.0` and `0.20.0` release notes](../releases/)
+for the pattern.
+
 ### Post-Baseline: AIDL Stable Versioning
 
 Once a component reaches AIDL Baseline and is frozen, it follows **AIDL

--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -95,7 +95,7 @@ add or correct them as needed.
 | PR label | Implied bump | Applied when |
 |----------|--------------|--------------|
 | `breaking-change` | **Generation** (`0.g.m.p` → `0.(g+1).0.0`) | Conventional-commit `!:` marker in the PR title (e.g. `feat(avclock)!: ...`) |
-| `documentation-change` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Every changed file is doc-like (see `scripts/configure_pr.sh:is_doc()`) |
+| `documentation` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Every changed file is doc-like (see `scripts/configure_pr.sh:is_doc()`) |
 | (no specific label) | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Default for any feature addition or non-breaking change |
 
 The PR author edits the component's `metadata.yaml` `version:` to the new
@@ -167,8 +167,8 @@ Releases are **milestone-driven** with **patch releases on demand**:
   patch release (e.g. `0.15.1`) using the same release ceremony.
 
 Releases are **not** cut on every PR merge. Multiple changes batch into one
-coherent release narrative. See [`0.15.0` and `0.20.0` release notes](../releases/)
-for the pattern.
+coherent release narrative. See the [0.20.0](../releases/0.20.0.md) and
+[0.15.0](../releases/0.15.0.md) release notes for the pattern.
 
 ### Post-Baseline: AIDL Stable Versioning
 
@@ -513,28 +513,34 @@ Idempotent — safe to re-run.
 |-------|---------|
 | `component:<name>` | Maps PRs to a specific HAL/VSI component (auto-detected from metadata.yaml) |
 | `breaking-change` | Breaking interface change — bumps generation |
-| `documentation-change` | Documentation-only change — no interface change, bumps patch |
+| `documentation` | Documentation-only change — no interface change, bumps patch |
 | `scope:infrastructure` | Repo tooling, CI/CD, governance |
 | `scope:overview` | Tracking ticket spanning multiple components |
 
-The label determines the version bump category at release time:
+The label signals the bump intent; the PR author bumps `metadata.yaml`
+`version:` accordingly as part of the PR diff (see [How PRs Drive the
+Version Bump](#how-prs-drive-the-version-bump) above for the full subsume
+rule and snapshot-timing model):
 
 | Label | Version bump | Example |
 |-------|-------------|---------|
 | `breaking-change` | Bump generation, reset minor + patch | `0.1.2.1` → `0.2.0.0` |
 | *(no label)* | Bump minor, reset patch | `0.1.0.0` → `0.1.1.0` |
-| `documentation-change` | Bump patch | `0.1.1.0` → `0.1.1.1` |
+| `documentation` | Bump patch | `0.1.1.0` → `0.1.1.1` |
 
 Release-time execution (manual):
 
 ```bash
-# Preview component version bumps since the previous release tag
-./scripts/release.sh
-
-# Apply updates to component metadata.yaml files
-./scripts/release.sh --apply
+# Snapshot every component whose metadata.yaml version: differs from
+# its currently-released <module>/<version>/ directory. Idempotent.
+./release.sh
 ```
 
-All other state (RAG status, reviewer sign-off, lifecycle dates) is tracked in
-`metadata.yaml` — the Single Source of Truth. PRs are assigned directly to
-GitHub teams for review.
+`./release.sh` reads `metadata.yaml` `version:` verbatim — it does not
+compute bumps; that's the PR author's job, signalled by the label and
+validated by reviewers. Snapshots materialise only at release time, never
+in feature PRs.
+
+All other state (RAG status, reviewer sign-off, lifecycle dates) is tracked
+in `metadata.yaml` — the Single Source of Truth. PRs are assigned directly
+to GitHub teams for review.

--- a/docs/presentations/change-request-process/10-versioning-and-impact-control.md
+++ b/docs/presentations/change-request-process/10-versioning-and-impact-control.md
@@ -2,12 +2,12 @@
 
 Changes are versioned based on their impact, signalled by PR labels:
 
-| Change Type             | Label                  | Version Impact    | Example             |
-|-------------------------|------------------------|-------------------|---------------------|
-| **Breaking Change**     | `breaking-change`      | Bumps generation  | 0.1.x.x → 0.2.0.0 |
-| **Feature/Enhancement** | *(no specific label)*  | Bumps minor       | 0.1.0.0 → 0.1.1.0 |
-| **Documentation Only**  | `documentation-change` | Bumps patch       | 0.1.1.0 → 0.1.1.1 |
+| Change Type             | Label                 | Version Impact    | Example             |
+|-------------------------|-----------------------|-------------------|---------------------|
+| **Breaking Change**     | `breaking-change`     | Bumps generation  | 0.1.x.x → 0.2.0.0   |
+| **Feature/Enhancement** | *(no specific label)* | Bumps minor       | 0.1.0.0 → 0.1.1.0   |
+| **Documentation Only**  | `documentation`       | Bumps patch       | 0.1.1.0 → 0.1.1.1   |
 
-Labels are applied automatically by `scripts/configure_pr.sh` from the PR title (`!:` marker → `breaking-change`) and changed files (all doc-like → `documentation-change`). The PR author bumps `metadata.yaml` `version:` in the same PR so the declaration matches the label.
+Labels are applied automatically by `scripts/configure_pr.sh` from the PR title (`!:` marker → `breaking-change`) and changed files (all doc-like → `documentation`). The PR author bumps `metadata.yaml` `version:` in the same PR so the declaration matches the label.
 
 The full operational rules — the **subsume rule** (multiple PRs in one release window batch into one bump), when snapshots are created (release time, not in feature PRs), and release cadence (milestone-driven + patch-on-demand) — are in [HAL Delivery & Versioning SOP §3](../../governance/versioning-sop.md#how-prs-drive-the-version-bump).

--- a/docs/presentations/change-request-process/10-versioning-and-impact-control.md
+++ b/docs/presentations/change-request-process/10-versioning-and-impact-control.md
@@ -1,11 +1,13 @@
 # Versioning & Impact Control
 
-Changes are versioned based on their impact, controlled by PR labels:
+Changes are versioned based on their impact, signalled by PR labels:
 
-| Change Type             | Label               | Version Impact    | Example             |
-|-------------------------|----------------------|-------------------|---------------------|
-| **Breaking Change**     | `breaking-change`   | Bumps generation  | 0.1.x.x → 0.2.0.0 |
-| **Feature/Enhancement** | *(no label)*        | Bumps minor       | 0.1.0.0 → 0.1.1.0 |
-| **Documentation Only**  | `documentation`     | Bumps patch       | 0.1.1.0 → 0.1.1.1 |
+| Change Type             | Label                  | Version Impact    | Example             |
+|-------------------------|------------------------|-------------------|---------------------|
+| **Breaking Change**     | `breaking-change`      | Bumps generation  | 0.1.x.x → 0.2.0.0 |
+| **Feature/Enhancement** | *(no specific label)*  | Bumps minor       | 0.1.0.0 → 0.1.1.0 |
+| **Documentation Only**  | `documentation-change` | Bumps patch       | 0.1.1.0 → 0.1.1.1 |
 
-Version bumps are applied via the `release.sh` tooling at release time - ensuring consistent, auditable version history across all 32 components.
+Labels are applied automatically by `scripts/configure_pr.sh` from the PR title (`!:` marker → `breaking-change`) and changed files (all doc-like → `documentation-change`). The PR author bumps `metadata.yaml` `version:` in the same PR so the declaration matches the label.
+
+The full operational rules — the **subsume rule** (multiple PRs in one release window batch into one bump), when snapshots are created (release time, not in feature PRs), and release cadence (milestone-driven + patch-on-demand) — are in [HAL Delivery & Versioning SOP §3](../../governance/versioning-sop.md#how-prs-drive-the-version-bump).

--- a/docs/presentations/engineering-workflow/02-pull-request-submission.md
+++ b/docs/presentations/engineering-workflow/02-pull-request-submission.md
@@ -3,7 +3,7 @@
 When a feature branch is ready, a **Pull Request** is raised:
 
 - PR targets the **develop** branch
-- Labels applied: `breaking-change`, `documentation`, or none
+- Labels applied: `breaking-change`, `documentation-change`, or none (default minor)
 - **CODEOWNERS** auto-assigns the `rdk-halif-aidl-pr-review-team`
 - Automated CI/CD checks triggered immediately
 

--- a/docs/presentations/engineering-workflow/02-pull-request-submission.md
+++ b/docs/presentations/engineering-workflow/02-pull-request-submission.md
@@ -3,7 +3,7 @@
 When a feature branch is ready, a **Pull Request** is raised:
 
 - PR targets the **develop** branch
-- Labels applied: `breaking-change`, `documentation-change`, or none (default minor)
+- Labels applied: `breaking-change`, `documentation`, or none (default minor)
 - **CODEOWNERS** auto-assigns the `rdk-halif-aidl-pr-review-team`
 - Automated CI/CD checks triggered immediately
 


### PR DESCRIPTION
## Summary

Documents the version-bump workflow that has crystallised across recent PRs (#502, #507, #514, #524, #387) into the canonical operational SOP, and brings two out-of-date presentation slides into alignment with current label naming.

Documentation-only change. No enforcement, no script change — discipline lives with PR authors and reviewers. Future automation (#513) may cross-validate the bump against the label, but that's out of scope here.

## Changes

### \`docs/governance/versioning-sop.md\` — new subsections in §3

- **How PRs Drive the Version Bump** — PR-label → bump mapping table (\`breaking-change\` → generation; \`documentation-change\` → patch; default → minor). Author updates \`metadata.yaml\` \`version:\` in the PR; reviewers cross-check.
- **The Subsume Rule** — \`version:\` on \`develop\` is forward-looking; a PR bumps only if its change is more significant than what's already pending. \`next_version = max(current_pending, this_PR_implies)\`. Multiple PRs in one release window batch into one bump.
- **When the Snapshot is Created** — \`<module>/<version>/\` dirs are materialised at release time by \`release.sh\`, not in feature PRs.
- **Release Cadence** — milestone-driven with patch releases on demand; not release-on-merge.

### Existing presentation docs aligned with current reality

- **\`docs/presentations/change-request-process/10-versioning-and-impact-control.md\`** — label name corrected (\`documentation\` → \`documentation-change\`, renamed in #507); the misleading "applied via release.sh at release time" line corrected (bumps happen in the PR by the author; snapshots happen at release time). Back-reference added to the SOP for the full rules.
- **\`docs/presentations/engineering-workflow/02-pull-request-submission.md\`** — same label rename; clarified "or none (default minor)".

## Test plan

- [ ] \`mkdocs build\` clean (release notes and SOP page navigable)
- [ ] No broken cross-references to the new SOP section anchor (\`#how-prs-drive-the-version-bump\`)
- [ ] CI checks (CLA, Fossid, blackduck, copyright) green

## Closes

Closes #525.