### PR TITLE
fix(audiomixer): restore current/include and current/src wiped by #456 amend

### DIFF
--- a/audiomixer/current/include/com/rdk/hal/audiomixer/AQParameter.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/AQParameter.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class AQParameter : int32_t {
+  VOLUME_LEVELLER = 0,
+  DIALOGUE_ENHANCER = 1,
+  DIALOGUE_CLARITY = 2,
+  AC4_DIALOGUE_ENHANCER = 3,
+  BASS_ENHANCER_GAIN = 4,
+  BASS_ENHANCER_WIDTH = 5,
+  BASS_ENHANCER_CUTOFF = 6,
+  SURROUND_DECODER = 7,
+  SURROUND_VIRTUALIZER = 8,
+  MI_STEERING = 9,
+  GRAPHIC_EQUALIZER = 10,
+  INTELLIGENT_EQUALIZER = 11,
+  POST_GAIN = 12,
+  VOLUME_MODELER = 13,
+  AUDIO_OPTIMIZER = 14,
+  ACTIVE_DOWNMIX = 15,
+  CENTER_SPREADING = 16,
+  DRC = 17,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(AQParameter val) {
+  switch(val) {
+  case AQParameter::VOLUME_LEVELLER:
+    return "VOLUME_LEVELLER";
+  case AQParameter::DIALOGUE_ENHANCER:
+    return "DIALOGUE_ENHANCER";
+  case AQParameter::DIALOGUE_CLARITY:
+    return "DIALOGUE_CLARITY";
+  case AQParameter::AC4_DIALOGUE_ENHANCER:
+    return "AC4_DIALOGUE_ENHANCER";
+  case AQParameter::BASS_ENHANCER_GAIN:
+    return "BASS_ENHANCER_GAIN";
+  case AQParameter::BASS_ENHANCER_WIDTH:
+    return "BASS_ENHANCER_WIDTH";
+  case AQParameter::BASS_ENHANCER_CUTOFF:
+    return "BASS_ENHANCER_CUTOFF";
+  case AQParameter::SURROUND_DECODER:
+    return "SURROUND_DECODER";
+  case AQParameter::SURROUND_VIRTUALIZER:
+    return "SURROUND_VIRTUALIZER";
+  case AQParameter::MI_STEERING:
+    return "MI_STEERING";
+  case AQParameter::GRAPHIC_EQUALIZER:
+    return "GRAPHIC_EQUALIZER";
+  case AQParameter::INTELLIGENT_EQUALIZER:
+    return "INTELLIGENT_EQUALIZER";
+  case AQParameter::POST_GAIN:
+    return "POST_GAIN";
+  case AQParameter::VOLUME_MODELER:
+    return "VOLUME_MODELER";
+  case AQParameter::AUDIO_OPTIMIZER:
+    return "AUDIO_OPTIMIZER";
+  case AQParameter::ACTIVE_DOWNMIX:
+    return "ACTIVE_DOWNMIX";
+  case AQParameter::CENTER_SPREADING:
+    return "CENTER_SPREADING";
+  case AQParameter::DRC:
+    return "DRC";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::AQParameter, 18> enum_values<::com::rdk::hal::audiomixer::AQParameter> = {
+  ::com::rdk::hal::audiomixer::AQParameter::VOLUME_LEVELLER,
+  ::com::rdk::hal::audiomixer::AQParameter::DIALOGUE_ENHANCER,
+  ::com::rdk::hal::audiomixer::AQParameter::DIALOGUE_CLARITY,
+  ::com::rdk::hal::audiomixer::AQParameter::AC4_DIALOGUE_ENHANCER,
+  ::com::rdk::hal::audiomixer::AQParameter::BASS_ENHANCER_GAIN,
+  ::com::rdk::hal::audiomixer::AQParameter::BASS_ENHANCER_WIDTH,
+  ::com::rdk::hal::audiomixer::AQParameter::BASS_ENHANCER_CUTOFF,
+  ::com::rdk::hal::audiomixer::AQParameter::SURROUND_DECODER,
+  ::com::rdk::hal::audiomixer::AQParameter::SURROUND_VIRTUALIZER,
+  ::com::rdk::hal::audiomixer::AQParameter::MI_STEERING,
+  ::com::rdk::hal::audiomixer::AQParameter::GRAPHIC_EQUALIZER,
+  ::com::rdk::hal::audiomixer::AQParameter::INTELLIGENT_EQUALIZER,
+  ::com::rdk::hal::audiomixer::AQParameter::POST_GAIN,
+  ::com::rdk::hal::audiomixer::AQParameter::VOLUME_MODELER,
+  ::com::rdk::hal::audiomixer::AQParameter::AUDIO_OPTIMIZER,
+  ::com::rdk::hal::audiomixer::AQParameter::ACTIVE_DOWNMIX,
+  ::com::rdk::hal::audiomixer::AQParameter::CENTER_SPREADING,
+  ::com::rdk::hal::audiomixer::AQParameter::DRC,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/AQProcessor.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/AQProcessor.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class AQProcessor : int32_t {
+  UNDEFINED = 0,
+  DOLBY_MS12 = 1,
+  DTS_ULTRA = 2,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(AQProcessor val) {
+  switch(val) {
+  case AQProcessor::UNDEFINED:
+    return "UNDEFINED";
+  case AQProcessor::DOLBY_MS12:
+    return "DOLBY_MS12";
+  case AQProcessor::DTS_ULTRA:
+    return "DTS_ULTRA";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::AQProcessor, 3> enum_values<::com::rdk::hal::audiomixer::AQProcessor> = {
+  ::com::rdk::hal::audiomixer::AQProcessor::UNDEFINED,
+  ::com::rdk::hal::audiomixer::AQProcessor::DOLBY_MS12,
+  ::com::rdk::hal::audiomixer::AQProcessor::DTS_ULTRA,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/AudioSourceType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/AudioSourceType.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class AudioSourceType : int32_t {
+  NONE = 0,
+  AUDIO_SINK = 1,
+  HDMI_INPUT = 2,
+  COMPOSITE_INPUT = 3,
+  APPLICATION_AUDIO = 4,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(AudioSourceType val) {
+  switch(val) {
+  case AudioSourceType::NONE:
+    return "NONE";
+  case AudioSourceType::AUDIO_SINK:
+    return "AUDIO_SINK";
+  case AudioSourceType::HDMI_INPUT:
+    return "HDMI_INPUT";
+  case AudioSourceType::COMPOSITE_INPUT:
+    return "COMPOSITE_INPUT";
+  case AudioSourceType::APPLICATION_AUDIO:
+    return "APPLICATION_AUDIO";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::AudioSourceType, 5> enum_values<::com::rdk::hal::audiomixer::AudioSourceType> = {
+  ::com::rdk::hal::audiomixer::AudioSourceType::NONE,
+  ::com::rdk::hal::audiomixer::AudioSourceType::AUDIO_SINK,
+  ::com::rdk::hal::audiomixer::AudioSourceType::HDMI_INPUT,
+  ::com::rdk::hal::audiomixer::AudioSourceType::COMPOSITE_INPUT,
+  ::com::rdk::hal::audiomixer::AudioSourceType::APPLICATION_AUDIO,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAQParameter.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAQParameter.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAQProcessor.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAQProcessor.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixer.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixer.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioMixer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioMixer : public ::android::BnInterface<IAudioMixer> {
+public:
+  static constexpr uint32_t TRANSACTION_getAudioOutputPortIds = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_getAudioOutputPort = ::android::IBinder::FIRST_CALL_TRANSACTION + 1;
+  static constexpr uint32_t TRANSACTION_getCapabilities = ::android::IBinder::FIRST_CALL_TRANSACTION + 2;
+  static constexpr uint32_t TRANSACTION_getProperty = ::android::IBinder::FIRST_CALL_TRANSACTION + 3;
+  static constexpr uint32_t TRANSACTION_open = ::android::IBinder::FIRST_CALL_TRANSACTION + 4;
+  static constexpr uint32_t TRANSACTION_close = ::android::IBinder::FIRST_CALL_TRANSACTION + 5;
+  static constexpr uint32_t TRANSACTION_registerListener = ::android::IBinder::FIRST_CALL_TRANSACTION + 6;
+  static constexpr uint32_t TRANSACTION_unregisterListener = ::android::IBinder::FIRST_CALL_TRANSACTION + 7;
+  static constexpr uint32_t TRANSACTION_getCurrentSourceCodecs = ::android::IBinder::FIRST_CALL_TRANSACTION + 8;
+  static constexpr uint32_t TRANSACTION_getInputRouting = ::android::IBinder::FIRST_CALL_TRANSACTION + 9;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioMixer();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioMixer
+
+class IAudioMixerDelegator : public BnAudioMixer {
+public:
+  explicit IAudioMixerDelegator(::android::sp<IAudioMixer> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status getAudioOutputPortIds(::std::vector<int32_t>* _aidl_return) override {
+    return _aidl_delegate->getAudioOutputPortIds(_aidl_return);
+  }
+  ::android::binder::Status getAudioOutputPort(int32_t id, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPort>* _aidl_return) override {
+    return _aidl_delegate->getAudioOutputPort(id, _aidl_return);
+  }
+  ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::Capabilities* _aidl_return) override {
+    return _aidl_delegate->getCapabilities(_aidl_return);
+  }
+  ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::Property property, ::com::rdk::hal::PropertyValue* _aidl_return) override {
+    return _aidl_delegate->getProperty(property, _aidl_return);
+  }
+  ::android::binder::Status open(bool secure, const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& audioMixerEventListener, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>* _aidl_return) override {
+    return _aidl_delegate->open(secure, audioMixerEventListener, _aidl_return);
+  }
+  ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>& audioMixerController, bool* _aidl_return) override {
+    return _aidl_delegate->close(audioMixerController, _aidl_return);
+  }
+  ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) override {
+    return _aidl_delegate->registerListener(listener);
+  }
+  ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) override {
+    return _aidl_delegate->unregisterListener(listener);
+  }
+  ::android::binder::Status getCurrentSourceCodecs(::std::vector<::com::rdk::hal::audiodecoder::Codec>* _aidl_return) override {
+    return _aidl_delegate->getCurrentSourceCodecs(_aidl_return);
+  }
+  ::android::binder::Status getInputRouting(::std::vector<::com::rdk::hal::audiomixer::InputRouting>* _aidl_return) override {
+    return _aidl_delegate->getInputRouting(_aidl_return);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioMixer::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioMixer> _aidl_delegate;
+};  // class IAudioMixerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixerController.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixerController.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerController.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioMixerController : public ::android::BnInterface<IAudioMixerController> {
+public:
+  static constexpr uint32_t TRANSACTION_setInputRouting = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_setProperty = ::android::IBinder::FIRST_CALL_TRANSACTION + 1;
+  static constexpr uint32_t TRANSACTION_start = ::android::IBinder::FIRST_CALL_TRANSACTION + 2;
+  static constexpr uint32_t TRANSACTION_stop = ::android::IBinder::FIRST_CALL_TRANSACTION + 3;
+  static constexpr uint32_t TRANSACTION_flush = ::android::IBinder::FIRST_CALL_TRANSACTION + 4;
+  static constexpr uint32_t TRANSACTION_signalDiscontinuity = ::android::IBinder::FIRST_CALL_TRANSACTION + 5;
+  static constexpr uint32_t TRANSACTION_signalEOS = ::android::IBinder::FIRST_CALL_TRANSACTION + 6;
+  static constexpr uint32_t TRANSACTION_setInputVolume = ::android::IBinder::FIRST_CALL_TRANSACTION + 7;
+  static constexpr uint32_t TRANSACTION_getInputVolume = ::android::IBinder::FIRST_CALL_TRANSACTION + 8;
+  static constexpr uint32_t TRANSACTION_setInputVolumeRamp = ::android::IBinder::FIRST_CALL_TRANSACTION + 9;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioMixerController();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioMixerController
+
+class IAudioMixerControllerDelegator : public BnAudioMixerController {
+public:
+  explicit IAudioMixerControllerDelegator(::android::sp<IAudioMixerController> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status setInputRouting(const ::std::vector<::com::rdk::hal::audiomixer::InputRouting>& routing, bool* _aidl_return) override {
+    return _aidl_delegate->setInputRouting(routing, _aidl_return);
+  }
+  ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::Property property, const ::com::rdk::hal::PropertyValue& propertyValue, bool* _aidl_return) override {
+    return _aidl_delegate->setProperty(property, propertyValue, _aidl_return);
+  }
+  ::android::binder::Status start() override {
+    return _aidl_delegate->start();
+  }
+  ::android::binder::Status stop() override {
+    return _aidl_delegate->stop();
+  }
+  ::android::binder::Status flush(bool reset) override {
+    return _aidl_delegate->flush(reset);
+  }
+  ::android::binder::Status signalDiscontinuity() override {
+    return _aidl_delegate->signalDiscontinuity();
+  }
+  ::android::binder::Status signalEOS() override {
+    return _aidl_delegate->signalEOS();
+  }
+  ::android::binder::Status setInputVolume(int32_t inputIndex, int32_t volume, bool* _aidl_return) override {
+    return _aidl_delegate->setInputVolume(inputIndex, volume, _aidl_return);
+  }
+  ::android::binder::Status getInputVolume(int32_t inputIndex, int32_t* _aidl_return) override {
+    return _aidl_delegate->getInputVolume(inputIndex, _aidl_return);
+  }
+  ::android::binder::Status setInputVolumeRamp(int32_t inputIndex, int32_t targetVolume, int32_t overMs, ::com::rdk::hal::audiosink::VolumeRamp curve, bool* _aidl_return) override {
+    return _aidl_delegate->setInputVolumeRamp(inputIndex, targetVolume, overMs, curve, _aidl_return);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioMixerController::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioMixerController> _aidl_delegate;
+};  // class IAudioMixerControllerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixerEventListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixerEventListener.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerEventListener.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioMixerEventListener : public ::android::BnInterface<IAudioMixerEventListener> {
+public:
+  static constexpr uint32_t TRANSACTION_onInputCodecChanged = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_onError = ::android::IBinder::FIRST_CALL_TRANSACTION + 1;
+  static constexpr uint32_t TRANSACTION_onStateChanged = ::android::IBinder::FIRST_CALL_TRANSACTION + 2;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioMixerEventListener();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioMixerEventListener
+
+class IAudioMixerEventListenerDelegator : public BnAudioMixerEventListener {
+public:
+  explicit IAudioMixerEventListenerDelegator(::android::sp<IAudioMixerEventListener> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status onInputCodecChanged(int32_t audioMixerInputIndex, ::com::rdk::hal::audiodecoder::Codec codec, ::com::rdk::hal::audiomixer::ContentType contentType) override {
+    return _aidl_delegate->onInputCodecChanged(audioMixerInputIndex, codec, contentType);
+  }
+  ::android::binder::Status onError(int32_t errorCode, const ::android::String16& message) override {
+    return _aidl_delegate->onError(errorCode, message);
+  }
+  ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) override {
+    return _aidl_delegate->onStateChanged(oldState, newState);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioMixerEventListener::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioMixerEventListener> _aidl_delegate;
+};  // class IAudioMixerEventListenerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixerManager.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioMixerManager.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerManager.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioMixerManager : public ::android::BnInterface<IAudioMixerManager> {
+public:
+  static constexpr uint32_t TRANSACTION_getAudioMixerIds = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_getAudioMixer = ::android::IBinder::FIRST_CALL_TRANSACTION + 1;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioMixerManager();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioMixerManager
+
+class IAudioMixerManagerDelegator : public BnAudioMixerManager {
+public:
+  explicit IAudioMixerManagerDelegator(::android::sp<IAudioMixerManager> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status getAudioMixerIds(::std::vector<::com::rdk::hal::audiomixer::IAudioMixer::Id>* _aidl_return) override {
+    return _aidl_delegate->getAudioMixerIds(_aidl_return);
+  }
+  ::android::binder::Status getAudioMixer(::com::rdk::hal::audiomixer::IAudioMixer::Id id, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixer>* _aidl_return) override {
+    return _aidl_delegate->getAudioMixer(id, _aidl_return);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioMixerManager::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioMixerManager> _aidl_delegate;
+};  // class IAudioMixerManagerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPort.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPort.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPort.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioOutputPort : public ::android::BnInterface<IAudioOutputPort> {
+public:
+  static constexpr uint32_t TRANSACTION_getCapabilities = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_getState = ::android::IBinder::FIRST_CALL_TRANSACTION + 1;
+  static constexpr uint32_t TRANSACTION_getProperty = ::android::IBinder::FIRST_CALL_TRANSACTION + 2;
+  static constexpr uint32_t TRANSACTION_open = ::android::IBinder::FIRST_CALL_TRANSACTION + 3;
+  static constexpr uint32_t TRANSACTION_close = ::android::IBinder::FIRST_CALL_TRANSACTION + 4;
+  static constexpr uint32_t TRANSACTION_registerListener = ::android::IBinder::FIRST_CALL_TRANSACTION + 5;
+  static constexpr uint32_t TRANSACTION_unregisterListener = ::android::IBinder::FIRST_CALL_TRANSACTION + 6;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioOutputPort();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioOutputPort
+
+class IAudioOutputPortDelegator : public BnAudioOutputPort {
+public:
+  explicit IAudioOutputPortDelegator(::android::sp<IAudioOutputPort> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::OutputPortCapabilities* _aidl_return) override {
+    return _aidl_delegate->getCapabilities(_aidl_return);
+  }
+  ::android::binder::Status getState(::com::rdk::hal::audiomixer::State* _aidl_return) override {
+    return _aidl_delegate->getState(_aidl_return);
+  }
+  ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, ::com::rdk::hal::PropertyValue* _aidl_return) override {
+    return _aidl_delegate->getProperty(property, _aidl_return);
+  }
+  ::android::binder::Status open(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortControllerListener>& listener, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>* _aidl_return) override {
+    return _aidl_delegate->open(listener, _aidl_return);
+  }
+  ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>& controller, bool* _aidl_return) override {
+    return _aidl_delegate->close(controller, _aidl_return);
+  }
+  ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) override {
+    return _aidl_delegate->registerListener(listener);
+  }
+  ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) override {
+    return _aidl_delegate->unregisterListener(listener);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioOutputPort::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioOutputPort> _aidl_delegate;
+};  // class IAudioOutputPortDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPortController.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPortController.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortController.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioOutputPortController : public ::android::BnInterface<IAudioOutputPortController> {
+public:
+  static constexpr uint32_t TRANSACTION_setProperty = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioOutputPortController();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioOutputPortController
+
+class IAudioOutputPortControllerDelegator : public BnAudioOutputPortController {
+public:
+  explicit IAudioOutputPortControllerDelegator(::android::sp<IAudioOutputPortController> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& value, bool* _aidl_return) override {
+    return _aidl_delegate->setProperty(property, value, _aidl_return);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioOutputPortController::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioOutputPortController> _aidl_delegate;
+};  // class IAudioOutputPortControllerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPortControllerListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPortControllerListener.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioOutputPortControllerListener : public ::android::BnInterface<IAudioOutputPortControllerListener> {
+public:
+  static constexpr uint32_t TRANSACTION_onStateChanged = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioOutputPortControllerListener();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioOutputPortControllerListener
+
+class IAudioOutputPortControllerListenerDelegator : public BnAudioOutputPortControllerListener {
+public:
+  explicit IAudioOutputPortControllerListenerDelegator(::android::sp<IAudioOutputPortControllerListener> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) override {
+    return _aidl_delegate->onStateChanged(oldState, newState);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioOutputPortControllerListener::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioOutputPortControllerListener> _aidl_delegate;
+};  // class IAudioOutputPortControllerListenerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPortListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioOutputPortListener.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <binder/IInterface.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortListener.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BnAudioOutputPortListener : public ::android::BnInterface<IAudioOutputPortListener> {
+public:
+  static constexpr uint32_t TRANSACTION_onPropertyChanged = ::android::IBinder::FIRST_CALL_TRANSACTION + 0;
+  static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
+  static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
+  explicit BnAudioOutputPortListener();
+  ::android::status_t onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) override;
+  int32_t getInterfaceVersion();
+  std::string getInterfaceHash();
+};  // class BnAudioOutputPortListener
+
+class IAudioOutputPortListenerDelegator : public BnAudioOutputPortListener {
+public:
+  explicit IAudioOutputPortListenerDelegator(::android::sp<IAudioOutputPortListener> &impl) : _aidl_delegate(impl) {}
+
+  ::android::binder::Status onPropertyChanged(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& newValue) override {
+    return _aidl_delegate->onPropertyChanged(property, newValue);
+  }
+  int32_t getInterfaceVersion() override {
+    int32_t _delegator_ver = BnAudioOutputPortListener::getInterfaceVersion();
+    int32_t _impl_ver = _aidl_delegate->getInterfaceVersion();
+    return _delegator_ver < _impl_ver ? _delegator_ver : _impl_ver;
+  }
+  std::string getInterfaceHash() override {
+    return _aidl_delegate->getInterfaceHash();
+  }
+private:
+  ::android::sp<IAudioOutputPortListener> _aidl_delegate;
+};  // class IAudioOutputPortListenerDelegator
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioSourceType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnAudioSourceType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnCapabilities.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnCapabilities.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnConnectionState.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnConnectionState.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnContentType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnContentType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnInputRouting.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnInputRouting.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnMixerInput.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnMixerInput.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnMixingMode.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnMixingMode.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputFormat.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputFormat.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputPortCapabilities.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputPortCapabilities.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputPortProperty.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputPortProperty.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputPortType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnOutputPortType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnProperty.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnProperty.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnState.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnState.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BnTranscodeFormat.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BnTranscodeFormat.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bn classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAQParameter.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAQParameter.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAQProcessor.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAQProcessor.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixer.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixer.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioMixer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioMixer : public ::android::BpInterface<IAudioMixer> {
+public:
+  explicit BpAudioMixer(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioMixer() = default;
+  ::android::binder::Status getAudioOutputPortIds(::std::vector<int32_t>* _aidl_return) override;
+  ::android::binder::Status getAudioOutputPort(int32_t id, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPort>* _aidl_return) override;
+  ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::Capabilities* _aidl_return) override;
+  ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::Property property, ::com::rdk::hal::PropertyValue* _aidl_return) override;
+  ::android::binder::Status open(bool secure, const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& audioMixerEventListener, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>* _aidl_return) override;
+  ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>& audioMixerController, bool* _aidl_return) override;
+  ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) override;
+  ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) override;
+  ::android::binder::Status getCurrentSourceCodecs(::std::vector<::com::rdk::hal::audiodecoder::Codec>* _aidl_return) override;
+  ::android::binder::Status getInputRouting(::std::vector<::com::rdk::hal::audiomixer::InputRouting>* _aidl_return) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioMixer
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixerController.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixerController.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerController.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioMixerController : public ::android::BpInterface<IAudioMixerController> {
+public:
+  explicit BpAudioMixerController(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioMixerController() = default;
+  ::android::binder::Status setInputRouting(const ::std::vector<::com::rdk::hal::audiomixer::InputRouting>& routing, bool* _aidl_return) override;
+  ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::Property property, const ::com::rdk::hal::PropertyValue& propertyValue, bool* _aidl_return) override;
+  ::android::binder::Status start() override;
+  ::android::binder::Status stop() override;
+  ::android::binder::Status flush(bool reset) override;
+  ::android::binder::Status signalDiscontinuity() override;
+  ::android::binder::Status signalEOS() override;
+  ::android::binder::Status setInputVolume(int32_t inputIndex, int32_t volume, bool* _aidl_return) override;
+  ::android::binder::Status getInputVolume(int32_t inputIndex, int32_t* _aidl_return) override;
+  ::android::binder::Status setInputVolumeRamp(int32_t inputIndex, int32_t targetVolume, int32_t overMs, ::com::rdk::hal::audiosink::VolumeRamp curve, bool* _aidl_return) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioMixerController
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixerEventListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixerEventListener.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerEventListener.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioMixerEventListener : public ::android::BpInterface<IAudioMixerEventListener> {
+public:
+  explicit BpAudioMixerEventListener(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioMixerEventListener() = default;
+  ::android::binder::Status onInputCodecChanged(int32_t audioMixerInputIndex, ::com::rdk::hal::audiodecoder::Codec codec, ::com::rdk::hal::audiomixer::ContentType contentType) override;
+  ::android::binder::Status onError(int32_t errorCode, const ::android::String16& message) override;
+  ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioMixerEventListener
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixerManager.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioMixerManager.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerManager.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioMixerManager : public ::android::BpInterface<IAudioMixerManager> {
+public:
+  explicit BpAudioMixerManager(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioMixerManager() = default;
+  ::android::binder::Status getAudioMixerIds(::std::vector<::com::rdk::hal::audiomixer::IAudioMixer::Id>* _aidl_return) override;
+  ::android::binder::Status getAudioMixer(::com::rdk::hal::audiomixer::IAudioMixer::Id id, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixer>* _aidl_return) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioMixerManager
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPort.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPort.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPort.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioOutputPort : public ::android::BpInterface<IAudioOutputPort> {
+public:
+  explicit BpAudioOutputPort(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioOutputPort() = default;
+  ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::OutputPortCapabilities* _aidl_return) override;
+  ::android::binder::Status getState(::com::rdk::hal::audiomixer::State* _aidl_return) override;
+  ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, ::com::rdk::hal::PropertyValue* _aidl_return) override;
+  ::android::binder::Status open(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortControllerListener>& listener, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>* _aidl_return) override;
+  ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>& controller, bool* _aidl_return) override;
+  ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) override;
+  ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioOutputPort
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPortController.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPortController.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortController.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioOutputPortController : public ::android::BpInterface<IAudioOutputPortController> {
+public:
+  explicit BpAudioOutputPortController(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioOutputPortController() = default;
+  ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& value, bool* _aidl_return) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioOutputPortController
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPortControllerListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPortControllerListener.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioOutputPortControllerListener : public ::android::BpInterface<IAudioOutputPortControllerListener> {
+public:
+  explicit BpAudioOutputPortControllerListener(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioOutputPortControllerListener() = default;
+  ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioOutputPortControllerListener
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPortListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioOutputPortListener.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <mutex>
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <utils/Errors.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortListener.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class BpAudioOutputPortListener : public ::android::BpInterface<IAudioOutputPortListener> {
+public:
+  explicit BpAudioOutputPortListener(const ::android::sp<::android::IBinder>& _aidl_impl);
+  virtual ~BpAudioOutputPortListener() = default;
+  ::android::binder::Status onPropertyChanged(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& newValue) override;
+  int32_t getInterfaceVersion() override;
+  std::string getInterfaceHash() override;
+private:
+  int32_t cached_version_ = -1;
+  std::string cached_hash_ = "-1";
+  std::mutex cached_hash_mutex_;
+};  // class BpAudioOutputPortListener
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioSourceType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpAudioSourceType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpCapabilities.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpCapabilities.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpConnectionState.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpConnectionState.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpContentType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpContentType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpInputRouting.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpInputRouting.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpMixerInput.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpMixerInput.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpMixingMode.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpMixingMode.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputFormat.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputFormat.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputPortCapabilities.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputPortCapabilities.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputPortProperty.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputPortProperty.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputPortType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpOutputPortType.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpProperty.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpProperty.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpState.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpState.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/BpTranscodeFormat.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/BpTranscodeFormat.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) enums do not have bp classes

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/Capabilities.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/Capabilities.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiomixer/MixerInput.h>
+#include <optional>
+#include <tuple>
+#include <utils/String16.h>
+#include <vector>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class Capabilities : public ::android::Parcelable {
+public:
+  bool supportsSecure = false;
+  ::std::vector<::com::rdk::hal::audiomixer::MixerInput> inputs;
+  ::std::optional<::android::String16> name;
+  inline bool operator!=(const Capabilities& rhs) const {
+    return std::tie(supportsSecure, inputs, name) != std::tie(rhs.supportsSecure, rhs.inputs, rhs.name);
+  }
+  inline bool operator<(const Capabilities& rhs) const {
+    return std::tie(supportsSecure, inputs, name) < std::tie(rhs.supportsSecure, rhs.inputs, rhs.name);
+  }
+  inline bool operator<=(const Capabilities& rhs) const {
+    return std::tie(supportsSecure, inputs, name) <= std::tie(rhs.supportsSecure, rhs.inputs, rhs.name);
+  }
+  inline bool operator==(const Capabilities& rhs) const {
+    return std::tie(supportsSecure, inputs, name) == std::tie(rhs.supportsSecure, rhs.inputs, rhs.name);
+  }
+  inline bool operator>(const Capabilities& rhs) const {
+    return std::tie(supportsSecure, inputs, name) > std::tie(rhs.supportsSecure, rhs.inputs, rhs.name);
+  }
+  inline bool operator>=(const Capabilities& rhs) const {
+    return std::tie(supportsSecure, inputs, name) >= std::tie(rhs.supportsSecure, rhs.inputs, rhs.name);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.audiomixer.Capabilities");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "Capabilities{";
+    os << "supportsSecure: " << ::android::internal::ToString(supportsSecure);
+    os << ", inputs: " << ::android::internal::ToString(inputs);
+    os << ", name: " << ::android::internal::ToString(name);
+    os << "}";
+    return os.str();
+  }
+};  // class Capabilities
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/ConnectionState.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/ConnectionState.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class ConnectionState : int32_t {
+  UNKNOWN = 0,
+  DISCONNECTED = 1,
+  CONNECTED = 2,
+  PENDING = 3,
+  FAULT = 4,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(ConnectionState val) {
+  switch(val) {
+  case ConnectionState::UNKNOWN:
+    return "UNKNOWN";
+  case ConnectionState::DISCONNECTED:
+    return "DISCONNECTED";
+  case ConnectionState::CONNECTED:
+    return "CONNECTED";
+  case ConnectionState::PENDING:
+    return "PENDING";
+  case ConnectionState::FAULT:
+    return "FAULT";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::ConnectionState, 5> enum_values<::com::rdk::hal::audiomixer::ConnectionState> = {
+  ::com::rdk::hal::audiomixer::ConnectionState::UNKNOWN,
+  ::com::rdk::hal::audiomixer::ConnectionState::DISCONNECTED,
+  ::com::rdk::hal::audiomixer::ConnectionState::CONNECTED,
+  ::com::rdk::hal::audiomixer::ConnectionState::PENDING,
+  ::com::rdk::hal::audiomixer::ConnectionState::FAULT,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/ContentType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/ContentType.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class ContentType : int32_t {
+  UNDEFINED = -1,
+  CLIP = 0,
+  STREAM = 1,
+  TTS = 2,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(ContentType val) {
+  switch(val) {
+  case ContentType::UNDEFINED:
+    return "UNDEFINED";
+  case ContentType::CLIP:
+    return "CLIP";
+  case ContentType::STREAM:
+    return "STREAM";
+  case ContentType::TTS:
+    return "TTS";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::ContentType, 4> enum_values<::com::rdk::hal::audiomixer::ContentType> = {
+  ::com::rdk::hal::audiomixer::ContentType::UNDEFINED,
+  ::com::rdk::hal::audiomixer::ContentType::CLIP,
+  ::com::rdk::hal::audiomixer::ContentType::STREAM,
+  ::com::rdk::hal::audiomixer::ContentType::TTS,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixer.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixer.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/PropertyValue.h>
+#include <com/rdk/hal/audiodecoder/Codec.h>
+#include <com/rdk/hal/audiomixer/Capabilities.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerController.h>
+#include <com/rdk/hal/audiomixer/IAudioMixerEventListener.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPort.h>
+#include <com/rdk/hal/audiomixer/InputRouting.h>
+#include <com/rdk/hal/audiomixer/Property.h>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+#include <vector>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioMixer : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioMixer)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  enum class Id : int32_t {
+    MIXER_SYSTEM = 0,
+    MIX1 = 1,
+    MIX2 = 2,
+    MIX3 = 3,
+    MIX4 = 4,
+    MIX5 = 5,
+  };
+  virtual ::android::binder::Status getAudioOutputPortIds(::std::vector<int32_t>* _aidl_return) = 0;
+  virtual ::android::binder::Status getAudioOutputPort(int32_t id, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPort>* _aidl_return) = 0;
+  virtual ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::Capabilities* _aidl_return) = 0;
+  virtual ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::Property property, ::com::rdk::hal::PropertyValue* _aidl_return) = 0;
+  virtual ::android::binder::Status open(bool secure, const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& audioMixerEventListener, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>* _aidl_return) = 0;
+  virtual ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>& audioMixerController, bool* _aidl_return) = 0;
+  virtual ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) = 0;
+  virtual ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) = 0;
+  virtual ::android::binder::Status getCurrentSourceCodecs(::std::vector<::com::rdk::hal::audiodecoder::Codec>* _aidl_return) = 0;
+  virtual ::android::binder::Status getInputRouting(::std::vector<::com::rdk::hal::audiomixer::InputRouting>* _aidl_return) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioMixer
+
+class IAudioMixerDefault : public IAudioMixer {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status getAudioOutputPortIds(::std::vector<int32_t>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getAudioOutputPort(int32_t /*id*/, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPort>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::Capabilities* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::Property /*property*/, ::com::rdk::hal::PropertyValue* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status open(bool /*secure*/, const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& /*audioMixerEventListener*/, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>& /*audioMixerController*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& /*listener*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& /*listener*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getCurrentSourceCodecs(::std::vector<::com::rdk::hal::audiodecoder::Codec>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getInputRouting(::std::vector<::com::rdk::hal::audiomixer::InputRouting>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioMixerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(IAudioMixer::Id val) {
+  switch(val) {
+  case IAudioMixer::Id::MIXER_SYSTEM:
+    return "MIXER_SYSTEM";
+  case IAudioMixer::Id::MIX1:
+    return "MIX1";
+  case IAudioMixer::Id::MIX2:
+    return "MIX2";
+  case IAudioMixer::Id::MIX3:
+    return "MIX3";
+  case IAudioMixer::Id::MIX4:
+    return "MIX4";
+  case IAudioMixer::Id::MIX5:
+    return "MIX5";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::IAudioMixer::Id, 6> enum_values<::com::rdk::hal::audiomixer::IAudioMixer::Id> = {
+  ::com::rdk::hal::audiomixer::IAudioMixer::Id::MIXER_SYSTEM,
+  ::com::rdk::hal::audiomixer::IAudioMixer::Id::MIX1,
+  ::com::rdk::hal::audiomixer::IAudioMixer::Id::MIX2,
+  ::com::rdk::hal::audiomixer::IAudioMixer::Id::MIX3,
+  ::com::rdk::hal::audiomixer::IAudioMixer::Id::MIX4,
+  ::com::rdk::hal::audiomixer::IAudioMixer::Id::MIX5,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixerController.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixerController.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/PropertyValue.h>
+#include <com/rdk/hal/audiomixer/InputRouting.h>
+#include <com/rdk/hal/audiomixer/Property.h>
+#include <com/rdk/hal/audiosink/VolumeRamp.h>
+#include <cstdint>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+#include <vector>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioMixerController : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioMixerController)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  virtual ::android::binder::Status setInputRouting(const ::std::vector<::com::rdk::hal::audiomixer::InputRouting>& routing, bool* _aidl_return) = 0;
+  virtual ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::Property property, const ::com::rdk::hal::PropertyValue& propertyValue, bool* _aidl_return) = 0;
+  virtual ::android::binder::Status start() = 0;
+  virtual ::android::binder::Status stop() = 0;
+  virtual ::android::binder::Status flush(bool reset) = 0;
+  virtual ::android::binder::Status signalDiscontinuity() = 0;
+  virtual ::android::binder::Status signalEOS() = 0;
+  virtual ::android::binder::Status setInputVolume(int32_t inputIndex, int32_t volume, bool* _aidl_return) = 0;
+  virtual ::android::binder::Status getInputVolume(int32_t inputIndex, int32_t* _aidl_return) = 0;
+  virtual ::android::binder::Status setInputVolumeRamp(int32_t inputIndex, int32_t targetVolume, int32_t overMs, ::com::rdk::hal::audiosink::VolumeRamp curve, bool* _aidl_return) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioMixerController
+
+class IAudioMixerControllerDefault : public IAudioMixerController {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status setInputRouting(const ::std::vector<::com::rdk::hal::audiomixer::InputRouting>& /*routing*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::Property /*property*/, const ::com::rdk::hal::PropertyValue& /*propertyValue*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status start() override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status stop() override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status flush(bool /*reset*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status signalDiscontinuity() override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status signalEOS() override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status setInputVolume(int32_t /*inputIndex*/, int32_t /*volume*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getInputVolume(int32_t /*inputIndex*/, int32_t* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status setInputVolumeRamp(int32_t /*inputIndex*/, int32_t /*targetVolume*/, int32_t /*overMs*/, ::com::rdk::hal::audiosink::VolumeRamp /*curve*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioMixerControllerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixerEventListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixerEventListener.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiodecoder/Codec.h>
+#include <com/rdk/hal/audiomixer/ContentType.h>
+#include <com/rdk/hal/audiomixer/State.h>
+#include <cstdint>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioMixerEventListener : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioMixerEventListener)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  virtual ::android::binder::Status onInputCodecChanged(int32_t audioMixerInputIndex, ::com::rdk::hal::audiodecoder::Codec codec, ::com::rdk::hal::audiomixer::ContentType contentType) = 0;
+  virtual ::android::binder::Status onError(int32_t errorCode, const ::android::String16& message) = 0;
+  virtual ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioMixerEventListener
+
+class IAudioMixerEventListenerDefault : public IAudioMixerEventListener {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status onInputCodecChanged(int32_t /*audioMixerInputIndex*/, ::com::rdk::hal::audiodecoder::Codec /*codec*/, ::com::rdk::hal::audiomixer::ContentType /*contentType*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status onError(int32_t /*errorCode*/, const ::android::String16& /*message*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State /*oldState*/, ::com::rdk::hal::audiomixer::State /*newState*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioMixerEventListenerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixerManager.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioMixerManager.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiomixer/IAudioMixer.h>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+#include <vector>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioMixerManager : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioMixerManager)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  static const ::std::string& serviceName();
+  virtual ::android::binder::Status getAudioMixerIds(::std::vector<::com::rdk::hal::audiomixer::IAudioMixer::Id>* _aidl_return) = 0;
+  virtual ::android::binder::Status getAudioMixer(::com::rdk::hal::audiomixer::IAudioMixer::Id id, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixer>* _aidl_return) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioMixerManager
+
+class IAudioMixerManagerDefault : public IAudioMixerManager {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status getAudioMixerIds(::std::vector<::com::rdk::hal::audiomixer::IAudioMixer::Id>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getAudioMixer(::com::rdk::hal::audiomixer::IAudioMixer::Id /*id*/, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixer>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioMixerManagerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPort.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPort.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/PropertyValue.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortController.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.h>
+#include <com/rdk/hal/audiomixer/IAudioOutputPortListener.h>
+#include <com/rdk/hal/audiomixer/OutputPortCapabilities.h>
+#include <com/rdk/hal/audiomixer/OutputPortProperty.h>
+#include <com/rdk/hal/audiomixer/State.h>
+#include <cstdint>
+#include <optional>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioOutputPort : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioOutputPort)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  virtual ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::OutputPortCapabilities* _aidl_return) = 0;
+  virtual ::android::binder::Status getState(::com::rdk::hal::audiomixer::State* _aidl_return) = 0;
+  virtual ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, ::com::rdk::hal::PropertyValue* _aidl_return) = 0;
+  virtual ::android::binder::Status open(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortControllerListener>& listener, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>* _aidl_return) = 0;
+  virtual ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>& controller, bool* _aidl_return) = 0;
+  virtual ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) = 0;
+  virtual ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioOutputPort
+
+class IAudioOutputPortDefault : public IAudioOutputPort {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status getCapabilities(::com::rdk::hal::audiomixer::OutputPortCapabilities* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getState(::com::rdk::hal::audiomixer::State* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status getProperty(::com::rdk::hal::audiomixer::OutputPortProperty /*property*/, ::com::rdk::hal::PropertyValue* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status open(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortControllerListener>& /*listener*/, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>& /*controller*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& /*listener*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  ::android::binder::Status unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& /*listener*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioOutputPortDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPortController.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPortController.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/PropertyValue.h>
+#include <com/rdk/hal/audiomixer/OutputPortProperty.h>
+#include <cstdint>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioOutputPortController : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioOutputPortController)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  virtual ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& value, bool* _aidl_return) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioOutputPortController
+
+class IAudioOutputPortControllerDefault : public IAudioOutputPortController {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status setProperty(::com::rdk::hal::audiomixer::OutputPortProperty /*property*/, const ::com::rdk::hal::PropertyValue& /*value*/, bool* /*_aidl_return*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioOutputPortControllerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiomixer/State.h>
+#include <cstdint>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioOutputPortControllerListener : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioOutputPortControllerListener)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  virtual ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioOutputPortControllerListener
+
+class IAudioOutputPortControllerListenerDefault : public IAudioOutputPortControllerListener {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status onStateChanged(::com::rdk::hal::audiomixer::State /*oldState*/, ::com::rdk::hal::audiomixer::State /*newState*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioOutputPortControllerListenerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPortListener.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/IAudioOutputPortListener.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <binder/IBinder.h>
+#include <binder/IInterface.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/PropertyValue.h>
+#include <com/rdk/hal/audiomixer/OutputPortProperty.h>
+#include <cstdint>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class IAudioOutputPortListener : public ::android::IInterface {
+public:
+  DECLARE_META_INTERFACE(AudioOutputPortListener)
+  static const int32_t VERSION = 1;
+  const std::string HASH = "notfrozen";
+  static constexpr char* HASHVALUE = "notfrozen";
+  virtual ::android::binder::Status onPropertyChanged(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& newValue) = 0;
+  virtual int32_t getInterfaceVersion() = 0;
+  virtual std::string getInterfaceHash() = 0;
+};  // class IAudioOutputPortListener
+
+class IAudioOutputPortListenerDefault : public IAudioOutputPortListener {
+public:
+  ::android::IBinder* onAsBinder() override {
+    return nullptr;
+  }
+  ::android::binder::Status onPropertyChanged(::com::rdk::hal::audiomixer::OutputPortProperty /*property*/, const ::com::rdk::hal::PropertyValue& /*newValue*/) override {
+    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
+  }
+  int32_t getInterfaceVersion() override {
+    return 0;
+  }
+  std::string getInterfaceHash() override {
+    return "";
+  }
+};  // class IAudioOutputPortListenerDefault
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/InputRouting.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/InputRouting.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiomixer/AudioSourceType.h>
+#include <cstdint>
+#include <tuple>
+#include <utils/String16.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class InputRouting : public ::android::Parcelable {
+public:
+  ::com::rdk::hal::audiomixer::AudioSourceType sourceType = ::com::rdk::hal::audiomixer::AudioSourceType(0);
+  int32_t sourceIndex = 0;
+  inline bool operator!=(const InputRouting& rhs) const {
+    return std::tie(sourceType, sourceIndex) != std::tie(rhs.sourceType, rhs.sourceIndex);
+  }
+  inline bool operator<(const InputRouting& rhs) const {
+    return std::tie(sourceType, sourceIndex) < std::tie(rhs.sourceType, rhs.sourceIndex);
+  }
+  inline bool operator<=(const InputRouting& rhs) const {
+    return std::tie(sourceType, sourceIndex) <= std::tie(rhs.sourceType, rhs.sourceIndex);
+  }
+  inline bool operator==(const InputRouting& rhs) const {
+    return std::tie(sourceType, sourceIndex) == std::tie(rhs.sourceType, rhs.sourceIndex);
+  }
+  inline bool operator>(const InputRouting& rhs) const {
+    return std::tie(sourceType, sourceIndex) > std::tie(rhs.sourceType, rhs.sourceIndex);
+  }
+  inline bool operator>=(const InputRouting& rhs) const {
+    return std::tie(sourceType, sourceIndex) >= std::tie(rhs.sourceType, rhs.sourceIndex);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.audiomixer.InputRouting");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "InputRouting{";
+    os << "sourceType: " << ::android::internal::ToString(sourceType);
+    os << ", sourceIndex: " << ::android::internal::ToString(sourceIndex);
+    os << "}";
+    return os.str();
+  }
+};  // class InputRouting
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/MixerInput.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/MixerInput.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiodecoder/Codec.h>
+#include <com/rdk/hal/audiomixer/ContentType.h>
+#include <optional>
+#include <tuple>
+#include <utils/String16.h>
+#include <vector>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class MixerInput : public ::android::Parcelable {
+public:
+  ::std::vector<::com::rdk::hal::audiomixer::ContentType> supportedContentTypes;
+  ::std::vector<::com::rdk::hal::audiodecoder::Codec> supportedCodecs;
+  ::std::optional<::android::String16> name;
+  inline bool operator!=(const MixerInput& rhs) const {
+    return std::tie(supportedContentTypes, supportedCodecs, name) != std::tie(rhs.supportedContentTypes, rhs.supportedCodecs, rhs.name);
+  }
+  inline bool operator<(const MixerInput& rhs) const {
+    return std::tie(supportedContentTypes, supportedCodecs, name) < std::tie(rhs.supportedContentTypes, rhs.supportedCodecs, rhs.name);
+  }
+  inline bool operator<=(const MixerInput& rhs) const {
+    return std::tie(supportedContentTypes, supportedCodecs, name) <= std::tie(rhs.supportedContentTypes, rhs.supportedCodecs, rhs.name);
+  }
+  inline bool operator==(const MixerInput& rhs) const {
+    return std::tie(supportedContentTypes, supportedCodecs, name) == std::tie(rhs.supportedContentTypes, rhs.supportedCodecs, rhs.name);
+  }
+  inline bool operator>(const MixerInput& rhs) const {
+    return std::tie(supportedContentTypes, supportedCodecs, name) > std::tie(rhs.supportedContentTypes, rhs.supportedCodecs, rhs.name);
+  }
+  inline bool operator>=(const MixerInput& rhs) const {
+    return std::tie(supportedContentTypes, supportedCodecs, name) >= std::tie(rhs.supportedContentTypes, rhs.supportedCodecs, rhs.name);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.audiomixer.MixerInput");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "MixerInput{";
+    os << "supportedContentTypes: " << ::android::internal::ToString(supportedContentTypes);
+    os << ", supportedCodecs: " << ::android::internal::ToString(supportedCodecs);
+    os << ", name: " << ::android::internal::ToString(name);
+    os << "}";
+    return os.str();
+  }
+};  // class MixerInput
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/MixingMode.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/MixingMode.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class MixingMode : int32_t {
+  NORMAL = 0,
+  MUTED = 1,
+  DUCKED = 2,
+  SOLO = 3,
+  MIXED_OVERRIDE = 4,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(MixingMode val) {
+  switch(val) {
+  case MixingMode::NORMAL:
+    return "NORMAL";
+  case MixingMode::MUTED:
+    return "MUTED";
+  case MixingMode::DUCKED:
+    return "DUCKED";
+  case MixingMode::SOLO:
+    return "SOLO";
+  case MixingMode::MIXED_OVERRIDE:
+    return "MIXED_OVERRIDE";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::MixingMode, 5> enum_values<::com::rdk::hal::audiomixer::MixingMode> = {
+  ::com::rdk::hal::audiomixer::MixingMode::NORMAL,
+  ::com::rdk::hal::audiomixer::MixingMode::MUTED,
+  ::com::rdk::hal::audiomixer::MixingMode::DUCKED,
+  ::com::rdk::hal::audiomixer::MixingMode::SOLO,
+  ::com::rdk::hal::audiomixer::MixingMode::MIXED_OVERRIDE,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/OutputFormat.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/OutputFormat.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class OutputFormat : int32_t {
+  AUTO = 0,
+  PASSTHROUGH = 1,
+  PCM = 2,
+  AC3 = 3,
+  EAC3 = 4,
+  MAT = 5,
+  TRUEHD = 6,
+  DTS = 7,
+  DTS_HD = 8,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(OutputFormat val) {
+  switch(val) {
+  case OutputFormat::AUTO:
+    return "AUTO";
+  case OutputFormat::PASSTHROUGH:
+    return "PASSTHROUGH";
+  case OutputFormat::PCM:
+    return "PCM";
+  case OutputFormat::AC3:
+    return "AC3";
+  case OutputFormat::EAC3:
+    return "EAC3";
+  case OutputFormat::MAT:
+    return "MAT";
+  case OutputFormat::TRUEHD:
+    return "TRUEHD";
+  case OutputFormat::DTS:
+    return "DTS";
+  case OutputFormat::DTS_HD:
+    return "DTS_HD";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::OutputFormat, 9> enum_values<::com::rdk::hal::audiomixer::OutputFormat> = {
+  ::com::rdk::hal::audiomixer::OutputFormat::AUTO,
+  ::com::rdk::hal::audiomixer::OutputFormat::PASSTHROUGH,
+  ::com::rdk::hal::audiomixer::OutputFormat::PCM,
+  ::com::rdk::hal::audiomixer::OutputFormat::AC3,
+  ::com::rdk::hal::audiomixer::OutputFormat::EAC3,
+  ::com::rdk::hal::audiomixer::OutputFormat::MAT,
+  ::com::rdk::hal::audiomixer::OutputFormat::TRUEHD,
+  ::com::rdk::hal::audiomixer::OutputFormat::DTS,
+  ::com::rdk::hal::audiomixer::OutputFormat::DTS_HD,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/OutputPortCapabilities.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/OutputPortCapabilities.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/audiomixer/AQParameter.h>
+#include <com/rdk/hal/audiomixer/AQProcessor.h>
+#include <com/rdk/hal/audiomixer/OutputFormat.h>
+#include <com/rdk/hal/audiomixer/OutputPortProperty.h>
+#include <com/rdk/hal/audiomixer/OutputPortType.h>
+#include <com/rdk/hal/audiomixer/TranscodeFormat.h>
+#include <tuple>
+#include <utils/String16.h>
+#include <vector>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+class OutputPortCapabilities : public ::android::Parcelable {
+public:
+  ::android::String16 portName;
+  ::com::rdk::hal::audiomixer::OutputPortType portType = ::com::rdk::hal::audiomixer::OutputPortType(0);
+  ::std::vector<::com::rdk::hal::audiomixer::OutputPortProperty> supportedProperties;
+  ::std::vector<::com::rdk::hal::audiomixer::OutputFormat> supportedOutputFormats;
+  ::std::vector<::com::rdk::hal::audiomixer::TranscodeFormat> supportedTranscodeFormats;
+  ::std::vector<::com::rdk::hal::audiomixer::AQProcessor> supportedAQProcessors;
+  ::std::vector<::com::rdk::hal::audiomixer::AQParameter> supportedAQ;
+  inline bool operator!=(const OutputPortCapabilities& rhs) const {
+    return std::tie(portName, portType, supportedProperties, supportedOutputFormats, supportedTranscodeFormats, supportedAQProcessors, supportedAQ) != std::tie(rhs.portName, rhs.portType, rhs.supportedProperties, rhs.supportedOutputFormats, rhs.supportedTranscodeFormats, rhs.supportedAQProcessors, rhs.supportedAQ);
+  }
+  inline bool operator<(const OutputPortCapabilities& rhs) const {
+    return std::tie(portName, portType, supportedProperties, supportedOutputFormats, supportedTranscodeFormats, supportedAQProcessors, supportedAQ) < std::tie(rhs.portName, rhs.portType, rhs.supportedProperties, rhs.supportedOutputFormats, rhs.supportedTranscodeFormats, rhs.supportedAQProcessors, rhs.supportedAQ);
+  }
+  inline bool operator<=(const OutputPortCapabilities& rhs) const {
+    return std::tie(portName, portType, supportedProperties, supportedOutputFormats, supportedTranscodeFormats, supportedAQProcessors, supportedAQ) <= std::tie(rhs.portName, rhs.portType, rhs.supportedProperties, rhs.supportedOutputFormats, rhs.supportedTranscodeFormats, rhs.supportedAQProcessors, rhs.supportedAQ);
+  }
+  inline bool operator==(const OutputPortCapabilities& rhs) const {
+    return std::tie(portName, portType, supportedProperties, supportedOutputFormats, supportedTranscodeFormats, supportedAQProcessors, supportedAQ) == std::tie(rhs.portName, rhs.portType, rhs.supportedProperties, rhs.supportedOutputFormats, rhs.supportedTranscodeFormats, rhs.supportedAQProcessors, rhs.supportedAQ);
+  }
+  inline bool operator>(const OutputPortCapabilities& rhs) const {
+    return std::tie(portName, portType, supportedProperties, supportedOutputFormats, supportedTranscodeFormats, supportedAQProcessors, supportedAQ) > std::tie(rhs.portName, rhs.portType, rhs.supportedProperties, rhs.supportedOutputFormats, rhs.supportedTranscodeFormats, rhs.supportedAQProcessors, rhs.supportedAQ);
+  }
+  inline bool operator>=(const OutputPortCapabilities& rhs) const {
+    return std::tie(portName, portType, supportedProperties, supportedOutputFormats, supportedTranscodeFormats, supportedAQProcessors, supportedAQ) >= std::tie(rhs.portName, rhs.portType, rhs.supportedProperties, rhs.supportedOutputFormats, rhs.supportedTranscodeFormats, rhs.supportedAQProcessors, rhs.supportedAQ);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.audiomixer.OutputPortCapabilities");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "OutputPortCapabilities{";
+    os << "portName: " << ::android::internal::ToString(portName);
+    os << ", portType: " << ::android::internal::ToString(portType);
+    os << ", supportedProperties: " << ::android::internal::ToString(supportedProperties);
+    os << ", supportedOutputFormats: " << ::android::internal::ToString(supportedOutputFormats);
+    os << ", supportedTranscodeFormats: " << ::android::internal::ToString(supportedTranscodeFormats);
+    os << ", supportedAQProcessors: " << ::android::internal::ToString(supportedAQProcessors);
+    os << ", supportedAQ: " << ::android::internal::ToString(supportedAQ);
+    os << "}";
+    return os.str();
+  }
+};  // class OutputPortCapabilities
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/OutputPortProperty.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/OutputPortProperty.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class OutputPortProperty : int32_t {
+  VOLUME = 0,
+  DELAY_MS = 1,
+  MUTE = 2,
+  ENABLED = 3,
+  OUTPUT_FORMAT = 4,
+  SUPPORTED_AUDIO_FORMATS = 5,
+  DOLBY_ATMOS_SUPPORT = 6,
+  STATE = 7,
+  TRANSCODE_FORMAT = 8,
+  CONNECTION_STATE = 9,
+  AQ_PROCESSOR_ID = 10,
+  VENDOR_EXTENSION = 1000,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(OutputPortProperty val) {
+  switch(val) {
+  case OutputPortProperty::VOLUME:
+    return "VOLUME";
+  case OutputPortProperty::DELAY_MS:
+    return "DELAY_MS";
+  case OutputPortProperty::MUTE:
+    return "MUTE";
+  case OutputPortProperty::ENABLED:
+    return "ENABLED";
+  case OutputPortProperty::OUTPUT_FORMAT:
+    return "OUTPUT_FORMAT";
+  case OutputPortProperty::SUPPORTED_AUDIO_FORMATS:
+    return "SUPPORTED_AUDIO_FORMATS";
+  case OutputPortProperty::DOLBY_ATMOS_SUPPORT:
+    return "DOLBY_ATMOS_SUPPORT";
+  case OutputPortProperty::STATE:
+    return "STATE";
+  case OutputPortProperty::TRANSCODE_FORMAT:
+    return "TRANSCODE_FORMAT";
+  case OutputPortProperty::CONNECTION_STATE:
+    return "CONNECTION_STATE";
+  case OutputPortProperty::AQ_PROCESSOR_ID:
+    return "AQ_PROCESSOR_ID";
+  case OutputPortProperty::VENDOR_EXTENSION:
+    return "VENDOR_EXTENSION";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::OutputPortProperty, 12> enum_values<::com::rdk::hal::audiomixer::OutputPortProperty> = {
+  ::com::rdk::hal::audiomixer::OutputPortProperty::VOLUME,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::DELAY_MS,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::MUTE,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::ENABLED,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::OUTPUT_FORMAT,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::SUPPORTED_AUDIO_FORMATS,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::DOLBY_ATMOS_SUPPORT,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::STATE,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::TRANSCODE_FORMAT,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::CONNECTION_STATE,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::AQ_PROCESSOR_ID,
+  ::com::rdk::hal::audiomixer::OutputPortProperty::VENDOR_EXTENSION,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/OutputPortType.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/OutputPortType.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class OutputPortType : int32_t {
+  UNKNOWN = 0,
+  HDMI = 1,
+  SPDIF = 2,
+  OPTICAL = 3,
+  SPEAKERS = 4,
+  BLUETOOTH = 5,
+  ARC = 6,
+  EARC = 7,
+  COMPOSITE = 8,
+  INTERNAL = 1000,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(OutputPortType val) {
+  switch(val) {
+  case OutputPortType::UNKNOWN:
+    return "UNKNOWN";
+  case OutputPortType::HDMI:
+    return "HDMI";
+  case OutputPortType::SPDIF:
+    return "SPDIF";
+  case OutputPortType::OPTICAL:
+    return "OPTICAL";
+  case OutputPortType::SPEAKERS:
+    return "SPEAKERS";
+  case OutputPortType::BLUETOOTH:
+    return "BLUETOOTH";
+  case OutputPortType::ARC:
+    return "ARC";
+  case OutputPortType::EARC:
+    return "EARC";
+  case OutputPortType::COMPOSITE:
+    return "COMPOSITE";
+  case OutputPortType::INTERNAL:
+    return "INTERNAL";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::OutputPortType, 10> enum_values<::com::rdk::hal::audiomixer::OutputPortType> = {
+  ::com::rdk::hal::audiomixer::OutputPortType::UNKNOWN,
+  ::com::rdk::hal::audiomixer::OutputPortType::HDMI,
+  ::com::rdk::hal::audiomixer::OutputPortType::SPDIF,
+  ::com::rdk::hal::audiomixer::OutputPortType::OPTICAL,
+  ::com::rdk::hal::audiomixer::OutputPortType::SPEAKERS,
+  ::com::rdk::hal::audiomixer::OutputPortType::BLUETOOTH,
+  ::com::rdk::hal::audiomixer::OutputPortType::ARC,
+  ::com::rdk::hal::audiomixer::OutputPortType::EARC,
+  ::com::rdk::hal::audiomixer::OutputPortType::COMPOSITE,
+  ::com::rdk::hal::audiomixer::OutputPortType::INTERNAL,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/Property.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/Property.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class Property : int32_t {
+  LATENCY_MS = 0,
+  DEBUG_TAP_ENABLED = 1,
+  ACTIVE_AQ_PROFILE = 2,
+  MIXING_MODE = 3,
+  MUTE = 4,
+  FADER_LEVEL = 5,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(Property val) {
+  switch(val) {
+  case Property::LATENCY_MS:
+    return "LATENCY_MS";
+  case Property::DEBUG_TAP_ENABLED:
+    return "DEBUG_TAP_ENABLED";
+  case Property::ACTIVE_AQ_PROFILE:
+    return "ACTIVE_AQ_PROFILE";
+  case Property::MIXING_MODE:
+    return "MIXING_MODE";
+  case Property::MUTE:
+    return "MUTE";
+  case Property::FADER_LEVEL:
+    return "FADER_LEVEL";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::Property, 6> enum_values<::com::rdk::hal::audiomixer::Property> = {
+  ::com::rdk::hal::audiomixer::Property::LATENCY_MS,
+  ::com::rdk::hal::audiomixer::Property::DEBUG_TAP_ENABLED,
+  ::com::rdk::hal::audiomixer::Property::ACTIVE_AQ_PROFILE,
+  ::com::rdk::hal::audiomixer::Property::MIXING_MODE,
+  ::com::rdk::hal::audiomixer::Property::MUTE,
+  ::com::rdk::hal::audiomixer::Property::FADER_LEVEL,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/State.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/State.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class State : int32_t {
+  UNKNOWN = 0,
+  CLOSED = 1,
+  OPENING = 2,
+  READY = 3,
+  STARTING = 4,
+  STARTED = 5,
+  FLUSHING = 6,
+  STOPPING = 7,
+  CLOSING = 8,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(State val) {
+  switch(val) {
+  case State::UNKNOWN:
+    return "UNKNOWN";
+  case State::CLOSED:
+    return "CLOSED";
+  case State::OPENING:
+    return "OPENING";
+  case State::READY:
+    return "READY";
+  case State::STARTING:
+    return "STARTING";
+  case State::STARTED:
+    return "STARTED";
+  case State::FLUSHING:
+    return "FLUSHING";
+  case State::STOPPING:
+    return "STOPPING";
+  case State::CLOSING:
+    return "CLOSING";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::State, 9> enum_values<::com::rdk::hal::audiomixer::State> = {
+  ::com::rdk::hal::audiomixer::State::UNKNOWN,
+  ::com::rdk::hal::audiomixer::State::CLOSED,
+  ::com::rdk::hal::audiomixer::State::OPENING,
+  ::com::rdk::hal::audiomixer::State::READY,
+  ::com::rdk::hal::audiomixer::State::STARTING,
+  ::com::rdk::hal::audiomixer::State::STARTED,
+  ::com::rdk::hal::audiomixer::State::FLUSHING,
+  ::com::rdk::hal::audiomixer::State::STOPPING,
+  ::com::rdk::hal::audiomixer::State::CLOSING,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/include/com/rdk/hal/audiomixer/TranscodeFormat.h
+++ b/audiomixer/current/include/com/rdk/hal/audiomixer/TranscodeFormat.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <array>
+#include <binder/Enums.h>
+#include <cstdint>
+#include <string>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+enum class TranscodeFormat : int32_t {
+  NONE = 0,
+  PCM = 1,
+  DOLBY_AC3 = 2,
+  DOLBY_AC3_PLUS = 3,
+  DOLBY_MAT = 4,
+  DOLBY_TRUEHD = 5,
+  DTS = 6,
+  MPEG2 = 7,
+  OTHER = 100,
+};
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+[[nodiscard]] static inline std::string toString(TranscodeFormat val) {
+  switch(val) {
+  case TranscodeFormat::NONE:
+    return "NONE";
+  case TranscodeFormat::PCM:
+    return "PCM";
+  case TranscodeFormat::DOLBY_AC3:
+    return "DOLBY_AC3";
+  case TranscodeFormat::DOLBY_AC3_PLUS:
+    return "DOLBY_AC3_PLUS";
+  case TranscodeFormat::DOLBY_MAT:
+    return "DOLBY_MAT";
+  case TranscodeFormat::DOLBY_TRUEHD:
+    return "DOLBY_TRUEHD";
+  case TranscodeFormat::DTS:
+    return "DTS";
+  case TranscodeFormat::MPEG2:
+    return "MPEG2";
+  case TranscodeFormat::OTHER:
+    return "OTHER";
+  default:
+    return std::to_string(static_cast<int32_t>(val));
+  }
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+namespace android {
+namespace internal {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
+template <>
+constexpr inline std::array<::com::rdk::hal::audiomixer::TranscodeFormat, 9> enum_values<::com::rdk::hal::audiomixer::TranscodeFormat> = {
+  ::com::rdk::hal::audiomixer::TranscodeFormat::NONE,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::PCM,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::DOLBY_AC3,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::DOLBY_AC3_PLUS,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::DOLBY_MAT,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::DOLBY_TRUEHD,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::DTS,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::MPEG2,
+  ::com::rdk::hal::audiomixer::TranscodeFormat::OTHER,
+};
+#pragma clang diagnostic pop
+}  // namespace internal
+}  // namespace android

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/AQParameter.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/AQParameter.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/AQProcessor.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/AQProcessor.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/AudioSourceType.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/AudioSourceType.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/Capabilities.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/Capabilities.cpp
@@ -1,0 +1,70 @@
+#include <com/rdk/hal/audiomixer/Capabilities.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+::android::status_t Capabilities::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readBool(&supportsSecure);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readParcelableVector(&inputs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readString16(&name);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t Capabilities::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeBool(supportsSecure);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeParcelableVector(inputs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeString16(name);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/ConnectionState.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/ConnectionState.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/ContentType.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/ContentType.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixer.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixer.cpp
@@ -1,0 +1,727 @@
+#include <com/rdk/hal/audiomixer/IAudioMixer.h>
+#include <com/rdk/hal/audiomixer/BpAudioMixer.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioMixer, "com.rdk.hal.audiomixer.IAudioMixer")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioMixer.h>
+#include <com/rdk/hal/audiomixer/BnAudioMixer.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioMixer::BpAudioMixer(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioMixer>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioMixer::getAudioOutputPortIds(::std::vector<int32_t>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_getAudioOutputPortIds, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->getAudioOutputPortIds(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readInt32Vector(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::getAudioOutputPort(int32_t id, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPort>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(id);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_getAudioOutputPort, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->getAudioOutputPort(id, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readNullableStrongBinder(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::getCapabilities(::com::rdk::hal::audiomixer::Capabilities* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_getCapabilities, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->getCapabilities(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readParcelable(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::getProperty(::com::rdk::hal::audiomixer::Property property, ::com::rdk::hal::PropertyValue* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(property));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_getProperty, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->getProperty(property, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readParcelable(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::open(bool secure, const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& audioMixerEventListener, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeBool(secure);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(audioMixerEventListener);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_open, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->open(secure, audioMixerEventListener, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readNullableStrongBinder(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController>& audioMixerController, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(audioMixerController);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_close, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->close(audioMixerController, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(listener);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_registerListener, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->registerListener(listener);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener>& listener) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(listener);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_unregisterListener, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->unregisterListener(listener);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::getCurrentSourceCodecs(::std::vector<::com::rdk::hal::audiodecoder::Codec>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_getCurrentSourceCodecs, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->getCurrentSourceCodecs(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readEnumVector(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixer::getInputRouting(::std::vector<::com::rdk::hal::audiomixer::InputRouting>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixer::TRANSACTION_getInputRouting, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixer::getDefaultImpl())) {
+     return IAudioMixer::getDefaultImpl()->getInputRouting(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readParcelableVector(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioMixer::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixer::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioMixer::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixer::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioMixer.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioMixer::BnAudioMixer()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioMixer::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioMixer::TRANSACTION_getAudioOutputPortIds:
+  {
+    ::std::vector<int32_t> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getAudioOutputPortIds(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeInt32Vector(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getAudioOutputPort:
+  {
+    int32_t in_id;
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPort> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_id);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(getAudioOutputPort(in_id, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeStrongBinder(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getCapabilities:
+  {
+    ::com::rdk::hal::audiomixer::Capabilities _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getCapabilities(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeParcelable(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getProperty:
+  {
+    ::com::rdk::hal::audiomixer::Property in_property;
+    ::com::rdk::hal::PropertyValue _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_property));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(getProperty(in_property, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeParcelable(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_open:
+  {
+    bool in_secure;
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener> in_audioMixerEventListener;
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readBool(&in_secure);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_audioMixerEventListener);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(open(in_secure, in_audioMixerEventListener, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeStrongBinder(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_close:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerController> in_audioMixerController;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_audioMixerController);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(close(in_audioMixerController, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_registerListener:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener> in_listener;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_listener);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(registerListener(in_listener));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_unregisterListener:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioMixerEventListener> in_listener;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_listener);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(unregisterListener(in_listener));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getCurrentSourceCodecs:
+  {
+    ::std::vector<::com::rdk::hal::audiodecoder::Codec> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getCurrentSourceCodecs(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeEnumVector(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getInputRouting:
+  {
+    ::std::vector<::com::rdk::hal::audiomixer::InputRouting> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getInputRouting(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeParcelableVector(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioMixer::VERSION);
+  }
+  break;
+  case BnAudioMixer::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioMixer::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioMixer::getInterfaceVersion() {
+  return IAudioMixer::VERSION;
+}
+std::string BnAudioMixer::getInterfaceHash() {
+  return IAudioMixer::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixerController.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixerController.cpp
@@ -1,0 +1,736 @@
+#include <com/rdk/hal/audiomixer/IAudioMixerController.h>
+#include <com/rdk/hal/audiomixer/BpAudioMixerController.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioMixerController, "com.rdk.hal.audiomixer.IAudioMixerController")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioMixerController.h>
+#include <com/rdk/hal/audiomixer/BnAudioMixerController.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioMixerController::BpAudioMixerController(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioMixerController>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioMixerController::setInputRouting(const ::std::vector<::com::rdk::hal::audiomixer::InputRouting>& routing, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeParcelableVector(routing);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_setInputRouting, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->setInputRouting(routing, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::setProperty(::com::rdk::hal::audiomixer::Property property, const ::com::rdk::hal::PropertyValue& propertyValue, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(property));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeParcelable(propertyValue);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_setProperty, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->setProperty(property, propertyValue, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::start() {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_start, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->start();
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::stop() {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_stop, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->stop();
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::flush(bool reset) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeBool(reset);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_flush, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->flush(reset);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::signalDiscontinuity() {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_signalDiscontinuity, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->signalDiscontinuity();
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::signalEndOfStream() {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_signalEndOfStream, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->signalEndOfStream();
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::setInputVolume(int32_t inputIndex, int32_t volume, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(inputIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(volume);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_setInputVolume, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->setInputVolume(inputIndex, volume, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::getInputVolume(int32_t inputIndex, int32_t* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(inputIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_getInputVolume, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->getInputVolume(inputIndex, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readInt32(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerController::setInputVolumeRamp(int32_t inputIndex, int32_t targetVolume, int32_t overMs, ::com::rdk::hal::audiosink::VolumeRamp curve, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(inputIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(targetVolume);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(overMs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(curve));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerController::TRANSACTION_setInputVolumeRamp, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerController::getDefaultImpl())) {
+     return IAudioMixerController::getDefaultImpl()->setInputVolumeRamp(inputIndex, targetVolume, overMs, curve, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioMixerController::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixerController::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioMixerController::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixerController::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioMixerController.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioMixerController::BnAudioMixerController()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioMixerController::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioMixerController::TRANSACTION_setInputRouting:
+  {
+    ::std::vector<::com::rdk::hal::audiomixer::InputRouting> in_routing;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readParcelableVector(&in_routing);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(setInputRouting(in_routing, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_setProperty:
+  {
+    ::com::rdk::hal::audiomixer::Property in_property;
+    ::com::rdk::hal::PropertyValue in_propertyValue;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_property));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readParcelable(&in_propertyValue);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(setProperty(in_property, in_propertyValue, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_start:
+  {
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(start());
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_stop:
+  {
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(stop());
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_flush:
+  {
+    bool in_reset;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readBool(&in_reset);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(flush(in_reset));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_signalDiscontinuity:
+  {
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(signalDiscontinuity());
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_signalEndOfStream:
+  {
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(signalEndOfStream());
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_setInputVolume:
+  {
+    int32_t in_inputIndex;
+    int32_t in_volume;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_inputIndex);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_volume);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(setInputVolume(in_inputIndex, in_volume, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_getInputVolume:
+  {
+    int32_t in_inputIndex;
+    int32_t _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_inputIndex);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(getInputVolume(in_inputIndex, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeInt32(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_setInputVolumeRamp:
+  {
+    int32_t in_inputIndex;
+    int32_t in_targetVolume;
+    int32_t in_overMs;
+    ::com::rdk::hal::audiosink::VolumeRamp in_curve;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_inputIndex);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_targetVolume);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_overMs);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_curve));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(setInputVolumeRamp(in_inputIndex, in_targetVolume, in_overMs, in_curve, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioMixerController::VERSION);
+  }
+  break;
+  case BnAudioMixerController::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioMixerController::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioMixerController::getInterfaceVersion() {
+  return IAudioMixerController::VERSION;
+}
+std::string BnAudioMixerController::getInterfaceHash() {
+  return IAudioMixerController::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixerEventListener.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixerEventListener.cpp
@@ -1,0 +1,286 @@
+#include <com/rdk/hal/audiomixer/IAudioMixerEventListener.h>
+#include <com/rdk/hal/audiomixer/BpAudioMixerEventListener.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioMixerEventListener, "com.rdk.hal.audiomixer.IAudioMixerEventListener")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioMixerEventListener.h>
+#include <com/rdk/hal/audiomixer/BnAudioMixerEventListener.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioMixerEventListener::BpAudioMixerEventListener(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioMixerEventListener>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioMixerEventListener::onInputCodecChanged(int32_t audioMixerInputIndex, ::com::rdk::hal::audiodecoder::Codec codec, ::com::rdk::hal::audiomixer::ContentType contentType) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(audioMixerInputIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(codec));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(contentType));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerEventListener::TRANSACTION_onInputCodecChanged, _aidl_data, &_aidl_reply, ::android::IBinder::FLAG_ONEWAY);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerEventListener::getDefaultImpl())) {
+     return IAudioMixerEventListener::getDefaultImpl()->onInputCodecChanged(audioMixerInputIndex, codec, contentType);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerEventListener::onError(int32_t errorCode, const ::android::String16& message) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(errorCode);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeString16(message);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerEventListener::TRANSACTION_onError, _aidl_data, &_aidl_reply, ::android::IBinder::FLAG_ONEWAY);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerEventListener::getDefaultImpl())) {
+     return IAudioMixerEventListener::getDefaultImpl()->onError(errorCode, message);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerEventListener::onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(oldState));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(newState));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerEventListener::TRANSACTION_onStateChanged, _aidl_data, &_aidl_reply, ::android::IBinder::FLAG_ONEWAY);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerEventListener::getDefaultImpl())) {
+     return IAudioMixerEventListener::getDefaultImpl()->onStateChanged(oldState, newState);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioMixerEventListener::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixerEventListener::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioMixerEventListener::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixerEventListener::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioMixerEventListener.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioMixerEventListener::BnAudioMixerEventListener()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioMixerEventListener::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioMixerEventListener::TRANSACTION_onInputCodecChanged:
+  {
+    int32_t in_audioMixerInputIndex;
+    ::com::rdk::hal::audiodecoder::Codec in_codec;
+    ::com::rdk::hal::audiomixer::ContentType in_contentType;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_audioMixerInputIndex);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_codec));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_contentType));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(onInputCodecChanged(in_audioMixerInputIndex, in_codec, in_contentType));
+  }
+  break;
+  case BnAudioMixerEventListener::TRANSACTION_onError:
+  {
+    int32_t in_errorCode;
+    ::android::String16 in_message;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(&in_errorCode);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readString16(&in_message);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(onError(in_errorCode, in_message));
+  }
+  break;
+  case BnAudioMixerEventListener::TRANSACTION_onStateChanged:
+  {
+    ::com::rdk::hal::audiomixer::State in_oldState;
+    ::com::rdk::hal::audiomixer::State in_newState;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_oldState));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_newState));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(onStateChanged(in_oldState, in_newState));
+  }
+  break;
+  case BnAudioMixerEventListener::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioMixerEventListener::VERSION);
+  }
+  break;
+  case BnAudioMixerEventListener::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioMixerEventListener::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioMixerEventListener::getInterfaceVersion() {
+  return IAudioMixerEventListener::VERSION;
+}
+std::string BnAudioMixerEventListener::getInterfaceHash() {
+  return IAudioMixerEventListener::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixerManager.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioMixerManager.cpp
@@ -1,0 +1,243 @@
+#include <com/rdk/hal/audiomixer/IAudioMixerManager.h>
+#include <com/rdk/hal/audiomixer/BpAudioMixerManager.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioMixerManager, "com.rdk.hal.audiomixer.IAudioMixerManager")
+const ::std::string& IAudioMixerManager::serviceName() {
+  static const ::std::string value("audiomixer");
+  return value;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioMixerManager.h>
+#include <com/rdk/hal/audiomixer/BnAudioMixerManager.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioMixerManager::BpAudioMixerManager(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioMixerManager>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioMixerManager::getAudioMixerIds(::std::vector<::com::rdk::hal::audiomixer::IAudioMixer::Id>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerManager::TRANSACTION_getAudioMixerIds, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerManager::getDefaultImpl())) {
+     return IAudioMixerManager::getDefaultImpl()->getAudioMixerIds(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readEnumVector(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioMixerManager::getAudioMixer(::com::rdk::hal::audiomixer::IAudioMixer::Id id, ::android::sp<::com::rdk::hal::audiomixer::IAudioMixer>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(id));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioMixerManager::TRANSACTION_getAudioMixer, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioMixerManager::getDefaultImpl())) {
+     return IAudioMixerManager::getDefaultImpl()->getAudioMixer(id, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readNullableStrongBinder(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioMixerManager::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixerManager::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioMixerManager::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioMixerManager::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioMixerManager.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioMixerManager::BnAudioMixerManager()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioMixerManager::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioMixerManager::TRANSACTION_getAudioMixerIds:
+  {
+    ::std::vector<::com::rdk::hal::audiomixer::IAudioMixer::Id> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getAudioMixerIds(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeEnumVector(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerManager::TRANSACTION_getAudioMixer:
+  {
+    ::com::rdk::hal::audiomixer::IAudioMixer::Id in_id;
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioMixer> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_id));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(getAudioMixer(in_id, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeStrongBinder(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioMixerManager::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioMixerManager::VERSION);
+  }
+  break;
+  case BnAudioMixerManager::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioMixerManager::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioMixerManager::getInterfaceVersion() {
+  return IAudioMixerManager::VERSION;
+}
+std::string BnAudioMixerManager::getInterfaceHash() {
+  return IAudioMixerManager::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPort.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPort.cpp
@@ -1,0 +1,543 @@
+#include <com/rdk/hal/audiomixer/IAudioOutputPort.h>
+#include <com/rdk/hal/audiomixer/BpAudioOutputPort.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioOutputPort, "com.rdk.hal.audiomixer.IAudioOutputPort")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioOutputPort.h>
+#include <com/rdk/hal/audiomixer/BnAudioOutputPort.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioOutputPort::BpAudioOutputPort(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioOutputPort>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioOutputPort::getCapabilities(::com::rdk::hal::audiomixer::OutputPortCapabilities* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_getCapabilities, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->getCapabilities(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readParcelable(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioOutputPort::getState(::com::rdk::hal::audiomixer::State* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_getState, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->getState(_aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readInt32(reinterpret_cast<int32_t *>(_aidl_return));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioOutputPort::getProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, ::com::rdk::hal::PropertyValue* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(property));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_getProperty, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->getProperty(property, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readParcelable(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioOutputPort::open(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortControllerListener>& listener, ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(listener);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_open, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->open(listener, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readNullableStrongBinder(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioOutputPort::close(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController>& controller, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(controller);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_close, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->close(controller, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioOutputPort::registerListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(listener);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_registerListener, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->registerListener(listener);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+::android::binder::Status BpAudioOutputPort::unregisterListener(const ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener>& listener) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeStrongBinder(listener);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPort::TRANSACTION_unregisterListener, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPort::getDefaultImpl())) {
+     return IAudioOutputPort::getDefaultImpl()->unregisterListener(listener);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioOutputPort::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPort::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioOutputPort::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPort::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioOutputPort.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioOutputPort::BnAudioOutputPort()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioOutputPort::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioOutputPort::TRANSACTION_getCapabilities:
+  {
+    ::com::rdk::hal::audiomixer::OutputPortCapabilities _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getCapabilities(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeParcelable(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_getState:
+  {
+    ::com::rdk::hal::audiomixer::State _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    ::android::binder::Status _aidl_status(getState(&_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeInt32(static_cast<int32_t>(_aidl_return));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_getProperty:
+  {
+    ::com::rdk::hal::audiomixer::OutputPortProperty in_property;
+    ::com::rdk::hal::PropertyValue _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_property));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(getProperty(in_property, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeParcelable(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_open:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortControllerListener> in_listener;
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController> _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_listener);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(open(in_listener, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeStrongBinder(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_close:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortController> in_controller;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_controller);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(close(in_controller, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_registerListener:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener> in_listener;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_listener);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(registerListener(in_listener));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_unregisterListener:
+  {
+    ::android::sp<::com::rdk::hal::audiomixer::IAudioOutputPortListener> in_listener;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readStrongBinder(&in_listener);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(unregisterListener(in_listener));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioOutputPort::VERSION);
+  }
+  break;
+  case BnAudioOutputPort::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioOutputPort::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioOutputPort::getInterfaceVersion() {
+  return IAudioOutputPort::VERSION;
+}
+std::string BnAudioOutputPort::getInterfaceHash() {
+  return IAudioOutputPort::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPortController.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPortController.cpp
@@ -1,0 +1,194 @@
+#include <com/rdk/hal/audiomixer/IAudioOutputPortController.h>
+#include <com/rdk/hal/audiomixer/BpAudioOutputPortController.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioOutputPortController, "com.rdk.hal.audiomixer.IAudioOutputPortController")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioOutputPortController.h>
+#include <com/rdk/hal/audiomixer/BnAudioOutputPortController.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioOutputPortController::BpAudioOutputPortController(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioOutputPortController>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioOutputPortController::setProperty(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& value, bool* _aidl_return) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(property));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeParcelable(value);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPortController::TRANSACTION_setProperty, _aidl_data, &_aidl_reply, 0);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPortController::getDefaultImpl())) {
+     return IAudioOutputPortController::getDefaultImpl()->setProperty(property, value, _aidl_return);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  if (!_aidl_status.isOk()) {
+    return _aidl_status;
+  }
+  _aidl_ret_status = _aidl_reply.readBool(_aidl_return);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioOutputPortController::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPortController::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioOutputPortController::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPortController::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioOutputPortController.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioOutputPortController::BnAudioOutputPortController()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioOutputPortController::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioOutputPortController::TRANSACTION_setProperty:
+  {
+    ::com::rdk::hal::audiomixer::OutputPortProperty in_property;
+    ::com::rdk::hal::PropertyValue in_value;
+    bool _aidl_return;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_property));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readParcelable(&in_value);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(setProperty(in_property, in_value, &_aidl_return));
+    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (!_aidl_status.isOk()) {
+      break;
+    }
+    _aidl_ret_status = _aidl_reply->writeBool(_aidl_return);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+  }
+  break;
+  case BnAudioOutputPortController::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioOutputPortController::VERSION);
+  }
+  break;
+  case BnAudioOutputPortController::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioOutputPortController::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioOutputPortController::getInterfaceVersion() {
+  return IAudioOutputPortController::VERSION;
+}
+std::string BnAudioOutputPortController::getInterfaceHash() {
+  return IAudioOutputPortController::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.cpp
@@ -1,0 +1,171 @@
+#include <com/rdk/hal/audiomixer/IAudioOutputPortControllerListener.h>
+#include <com/rdk/hal/audiomixer/BpAudioOutputPortControllerListener.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioOutputPortControllerListener, "com.rdk.hal.audiomixer.IAudioOutputPortControllerListener")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioOutputPortControllerListener.h>
+#include <com/rdk/hal/audiomixer/BnAudioOutputPortControllerListener.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioOutputPortControllerListener::BpAudioOutputPortControllerListener(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioOutputPortControllerListener>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioOutputPortControllerListener::onStateChanged(::com::rdk::hal::audiomixer::State oldState, ::com::rdk::hal::audiomixer::State newState) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(oldState));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(newState));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPortControllerListener::TRANSACTION_onStateChanged, _aidl_data, &_aidl_reply, ::android::IBinder::FLAG_ONEWAY);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPortControllerListener::getDefaultImpl())) {
+     return IAudioOutputPortControllerListener::getDefaultImpl()->onStateChanged(oldState, newState);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioOutputPortControllerListener::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPortControllerListener::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioOutputPortControllerListener::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPortControllerListener::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioOutputPortControllerListener.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioOutputPortControllerListener::BnAudioOutputPortControllerListener()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioOutputPortControllerListener::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioOutputPortControllerListener::TRANSACTION_onStateChanged:
+  {
+    ::com::rdk::hal::audiomixer::State in_oldState;
+    ::com::rdk::hal::audiomixer::State in_newState;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_oldState));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_newState));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(onStateChanged(in_oldState, in_newState));
+  }
+  break;
+  case BnAudioOutputPortControllerListener::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioOutputPortControllerListener::VERSION);
+  }
+  break;
+  case BnAudioOutputPortControllerListener::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioOutputPortControllerListener::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioOutputPortControllerListener::getInterfaceVersion() {
+  return IAudioOutputPortControllerListener::VERSION;
+}
+std::string BnAudioOutputPortControllerListener::getInterfaceHash() {
+  return IAudioOutputPortControllerListener::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPortListener.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/IAudioOutputPortListener.cpp
@@ -1,0 +1,171 @@
+#include <com/rdk/hal/audiomixer/IAudioOutputPortListener.h>
+#include <com/rdk/hal/audiomixer/BpAudioOutputPortListener.h>
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+DO_NOT_DIRECTLY_USE_ME_IMPLEMENT_META_INTERFACE(AudioOutputPortListener, "com.rdk.hal.audiomixer.IAudioOutputPortListener")
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BpAudioOutputPortListener.h>
+#include <com/rdk/hal/audiomixer/BnAudioOutputPortListener.h>
+#include <binder/Parcel.h>
+#include <android-base/macros.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BpAudioOutputPortListener::BpAudioOutputPortListener(const ::android::sp<::android::IBinder>& _aidl_impl)
+    : BpInterface<IAudioOutputPortListener>(_aidl_impl){
+}
+
+::android::binder::Status BpAudioOutputPortListener::onPropertyChanged(::com::rdk::hal::audiomixer::OutputPortProperty property, const ::com::rdk::hal::PropertyValue& newValue) {
+  ::android::Parcel _aidl_data;
+  _aidl_data.markForBinder(remoteStrong());
+  ::android::Parcel _aidl_reply;
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  ::android::binder::Status _aidl_status;
+  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(property));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = _aidl_data.writeParcelable(newValue);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_ret_status = remote()->transact(BnAudioOutputPortListener::TRANSACTION_onPropertyChanged, _aidl_data, &_aidl_reply, ::android::IBinder::FLAG_ONEWAY);
+  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IAudioOutputPortListener::getDefaultImpl())) {
+     return IAudioOutputPortListener::getDefaultImpl()->onPropertyChanged(property, newValue);
+  }
+  if (((_aidl_ret_status) != (::android::OK))) {
+    goto _aidl_error;
+  }
+  _aidl_error:
+  _aidl_status.setFromStatusT(_aidl_ret_status);
+  return _aidl_status;
+}
+
+int32_t BpAudioOutputPortListener::getInterfaceVersion() {
+  if (cached_version_ == -1) {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPortListener::TRANSACTION_getInterfaceVersion, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        cached_version_ = reply.readInt32();
+      }
+    }
+  }
+  return cached_version_;
+}
+
+
+std::string BpAudioOutputPortListener::getInterfaceHash() {
+  std::lock_guard<std::mutex> lockGuard(cached_hash_mutex_);
+  if (cached_hash_ == "-1") {
+    ::android::Parcel data;
+    ::android::Parcel reply;
+    data.writeInterfaceToken(getInterfaceDescriptor());
+    ::android::status_t err = remote()->transact(BnAudioOutputPortListener::TRANSACTION_getInterfaceHash, data, &reply);
+    if (err == ::android::OK) {
+      ::android::binder::Status _aidl_status;
+      err = _aidl_status.readFromParcel(reply);
+      if (err == ::android::OK && _aidl_status.isOk()) {
+        reply.readUtf8FromUtf16(&cached_hash_);
+      }
+    }
+  }
+  return cached_hash_;
+}
+
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com
+#include <com/rdk/hal/audiomixer/BnAudioOutputPortListener.h>
+#include <binder/Parcel.h>
+#include <binder/Stability.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+
+BnAudioOutputPortListener::BnAudioOutputPortListener()
+{
+  ::android::internal::Stability::markVintf(this);
+}
+
+::android::status_t BnAudioOutputPortListener::onTransact(uint32_t _aidl_code, const ::android::Parcel& _aidl_data, ::android::Parcel* _aidl_reply, uint32_t _aidl_flags) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  switch (_aidl_code) {
+  case BnAudioOutputPortListener::TRANSACTION_onPropertyChanged:
+  {
+    ::com::rdk::hal::audiomixer::OutputPortProperty in_property;
+    ::com::rdk::hal::PropertyValue in_newValue;
+    if (!(_aidl_data.checkInterface(this))) {
+      _aidl_ret_status = ::android::BAD_TYPE;
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_property));
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    _aidl_ret_status = _aidl_data.readParcelable(&in_newValue);
+    if (((_aidl_ret_status) != (::android::OK))) {
+      break;
+    }
+    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
+      _aidl_ret_status = st.writeToParcel(_aidl_reply);
+      break;
+    }
+    ::android::binder::Status _aidl_status(onPropertyChanged(in_property, in_newValue));
+  }
+  break;
+  case BnAudioOutputPortListener::TRANSACTION_getInterfaceVersion:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeInt32(IAudioOutputPortListener::VERSION);
+  }
+  break;
+  case BnAudioOutputPortListener::TRANSACTION_getInterfaceHash:
+  {
+    _aidl_data.checkInterface(this);
+    _aidl_reply->writeNoException();
+    _aidl_reply->writeUtf8AsUtf16(IAudioOutputPortListener::HASH);
+  }
+  break;
+  default:
+  {
+    _aidl_ret_status = ::android::BBinder::onTransact(_aidl_code, _aidl_data, _aidl_reply, _aidl_flags);
+  }
+  break;
+  }
+  if (_aidl_ret_status == ::android::UNEXPECTED_NULL) {
+    _aidl_ret_status = ::android::binder::Status::fromExceptionCode(::android::binder::Status::EX_NULL_POINTER).writeOverParcel(_aidl_reply);
+  }
+  return _aidl_ret_status;
+}
+
+int32_t BnAudioOutputPortListener::getInterfaceVersion() {
+  return IAudioOutputPortListener::VERSION;
+}
+std::string BnAudioOutputPortListener::getInterfaceHash() {
+  return IAudioOutputPortListener::HASH;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/InputRouting.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/InputRouting.cpp
@@ -1,0 +1,58 @@
+#include <com/rdk/hal/audiomixer/InputRouting.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+::android::status_t InputRouting::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(reinterpret_cast<int32_t *>(&sourceType));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&sourceIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t InputRouting::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeInt32(static_cast<int32_t>(sourceType));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt32(sourceIndex);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/MixerInput.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/MixerInput.cpp
@@ -1,0 +1,70 @@
+#include <com/rdk/hal/audiomixer/MixerInput.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+::android::status_t MixerInput::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedContentTypes);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedCodecs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readString16(&name);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t MixerInput::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedContentTypes);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedCodecs);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeString16(name);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/MixingMode.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/MixingMode.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/OutputFormat.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/OutputFormat.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/OutputPortCapabilities.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/OutputPortCapabilities.cpp
@@ -1,0 +1,118 @@
+#include <com/rdk/hal/audiomixer/OutputPortCapabilities.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace audiomixer {
+::android::status_t OutputPortCapabilities::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readString16(&portName);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(reinterpret_cast<int32_t *>(&portType));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedProperties);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedOutputFormats);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedTranscodeFormats);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedAQProcessors);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedAQ);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t OutputPortCapabilities::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeString16(portName);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt32(static_cast<int32_t>(portType));
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedProperties);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedOutputFormats);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedTranscodeFormats);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedAQProcessors);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedAQ);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace audiomixer
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/OutputPortProperty.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/OutputPortProperty.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/OutputPortType.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/OutputPortType.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/Property.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/Property.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/State.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/State.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.

--- a/audiomixer/current/src/com/rdk/hal/audiomixer/TranscodeFormat.cpp
+++ b/audiomixer/current/src/com/rdk/hal/audiomixer/TranscodeFormat.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank as placeholder for enum declaration.


### PR DESCRIPTION
Botched amend on #456 (build env failed silently, empty include/src committed) wiped all 96 audiomixer C++ binding files on develop. This PR restores them from the agent's original (correct) regen commit. No AIDL or contract change — bindings only.