### PR TITLE
feat(videosink): populate Capabilities.aidl from hfp-videosink.yaml (#496)

### DIFF
--- a/videosink/current/com/rdk/hal/videosink/Capabilities.aidl
+++ b/videosink/current/com/rdk/hal/videosink/Capabilities.aidl
@@ -17,16 +17,83 @@
  * limitations under the License.
  */
 package com.rdk.hal.videosink;
+import com.rdk.hal.videosink.MemoryType;
+import com.rdk.hal.videosink.PixelFormat;
 
 /**
- *  @brief     Video Sink resource definition.
+ *  @brief     Video Sink capabilities parcelable definition.
  *  @author    Luc Kennedy-Lamb
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
+ *  @author    Gerald Weatherup
+ *
+ *  Per-instance, immutable Video Sink capabilities, populated by the SoC
+ *  vendor from the HAL Feature Profile (`hfp-videosink.yaml`). The values
+ *  returned by `IVideoSink.getCapabilities()` must not change between calls
+ *  for the lifetime of the Video Sink instance.
  */
-
 @VintfStability
 parcelable Capabilities
 {
+    /**
+     * Array of `PixelFormat` values that this Video Sink instance is able
+     * to consume. Mirrors `IVideoSink[i].supportedPixelFormats` in the HFP.
+     */
+    PixelFormat[] supportedPixelFormats;
 
+    /**
+     * Array of `MemoryType` values supported by this Video Sink instance
+     * for buffer transport. Mirrors `IVideoSink[i].supportedMemoryTypes`
+     * in the HFP.
+     */
+    MemoryType[] supportedMemoryTypes;
+
+    /**
+     * Maximum number of frames the sink queues internally for display.
+     * Used by clients to size their upstream buffer pools so frames are
+     * not dropped on submission. Mirrors `IVideoSink[i].sinkQueueDepth`
+     * in the HFP.
+     */
+    int sinkQueueDepth;
+
+    /**
+     * Indicates whether this Video Sink instance can synchronise frame
+     * presentation against an AV Clock. When `false`, the sink presents
+     * frames as soon as they are decoded (best-effort display).
+     * Mirrors `IVideoSink[i].supportsAVSync` in the HFP.
+     */
+    boolean supportsAVSync;
+
+    /**
+     * Vendor-characterised latency, in nanoseconds, between the moment a
+     * frame is committed for display and the moment it is actually scanned
+     * out on the display. Used by AV-sync logic to compensate for sink
+     * pipeline delay. Mirrors `IVideoSink[i].vsyncDisplayLatencyNs` in the
+     * HFP.
+     */
+    long vsyncDisplayLatencyNs;
+
+    /**
+     * Indicates whether this Video Sink instance can hold and continue to
+     * display the most recent frame after the upstream source stops
+     * delivering frames (for example on `stop()` or underflow), rather than
+     * blanking the output. Mirrors `IVideoSink[i].supportsHoldLastFrame`
+     * in the HFP.
+     */
+    boolean supportsHoldLastFrame;
+
+    /**
+     * Indicates whether this Video Sink instance is able to operate in
+     * Secure Video Path (SVP) mode and consume buffers carrying protected
+     * content. Mirrors `IVideoSink[i].supportsSecure` in the HFP.
+     */
+    boolean supportsSecure;
+
+    /**
+     * Zero-based index of the graphics / video plane that this Video Sink
+     * instance composes onto. Used by clients to coordinate Z-order and
+     * plane configuration with the plane control HAL. Mirrors
+     * `IVideoSink[i].planeIndex` in the HFP.
+     */
+    int planeIndex;
 }

--- a/videosink/current/com/rdk/hal/videosink/MemoryType.aidl
+++ b/videosink/current/com/rdk/hal/videosink/MemoryType.aidl
@@ -1,0 +1,47 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videosink;
+
+/**
+ *  @brief     Video Sink buffer memory type enumeration.
+ *  @author    Gerald Weatherup
+ *
+ *  Identifies the buffer memory transport mechanisms that a Video Sink
+ *  instance is able to accept for queued frames. Mirrors the
+ *  `supportedMemoryTypes` field declared in the HFP (`hfp-videosink.yaml`).
+ */
+@VintfStability
+@Backing(type="int")
+enum MemoryType
+{
+    /** Unknown / unspecified memory type. */
+    UNKNOWN = 0,
+
+    /**
+     * DMA-BUF shared memory descriptor (Linux dma-buf file descriptor).
+     */
+    DMABuf = 1,
+
+    /**
+     * Android NativeHandle wrapping one or more file descriptors and
+     * associated integer payload, used to carry vendor-specific buffer
+     * references (for example GBM/gralloc handles).
+     */
+    NativeHandle = 2,
+}

--- a/videosink/current/com/rdk/hal/videosink/PixelFormat.aidl
+++ b/videosink/current/com/rdk/hal/videosink/PixelFormat.aidl
@@ -1,0 +1,52 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videosink;
+
+/**
+ *  @brief     Video Sink pixel format enumeration.
+ *  @author    Gerald Weatherup
+ *
+ *  Identifies the concrete buffer pixel layouts that a Video Sink instance
+ *  is able to consume. Mirrors the `supportedPixelFormats` field declared in
+ *  the HFP (`hfp-videosink.yaml`).
+ */
+@VintfStability
+@Backing(type="int")
+enum PixelFormat
+{
+    /** Unknown / unspecified pixel format. */
+    UNKNOWN = 0,
+
+    /**
+     * NV12 — 8-bit YUV 4:2:0, two planes (Y plane, interleaved UV plane).
+     */
+    NV12 = 1,
+
+    /**
+     * I420 — 8-bit YUV 4:2:0, three planes (Y, U, V).
+     * Also known as YU12 / planar YUV 4:2:0.
+     */
+    I420 = 2,
+
+    /**
+     * P010 — 10-bit YUV 4:2:0, two planes (Y plane, interleaved UV plane),
+     * with each component stored in the most significant 10 bits of a 16-bit word.
+     */
+    P010 = 3,
+}

--- a/videosink/current/include/com/rdk/hal/videosink/BnMemoryType.h
+++ b/videosink/current/include/com/rdk/hal/videosink/BnMemoryType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/videosink/current/include/com/rdk/hal/videosink/BnPixelFormat.h
+++ b/videosink/current/include/com/rdk/hal/videosink/BnPixelFormat.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/videosink/current/include/com/rdk/hal/videosink/BpMemoryType.h
+++ b/videosink/current/include/com/rdk/hal/videosink/BpMemoryType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/videosink/current/include/com/rdk/hal/videosink/BpPixelFormat.h
+++ b/videosink/current/include/com/rdk/hal/videosink/BpPixelFormat.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/videosink/current/include/com/rdk/hal/videosink/Capabilities.h
+++ b/videosink/current/include/com/rdk/hal/videosink/Capabilities.h
@@ -3,8 +3,12 @@
 #include <android/binder_to_string.h>
 #include <binder/Parcel.h>
 #include <binder/Status.h>
+#include <com/rdk/hal/videosink/MemoryType.h>
+#include <com/rdk/hal/videosink/PixelFormat.h>
+#include <cstdint>
 #include <tuple>
 #include <utils/String16.h>
+#include <vector>
 
 namespace com {
 namespace rdk {
@@ -12,23 +16,31 @@ namespace hal {
 namespace videosink {
 class Capabilities : public ::android::Parcelable {
 public:
-  inline bool operator!=(const Capabilities&) const {
-    return std::tie() != std::tie();
+  ::std::vector<::com::rdk::hal::videosink::PixelFormat> supportedPixelFormats;
+  ::std::vector<::com::rdk::hal::videosink::MemoryType> supportedMemoryTypes;
+  int32_t sinkQueueDepth = 0;
+  bool supportsAVSync = false;
+  int64_t vsyncDisplayLatencyNs = 0L;
+  bool supportsHoldLastFrame = false;
+  bool supportsSecure = false;
+  int32_t planeIndex = 0;
+  inline bool operator!=(const Capabilities& rhs) const {
+    return std::tie(supportedPixelFormats, supportedMemoryTypes, sinkQueueDepth, supportsAVSync, vsyncDisplayLatencyNs, supportsHoldLastFrame, supportsSecure, planeIndex) != std::tie(rhs.supportedPixelFormats, rhs.supportedMemoryTypes, rhs.sinkQueueDepth, rhs.supportsAVSync, rhs.vsyncDisplayLatencyNs, rhs.supportsHoldLastFrame, rhs.supportsSecure, rhs.planeIndex);
   }
-  inline bool operator<(const Capabilities&) const {
-    return std::tie() < std::tie();
+  inline bool operator<(const Capabilities& rhs) const {
+    return std::tie(supportedPixelFormats, supportedMemoryTypes, sinkQueueDepth, supportsAVSync, vsyncDisplayLatencyNs, supportsHoldLastFrame, supportsSecure, planeIndex) < std::tie(rhs.supportedPixelFormats, rhs.supportedMemoryTypes, rhs.sinkQueueDepth, rhs.supportsAVSync, rhs.vsyncDisplayLatencyNs, rhs.supportsHoldLastFrame, rhs.supportsSecure, rhs.planeIndex);
   }
-  inline bool operator<=(const Capabilities&) const {
-    return std::tie() <= std::tie();
+  inline bool operator<=(const Capabilities& rhs) const {
+    return std::tie(supportedPixelFormats, supportedMemoryTypes, sinkQueueDepth, supportsAVSync, vsyncDisplayLatencyNs, supportsHoldLastFrame, supportsSecure, planeIndex) <= std::tie(rhs.supportedPixelFormats, rhs.supportedMemoryTypes, rhs.sinkQueueDepth, rhs.supportsAVSync, rhs.vsyncDisplayLatencyNs, rhs.supportsHoldLastFrame, rhs.supportsSecure, rhs.planeIndex);
   }
-  inline bool operator==(const Capabilities&) const {
-    return std::tie() == std::tie();
+  inline bool operator==(const Capabilities& rhs) const {
+    return std::tie(supportedPixelFormats, supportedMemoryTypes, sinkQueueDepth, supportsAVSync, vsyncDisplayLatencyNs, supportsHoldLastFrame, supportsSecure, planeIndex) == std::tie(rhs.supportedPixelFormats, rhs.supportedMemoryTypes, rhs.sinkQueueDepth, rhs.supportsAVSync, rhs.vsyncDisplayLatencyNs, rhs.supportsHoldLastFrame, rhs.supportsSecure, rhs.planeIndex);
   }
-  inline bool operator>(const Capabilities&) const {
-    return std::tie() > std::tie();
+  inline bool operator>(const Capabilities& rhs) const {
+    return std::tie(supportedPixelFormats, supportedMemoryTypes, sinkQueueDepth, supportsAVSync, vsyncDisplayLatencyNs, supportsHoldLastFrame, supportsSecure, planeIndex) > std::tie(rhs.supportedPixelFormats, rhs.supportedMemoryTypes, rhs.sinkQueueDepth, rhs.supportsAVSync, rhs.vsyncDisplayLatencyNs, rhs.supportsHoldLastFrame, rhs.supportsSecure, rhs.planeIndex);
   }
-  inline bool operator>=(const Capabilities&) const {
-    return std::tie() >= std::tie();
+  inline bool operator>=(const Capabilities& rhs) const {
+    return std::tie(supportedPixelFormats, supportedMemoryTypes, sinkQueueDepth, supportsAVSync, vsyncDisplayLatencyNs, supportsHoldLastFrame, supportsSecure, planeIndex) >= std::tie(rhs.supportedPixelFormats, rhs.supportedMemoryTypes, rhs.sinkQueueDepth, rhs.supportsAVSync, rhs.vsyncDisplayLatencyNs, rhs.supportsHoldLastFrame, rhs.supportsSecure, rhs.planeIndex);
   }
 
   ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
@@ -41,6 +53,14 @@ public:
   inline std::string toString() const {
     std::ostringstream os;
     os << "Capabilities{";
+    os << "supportedPixelFormats: " << ::android::internal::ToString(supportedPixelFormats);
+    os << ", supportedMemoryTypes: " << ::android::internal::ToString(supportedMemoryTypes);
+    os << ", sinkQueueDepth: " << ::android::internal::ToString(sinkQueueDepth);
+    os << ", supportsAVSync: " << ::android::internal::ToString(supportsAVSync);
+    os << ", vsyncDisplayLatencyNs: " << ::android::internal::ToString(vsyncDisplayLatencyNs);
+    os << ", supportsHoldLastFrame: " << ::android::internal::ToString(supportsHoldLastFrame);
+    os << ", supportsSecure: " << ::android::internal::ToString(supportsSecure);
+    os << ", planeIndex: " << ::android::internal::ToString(planeIndex);
     os << "}";
     return os.str();
   }

--- a/videosink/current/include/com/rdk/hal/videosink/MemoryType.h
+++ b/videosink/current/include/com/rdk/hal/videosink/MemoryType.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videosink {
+enum class MemoryType : int32_t {
+  UNKNOWN = 0,
+  DMABuf = 1,
+  NativeHandle = 2,
+};
+}  // namespace videosink
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videosink {
+[[nodiscard]] static inline std::string toString(MemoryType val) {
+  switch(val) {
+  case MemoryType::UNKNOWN:
+    return "UNKNOWN";
+  case MemoryType::DMABuf:
+    return "DMABuf";
+  case MemoryType::NativeHandle:
+    return "NativeHandle";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace videosink
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::videosink::MemoryType, 3> enum_values<::com::rdk::hal::videosink::MemoryType> = {
+  ::com::rdk::hal::videosink::MemoryType::UNKNOWN,
+  ::com::rdk::hal::videosink::MemoryType::DMABuf,
+  ::com::rdk::hal::videosink::MemoryType::NativeHandle,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/videosink/current/include/com/rdk/hal/videosink/PixelFormat.h
+++ b/videosink/current/include/com/rdk/hal/videosink/PixelFormat.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videosink {
+enum class PixelFormat : int32_t {
+  UNKNOWN = 0,
+  NV12 = 1,
+  I420 = 2,
+  P010 = 3,
+};
+}  // namespace videosink
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videosink {
+[[nodiscard]] static inline std::string toString(PixelFormat val) {
+  switch(val) {
+  case PixelFormat::UNKNOWN:
+    return "UNKNOWN";
+  case PixelFormat::NV12:
+    return "NV12";
+  case PixelFormat::I420:
+    return "I420";
+  case PixelFormat::P010:
+    return "P010";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace videosink
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::videosink::PixelFormat, 4> enum_values<::com::rdk::hal::videosink::PixelFormat> = {
+  ::com::rdk::hal::videosink::PixelFormat::UNKNOWN,
+  ::com::rdk::hal::videosink::PixelFormat::NV12,
+  ::com::rdk::hal::videosink::PixelFormat::I420,
+  ::com::rdk::hal::videosink::PixelFormat::P010,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/videosink/current/src/com/rdk/hal/videosink/Capabilities.cpp
+++ b/videosink/current/src/com/rdk/hal/videosink/Capabilities.cpp
@@ -15,6 +15,70 @@ namespace videosink {
   if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
   size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
   if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedPixelFormats);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedMemoryTypes);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&sinkQueueDepth);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readBool(&supportsAVSync);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt64(&vsyncDisplayLatencyNs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readBool(&supportsHoldLastFrame);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readBool(&supportsSecure);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&planeIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
   _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
   return _aidl_ret_status;
 }
@@ -22,6 +86,38 @@ namespace videosink {
   ::android::status_t _aidl_ret_status = ::android::OK;
   auto _aidl_start_pos = _aidl_parcel->dataPosition();
   _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedPixelFormats);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedMemoryTypes);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt32(sinkQueueDepth);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeBool(supportsAVSync);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt64(vsyncDisplayLatencyNs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeBool(supportsHoldLastFrame);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeBool(supportsSecure);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt32(planeIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
   auto _aidl_end_pos = _aidl_parcel->dataPosition();
   _aidl_parcel->setDataPosition(_aidl_start_pos);
   _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);

--- a/videosink/current/src/com/rdk/hal/videosink/MemoryType.cpp
+++ b/videosink/current/src/com/rdk/hal/videosink/MemoryType.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/videosink/current/src/com/rdk/hal/videosink/PixelFormat.cpp
+++ b/videosink/current/src/com/rdk/hal/videosink/PixelFormat.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/videosink/metadata.yaml
+++ b/videosink/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videosink
-version: 0.1.0.0
+version: 0.1.1.0
 status: GREEN
 description: "Video output rendering and display sink management"
 type: SOC
@@ -55,8 +55,8 @@ notes:
 # reviewers - Sign-off status per stakeholder team                       [manual]
 #   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
 reviewers:
-    Architecture: reviewed
-    Product_Architecture: reviewed
-    AV_Architecture: reviewed
-    Vendor_Layer_Team: reviewed
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    Vendor_Layer_Team: pending
 


### PR DESCRIPTION
## Summary

Closes #496.

The `VideoSink` HAL shipped a `Capabilities` parcelable that was effectively empty, while `videosink/current/hfp-videosink.yaml` already defined a detailed per-instance capability schema. This PR populates `Capabilities.aidl` so consumers can actually query VideoSink capabilities at runtime, aligning the AIDL surface 1:1 with the HFP fields that integrators populate at platform bring-up time.

## Fields added to `Capabilities.aidl`

| AIDL field | Type | HFP source (`IVideoSink[i].*`) |
|---|---|---|
| `supportedPixelFormats` | `PixelFormat[]` | `supportedPixelFormats` |
| `supportedMemoryTypes`  | `MemoryType[]`  | `supportedMemoryTypes`  |
| `sinkQueueDepth`        | `int`           | `sinkQueueDepth`        |
| `supportsAVSync`        | `boolean`       | `supportsAVSync`        |
| `vsyncDisplayLatencyNs` | `long`          | `vsyncDisplayLatencyNs` |
| `supportsHoldLastFrame` | `boolean`       | `supportsHoldLastFrame` |
| `supportsSecure`        | `boolean`       | `supportsSecure`        |
| `planeIndex`            | `int`           | `planeIndex`            |

Two new package-local enums are added to back the array fields:

- `PixelFormat` — `NV12`, `I420`, `P010` (mirrors the concrete buffer layouts the HFP enumerates; the existing `videodecoder.PixelFormat` uses generic `YCBCR420/422/444` names that do not match what integrators populate sink-side).
- `MemoryType` — `DMABuf`, `NativeHandle` (mirrors the HFP `supportedMemoryTypes` values).

`IVideoSink.getCapabilities()` itself is unchanged — it already returns `Capabilities`; only the parcelable's contents are populated.

## Versioning & compatibility

- **Additive change.** Populating a previously empty parcelable with new fields does not break consumers reading the old empty `Capabilities`; consumers that read the new fields get the data the HFP already promises.
- `videosink/metadata.yaml` version bumped `0.1.0.0` -> `0.1.1.0` (minor).
- Reviewers reset to `pending`.

## Snapshot policy

- No `videosink/0.1.1.0/` snapshot directory created (snapshots are release-time only, not per-PR).
- `videosink/0.1.0.0/` historical snapshot is untouched.

## Build verification

- `rm -rf videosink/current/include videosink/current/src && ./build_modules.sh videosink` exits clean.
- `libvideosink-vcurrent-cpp.so` is produced at `out/target/lib/halif/` (722 544 bytes after regen).
- Regenerated C++ bindings under `videosink/current/{include,src}` are committed alongside the AIDL changes (new files for `MemoryType` and `PixelFormat`, modified `Capabilities.{h,cpp}`).

## HFP <-> AIDL alignment note for reviewers

This PR addresses the per-instance HFP shape only. The HFP also defines a `platformCapabilities:` section (metrics list, `supportsPlaneMapping`, `supportsFlushNotification`, `requiresFrameMetadata`, `supportsTunnelledPlayback`); a sibling `PlatformCapabilities.aidl` and `IVideoSinkManager.getPlatformCapabilities()` (matching the audiosink pattern) is a natural follow-up and is intentionally scoped out of this PR so the fix for the empty `Capabilities.aidl` lands cleanly. Happy to fold it in or open a follow-up issue per reviewer preference.

## Test plan

- [ ] CI green on `feature/496-populate-videosink-capabilities` against `develop`.
- [ ] Local: `./build_modules.sh videosink` clean; `libvideosink-vcurrent-cpp.so` present.
- [ ] Reviewers confirm field naming/types match HFP semantics and `PixelFormat`/`MemoryType` enum values cover the in-field profiles.