### PR TITLE
fix(scripts): align on 'documentation' label across configure_pr.sh and release.sh (#531)

### DIFF
--- a/scripts/configure_pr.sh
+++ b/scripts/configure_pr.sh
@@ -130,7 +130,7 @@ def is_doc(p):
 fs=[f["path"] for f in json.load(sys.stdin)["files"]]
 print("yes" if fs and all(is_doc(p) for p in fs) else "no")
 ')
-    [ "$docs_only" = "yes" ] && desired_labels+="documentation-change\n"
+    [ "$docs_only" = "yes" ] && desired_labels+="documentation\n"
 
     local add_labels=()
     while IFS= read -r lbl; do

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -227,7 +227,7 @@ for sha in "${FP_COMMITS[@]}"; do
     while IFS= read -r lbl; do
         [[ -n "${lbl}" ]] || continue
         [[ "${lbl}" == "breaking-change" ]] && has_breaking_label=1
-        [[ "${lbl}" == "documentation-change" ]] && has_doc_label=1
+        [[ "${lbl}" == "documentation" ]] && has_doc_label=1
     done <<< "${labels}"
 
     declare -A COMMIT_COMP_TOUCHED=()


### PR DESCRIPTION
## Summary

Closes #531.

PR #507 introduced a three-way inconsistency in label handling:

| Script                  | Pre-#507              | Post-#507             |
|-------------------------|-----------------------|-----------------------|
| `setup_labels.sh`       | provisions `documentation` | provisions `documentation` |
| `configure_pr.sh`       | applies `documentation` | applies `documentation-change` |
| `release.sh`            | matches `documentation-change` | matches `documentation-change` |

PR #507 fixed the symmetry between `configure_pr.sh` and `release.sh` by
moving `configure_pr.sh` to use `documentation-change`. The cleaner
correction (per #531) is the other direction: align both consumer scripts
on the canonical name that `setup_labels.sh` actually provisions.

## Changes

- `scripts/configure_pr.sh`:1 line — `documentation-change` → `documentation`
  (the docs-only label string applied to PRs).
- `scripts/release.sh`:1 line — `documentation-change` → `documentation`
  (the label-driven patch-bump detection match).

## Cleanup (out-of-diff)

The orphan `documentation-change` label (created on the repo earlier today
as part of #526's first push) was deleted via
`gh label delete documentation-change --yes` as part of this fix. After
deletion, `gh label list --search documentation` shows only the canonical
`documentation` label.

## Test plan

- [x] `bash -n scripts/configure_pr.sh && bash -n scripts/release.sh` — both parse cleanly.
- [x] `scripts/setup_labels.sh --dry-run` reviewed; the script's hardcoded
      legacy-cleanup list still names `documentation-change`, but its
      non-dry-run `delete_label` is a silent no-op when the label is absent
      (which it now is). Cleaning that hardcoded list is out of scope here.
- [x] `gh label list --search documentation` returns only `documentation`.
- [ ] `./scripts/configure_pr.sh <this-PR>` applies `scope:infrastructure`
      cleanly (this is a scripts change, not docs-only, so no
      `documentation` label is expected on this PR itself).

## References

- Original misdirection: #507 (Copilot review nits on `configure_pr.sh`).
- Docs already corrected to use `documentation`: #526 commit 9736f7f6.