### PR TITLE
fix(build): always regenerate C++ from AIDL on build (#530)

### DIFF
--- a/binder_sdk.version
+++ b/binder_sdk.version
@@ -5,12 +5,9 @@
 # clones the toolchain. Keep it pinned so the committed module-local
 # generated C++ always matches the generator that produced it.
 #
-# Pinned to the always-regen-on-build fix commit on
-# feature/530-always-regen-on-build (linux_binder_idl#21). This commit
-# is the tip of the module-local generator branch (linux_binder_idl#20)
-# plus the rdk-halif-aidl#530 fix that drops the "skip regen when
-# current/include is already populated" guard. Bump to a release tag
-# once both PRs merge.
+# Pinned to release tag 2.1.0 (linux_binder_idl) which ships:
+#  - the module-local generated-output layout (linux_binder_idl#19/#20)
+#  - the always-regen-on-build fix (linux_binder_idl#21, closes rdk-halif-aidl#530)
 #
 # Override for a one-off build with:  BINDER_VERSION=<ref> ./build_binder.sh
-1db26cf
+2.1.0

--- a/binder_sdk.version
+++ b/binder_sdk.version
@@ -5,9 +5,12 @@
 # clones the toolchain. Keep it pinned so the committed module-local
 # generated C++ always matches the generator that produced it.
 #
-# Pinned to the module-local generator commit on
-# feature/19-module-local-generated-output (linux_binder_idl#20). Bump to a
-# release tag once that PR merges.
+# Pinned to the always-regen-on-build fix commit on
+# feature/530-always-regen-on-build (linux_binder_idl#21). This commit
+# is the tip of the module-local generator branch (linux_binder_idl#20)
+# plus the rdk-halif-aidl#530 fix that drops the "skip regen when
+# current/include is already populated" guard. Bump to a release tag
+# once both PRs merge.
 #
 # Override for a one-off build with:  BINDER_VERSION=<ref> ./build_binder.sh
-b3b6d69
+1db26cf


### PR DESCRIPTION
## Summary

Closes #530. Bumps `binder_sdk.version` to pull in the always-regen-on-build fix from [linux_binder_idl#21](https://github.com/rdkcentral/linux_binder_idl/pull/21).

The AIDL→C++ regeneration step in `build-tools/linux_binder_idl/host/CMakeLists.inc` was only running when `<module>/current/include/` and `<module>/current/src/` were **empty**. As soon as those directories held any pre-generated artefacts (a prior local build, a stale checkout, the seed snapshots committed by #502, or a previous regen agent's output) the regen was **silently skipped** — even when the source AIDL had changed.

This bit us **four times today** alone: every rebase agent on the #492 / #503 / #524 train had to manually `rm -rf <component>/current/include <component>/current/src` before running `./build_modules.sh <comp>` to defeat the guard, otherwise the build silently shipped stale generated C++. Worst case (already observed on #524): the AIDL update lands in commit *X*, but the C++ stays at the pre-*X* state, and a follow-up regen-only commit *Y* is required to reconcile.

## Option A rationale

The project owner selected **Option A** from #530 ("always regenerate") rather than **Option B** ("hash-compare"):

- **Deterministic regen**: AIDL→C++ is byte-deterministic; same AIDL produces same C++. If the AIDL is unchanged the regen produces an identical tree and `git status` shows no diff — the rebuild is invisible.
- **Zero staleness risk**: no possibility of the *"generated tree is stale relative to AIDL"* class of bugs. The entire failure mode that bit us 4× today disappears.
- **Negligible CPU cost**: `aidl` runs at CMake configure time, on the order of a few hundred ms per module. Dominated by the compile step that follows. Not measurable for users.
- **Less code than Option B**: no `.aidl_hash` file format to maintain, no hash drift to debug, no extra failure modes.

## Changes

Single-file change in this PR: `binder_sdk.version` bumps from `b3b6d69` to `1db26cf` (the tip of `linux_binder_idl:feature/530-always-regen-on-build` once linux_binder_idl#21 merges). The actual fix lives in [linux_binder_idl#21](https://github.com/rdkcentral/linux_binder_idl/pull/21):

- **`host/CMakeLists.inc`** — `AddInterfaceLibrary()`: always invoke `aidl_ops.py -g` when `interface_version == "current"`; keep the skip-if-pre-committed behaviour for frozen versions (the release contract); defensive fallback when regen produces no files in the expected source dir.
- **`host/aidl_interface.py`** — `load_interfaces()`: stable-sort discovered `interface.yaml` locations so `<module>/current/interface.yaml` is always inserted last into the `aidl_interfaces` dict. Prevents the new always-regen from accidentally clobbering frozen snapshot dirs when `os.walk` happens to walk them after `current/`.

## Test plan

- [x] **AC reproducer (from #530)**: edited `avclock/current/com/rdk/hal/avclock/IAVClock.aidl` to add a probe method, ran `./build_modules.sh avclock`, confirmed `git diff avclock/current/include/com/rdk/hal/avclock/IAVClock.h` shows the new method appearing in both `IAVClock` and `IAVClockDefault`. Reverted the AIDL edit and re-ran — working tree returned to clean.
- [x] **Full build clean (#502 seed snapshots preserved)**: `./build_modules.sh all` exits with `Build completed successfully!`, 26 libraries built (23 vcurrent + 3 frozen-version companion libs: `audiodecoder-v0.1.0.0`, `audiomixer-v0.1.0.1`, `boot-v0.1.0.0`), `git status` shows no modifications to any snapshot directory.
- [x] **No frozen-version regressions**: `audiomixer/0.1.0.1/`, `compositeinput/0.2.0.0/`, all `*/0.1.0.0/` directories untouched after a full build (verified `git status --porcelain` is empty post-build).
- [ ] **CI on a clean-room checkout**: needs a fresh-clone CI run to confirm first-time-generation paths still work end-to-end.

## Merge order

1. Land [linux_binder_idl#21](https://github.com/rdkcentral/linux_binder_idl/pull/21) first.
2. Tag a release (optional, or just keep the commit-hash pin in this PR).
3. Merge this PR (no rebase needed — only `binder_sdk.version` changed).

Closes #530.