### PR TITLE
docs(vsi): module boot sequence + HFP delivery (#86)

### DIFF
--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -95,31 +95,33 @@ A vComponent obtains its HFP from one of two sources:
 
 |Source|When|
 |------|----|
-|`--hfp <path>` command-line argument|Present at launch.|
+|`--hfp <locator>` command-line argument|Present at launch.|
 |Control plane message into `WAITING_FOR_CONFIG`|No `--hfp` at launch; the HFP arrives over the control plane after startup.|
 
-The module reads only `--hfp`; it does not read `/proc/cmdline`. The `--hfp` value is populated upstream — by an operator launching a single module by hand, or, in the default vDevice launch, by systemd from an environment file the generator derives from the kernel command-line `hfp=` locator.
+The module reads only `--hfp`; it does not read `/proc/cmdline`. The `--hfp` value is a locator — supplied by an operator for a standalone module, or, in the default boot, by systemd from the shared environment file the generator derives from the kernel command-line `hfp=` URL.
 
-### Kernel Command Line to systemd
+### HFP Locator via Boot Parameters
 
-The kernel command line carries an HFP **locator** — a path, partition, or URI — not the HFP contents:
+The default vDevice boot configures every module from a single HFP that declares the configuration for all of the platform's modules. When the VM is launched, the launcher passes the HFP locator to the bootloader, which places it on the kernel command line for the boot sequence to read:
 
 ```
-... hfp=/firmware/active/<module>.hfp
+... hfp=https://<host>/<org>/<repo>/raw/<ref>/<platform>.yaml
 ```
 
-A systemd generator reads `/proc/cmdline`, extracts the `hfp=` value, and writes an environment file that the templated unit consumes, so the module sees `--hfp` and never reads `/proc/cmdline` itself:
+The locator is a URL — ut-control resolves URL-defined configuration — pointing to one HFP file held in a git repository. A URL is used because the VM reaches its configuration over the network; the boot sequence fetches this single HFP, and each vComponent applies the section for its own domain.
+
+A systemd generator reads `/proc/cmdline`, extracts the `hfp=` value, and writes a shared environment file the module units consume, so a module sees `--hfp` and never reads `/proc/cmdline` itself:
 
 ```ini
-# /run/hfp/module@<port>.env  (written by the generator)
-HFP_FILE=/firmware/active/<module>.hfp
+# /run/hfp/hfp.env  (written by the generator, shared by all modules)
+HFP_FILE=https://<host>/<org>/<repo>/raw/<ref>/<platform>.yaml
 ```
 
 ```ini
 # module@.service  (templated, one instance per module)
 [Service]
 Type=notify
-EnvironmentFile=-/run/hfp/module@%i.env
+EnvironmentFile=-/run/hfp/hfp.env
 ExecStart=/usr/bin/<module> --port %i --hfp ${HFP_FILE}
 ```
 
@@ -139,7 +141,7 @@ A vComponent attaches to the control plane when it registers. For a vComponent p
 
 ### vDevice Boot Sequence
 
-The default vDevice boot, where the kernel command line supplies the HFP locator:
+The default vDevice boot, where the kernel command line supplies a single HFP URL for all modules:
 
 ```mermaid
 sequenceDiagram
@@ -153,12 +155,12 @@ sequenceDiagram
     end
     participant SM as Service Manager
 
-    Kernel->>Gen: hfp=/firmware/active/mod.hfp
-    Gen->>Systemd: write /run/hfp/module@5051.env
-    Systemd->>Module: ExecStart --port 5051 --hfp /firmware/active/mod.hfp
+    Kernel->>Gen: hfp=https://.../platform.yaml
+    Gen->>Systemd: write /run/hfp/hfp.env
+    Systemd->>Module: ExecStart --port 5051 --hfp https://.../platform.yaml
     Module->>SM: register service, attach control plane
     Note over Module: REGISTERED
-    Module->>Module: read HFP, apply
+    Module->>Module: fetch HFP, apply own section
     Note over Module: APPLYING → RUNNING
     Module->>Systemd: sd_notify(READY=1)
 ```

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -2,13 +2,9 @@
 
 ## Overview
 
-A HAL module runs as its own process, launched by [systemd](../../systemd/current/systemd.md). It listens on a Binder port and registers its interface with the [Service Manager](../../service_manager/current/service_manager.md), at which point clients can discover and call it.
+A HAL module runs as its own process, launched by [systemd](../../systemd/current/systemd.md). It registers its Binder interface with the [Service Manager](../../service_manager/current/service_manager.md) under its service name, at which point clients can discover and call it. A module backed by real hardware initialises from that hardware and registers over the kernel Binder driver, taking no command-line configuration.
 
-```
-<module> --port <port>
-```
-
-On the [vDevice](#vdevice-configuration), a module additionally presents the hardware capabilities declared in a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md), supplied with `--hfp` at launch or delivered over Binder afterwards. Because the HFP defines what the module emulates, a vDevice module completes startup only once an HFP is applied. A module backed by real hardware initialises from that hardware and does not depend on an HFP.
+On the [vDevice](#vdevice-configuration), a module is launched with the transport port it serves on and a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md) describing the hardware it emulates, supplied with `--hfp` at launch or delivered over Binder afterwards. Because the HFP defines what the module emulates, a vDevice module completes startup only once an HFP is applied.
 
 ---
 
@@ -35,13 +31,7 @@ On the [vDevice](#vdevice-configuration), a module additionally presents the har
 
 ## Startup Sequence
 
-A module is launched with the Binder port it listens on:
-
-```
-<module> --port <port>
-```
-
-It brings up its Binder interface, registers with the Service Manager, initialises, and becomes ready to serve clients.
+A module is launched by systemd. It brings up its Binder interface, registers with the Service Manager under its service name, initialises, and becomes ready to serve clients.
 
 ```mermaid
 stateDiagram-v2
@@ -60,16 +50,15 @@ stateDiagram-v2
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.BOOTSEQ.1** |A module shall accept the Binder port it listens on as the `--port` command-line argument.||
-|**HAL.BOOTSEQ.2** |A module shall bring up its Binder interface and register with the Service Manager during startup.|Registration makes the module discoverable to clients.|
-|**HAL.BOOTSEQ.3** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
-|**HAL.BOOTSEQ.4** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state.|Dependents ordered `After=` the module start against a ready module.|
+|**HAL.BOOTSEQ.1** |A module shall bring up its Binder interface and register with the Service Manager under its service name during startup.|Registration makes the module discoverable to clients.|
+|**HAL.BOOTSEQ.2** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
+|**HAL.BOOTSEQ.3** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state.|Dependents ordered `After=` the module start against a ready module.|
 
 ---
 
 ## vDevice Configuration
 
-On the vDevice, a module emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md). The HFP defines the capabilities the module presents, so a vDevice module registers with the Service Manager but completes startup only once an HFP is applied.
+On the vDevice, a module runs against a socket transport rather than the kernel Binder driver, so it is launched with the `--port` it serves on, and it emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md) given with `--hfp`. The HFP defines the capabilities the module presents, so a vDevice module registers with the Service Manager but completes startup only once an HFP is applied.
 
 ```
 <module> --port <port> --hfp <hfp-file>
@@ -146,7 +135,7 @@ interface IModuleControl {
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.VDEVICE.1** |A vDevice module shall accept its HFP file location as the `--hfp` command-line argument.||
+|**HAL.VDEVICE.1** |A vDevice module shall accept the transport port it serves on as the `--port` command-line argument, and its HFP file location as the `--hfp` command-line argument.||
 |**HAL.VDEVICE.2** |A vDevice module shall register with the Service Manager before requiring an HFP, entering a registered-but-unconfigured state.|Makes a module launched without an HFP discoverable rather than failed.|
 |**HAL.VDEVICE.3** |A vDevice module launched without `--hfp` shall apply an HFP delivered over Binder before completing startup.|The `--hfp` value, when present, is supplied by an operator or by systemd from the kernel command-line locator.|
 |**HAL.VDEVICE.4** |A vDevice module shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -52,9 +52,9 @@ stateDiagram-v2
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.BOOTSEQ.1** |A module shall bring up its Binder interface and register with the Service Manager under its service name during startup.|Registration makes the module discoverable to clients.|
+|**HAL.BOOTSEQ.1** |A module shall register its Binder interface with the [Service Manager](../../service_manager/current/service_manager.md) under its service name via the standard `publishAndJoinThreadPool()` helper.|Registration uses the Service Manager mechanism, not per-module code; it makes the module discoverable to clients.|
 |**HAL.BOOTSEQ.2** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
-|**HAL.BOOTSEQ.3** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state.|systemd holds units ordered `After=` this one until it receives `READY=1`, so dependents start only once the module is ready.|
+|**HAL.BOOTSEQ.3** |A module shall signal readiness through the common module bootstrap, which sends `sd_notify(READY=1)` only on reaching the running state.|Readiness is emitted by the shared bootstrap, not re-implemented per module. systemd holds units ordered `After=` this one until it receives `READY=1`.|
 
 ---
 

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -8,7 +8,7 @@ A HAL module runs as its own process, launched by [systemd](../../systemd/curren
 <module> --port <port>
 ```
 
-On the [vDevice](#vdevice-configuration), a module additionally presents the hardware capabilities declared in a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md), supplied with `--hfp`. Because the HFP defines what the module emulates, a vDevice module completes startup only once an HFP is applied. A module backed by real hardware initialises from that hardware and does not depend on an HFP.
+On the [vDevice](#vdevice-configuration), a module additionally presents the hardware capabilities declared in a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md), supplied with `--hfp` at launch or delivered over Binder afterwards. Because the HFP defines what the module emulates, a vDevice module completes startup only once an HFP is applied. A module backed by real hardware initialises from that hardware and does not depend on an HFP.
 
 ---
 
@@ -96,18 +96,16 @@ stateDiagram-v2
     class STARTING,APPLYING Transitory
 ```
 
-### HFP Resolution Order
+### HFP Resolution
 
-The HFP is resolved at the `REGISTERED` transition, taking the first source that yields one:
+A vDevice module obtains its HFP from one of two sources:
 
-|Priority|Source|Use|
-|-|------|---|
-|1|`--hfp <path>` command-line argument|An operator launching a single module by hand.|
-|2|systemd-provided environment (`EnvironmentFile`)|The on-device vDevice launch.|
-|3|Kernel command-line locator (`/proc/cmdline`)|The default vDevice launch.|
-|4|Binder delivery into `WAITING_FOR_CONFIG`|The HFP is pushed after startup.|
+|Source|When|
+|------|----|
+|`--hfp <path>` command-line argument|Present at launch.|
+|Binder delivery into `WAITING_FOR_CONFIG`|No `--hfp` at launch; the HFP is pushed after startup.|
 
-Sources 1–3 differ only in where the HFP location comes from; the same apply routine consumes all four.
+The module reads only `--hfp`; it does not read `/proc/cmdline`. The `--hfp` value is populated upstream — by an operator launching a single module by hand, or, in the default vDevice launch, by systemd from an environment file the generator derives from the kernel command-line `hfp=` locator.
 
 ### Kernel Command Line to systemd
 
@@ -150,7 +148,7 @@ interface IModuleControl {
 |-|------------|---------|
 |**HAL.VDEVICE.1** |A vDevice module shall accept its HFP file location as the `--hfp` command-line argument.||
 |**HAL.VDEVICE.2** |A vDevice module shall register with the Service Manager before requiring an HFP, entering a registered-but-unconfigured state.|Makes a module launched without an HFP discoverable rather than failed.|
-|**HAL.VDEVICE.3** |A vDevice module shall resolve its HFP from, in priority order: the `--hfp` argument, the systemd-provided environment, then the kernel command line. When none supplies one, the module shall wait for an HFP delivered over Binder.|First source that yields an HFP wins.|
+|**HAL.VDEVICE.3** |A vDevice module launched without `--hfp` shall apply an HFP delivered over Binder before completing startup.|The `--hfp` value, when present, is supplied by an operator or by systemd from the kernel command-line locator.|
 |**HAL.VDEVICE.4** |A vDevice module shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||
 |**HAL.VDEVICE.5** |A vDevice module that fails to apply its HFP shall exit non-zero, leaving recovery to the systemd restart policy.||
 

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -40,7 +40,7 @@ stateDiagram-v2
     direction LR
     [*] --> STARTING
     STARTING --> REGISTERED: binder up,<br>registered with Service Manager
-    REGISTERED --> RUNNING: initialised<br>sd_notify(READY=1)
+    REGISTERED --> RUNNING: initialised<br>signals ready
 
     classDef NonTransitory fill:#1976D2, color:white, font-weight:bold;
     classDef Transitory fill:#90CAF9, color:black, font-weight:bold;
@@ -54,7 +54,7 @@ stateDiagram-v2
 |-|------------|---------|
 |**HAL.BOOTSEQ.1** |A module shall register its Binder interface with the [Service Manager](../../service_manager/current/service_manager.md) under its service name via the standard `publishAndJoinThreadPool()` helper.|Registration uses the Service Manager mechanism, not per-module code; it makes the module discoverable to clients.|
 |**HAL.BOOTSEQ.2** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
-|**HAL.BOOTSEQ.3** |A module shall signal readiness through the common module bootstrap, which sends `sd_notify(READY=1)` only on reaching the running state.|Readiness is emitted by the shared bootstrap, not re-implemented per module. systemd holds units ordered `After=` this one until it receives `READY=1`.|
+|**HAL.BOOTSEQ.3** |A module shall signal readiness only on reaching the running state, so dependents are not started against an unconfigured module.|Emitted by the common module bootstrap, not re-implemented per module — for example `sd_notify(READY=1)` under systemd `Type=notify`.|
 
 ---
 
@@ -80,7 +80,7 @@ stateDiagram-v2
     REGISTERED --> WAITING_FOR_CONFIG: no HFP
     WAITING_FOR_CONFIG --> APPLYING: HFP control message
 
-    APPLYING --> RUNNING: success<br>sd_notify(READY=1)
+    APPLYING --> RUNNING: success<br>signals ready
     APPLYING --> [*]: <error> exit non-zero
 
     classDef NonTransitory fill:#1976D2, color:white, font-weight:bold;

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -52,7 +52,7 @@ stateDiagram-v2
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.BOOTSEQ.1** |A module shall register its Binder interface with the [Service Manager](../../service_manager/current/service_manager.md) under its service name via the standard `publishAndJoinThreadPool()` helper.|Registration uses the Service Manager mechanism, not per-module code; it makes the module discoverable to clients.|
+|**HAL.BOOTSEQ.1** |A module shall register its Binder interface with the [Service Manager](../../service_manager/current/service_manager.md) under its service name, using the standard registration mechanism rather than per-module code.|Makes the module discoverable to clients; see the Service Manager page for the registration calls.|
 |**HAL.BOOTSEQ.2** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
 |**HAL.BOOTSEQ.3** |A module shall signal readiness only on reaching the running state, so dependents are not started against an unconfigured module.|Emitted by the common module bootstrap, not re-implemented per module — for example `sd_notify(READY=1)` under systemd `Type=notify`.|
 
@@ -65,10 +65,10 @@ On the vDevice, a module runs as a vComponent managed by the vDevice Controller.
 The Controller provides a common control plane socket for all vComponents. A vComponent can also run standalone with its own control plane socket — given by `--port` — to debug a single module, optionally with its HFP on the command line:
 
 ```
-<module> --port <port> --hfp <hfp-file>
+<module> --port <port> --hfp <hfp-locator>
 ```
 
-A vComponent reaches `REGISTERED` without the HFP and attaches to the control plane there, then applies the HFP from `--hfp` when given. When it is not, the vComponent parks in `WAITING_FOR_CONFIG` until it receives an HFP as a control plane message. This gives one path whether the HFP is supplied at launch or afterwards.
+A vComponent reaches `REGISTERED` without the HFP and attaches to the control plane there. If `--hfp` was given at launch, it applies that HFP and continues; otherwise it parks in `WAITING_FOR_CONFIG` until an HFP arrives as a control plane message. This gives one path whether the HFP is supplied at launch or afterwards.
 
 ```mermaid
 stateDiagram-v2
@@ -133,7 +133,7 @@ A vComponent attaches to the control plane when it registers. For a vComponent p
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.VDEVICE.1** |A standalone vComponent shall accept the control plane socket it serves on as the `--port` command-line argument, and its HFP file location as the `--hfp` command-line argument.|Under the Controller, a vComponent uses the common control plane socket instead.|
+|**HAL.VDEVICE.1** |A standalone vComponent shall accept the control plane socket it serves on as the `--port` command-line argument, and its HFP locator as the `--hfp` command-line argument.|Under the Controller, a vComponent uses the common control plane socket instead.|
 |**HAL.VDEVICE.2** |A vComponent shall register and attach to the control plane before requiring an HFP, entering a registered-but-unconfigured state.|Makes a vComponent started without an HFP reachable rather than failed.|
 |**HAL.VDEVICE.3** |A vComponent started without `--hfp` shall apply an HFP delivered as a control plane message before completing startup.|The `--hfp` value, when present, is supplied by an operator or by systemd from the kernel command-line locator.|
 |**HAL.VDEVICE.4** |A vComponent shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -52,7 +52,7 @@ stateDiagram-v2
 |-|------------|---------|
 |**HAL.BOOTSEQ.1** |A module shall bring up its Binder interface and register with the Service Manager under its service name during startup.|Registration makes the module discoverable to clients.|
 |**HAL.BOOTSEQ.2** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
-|**HAL.BOOTSEQ.3** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state.|Dependents ordered `After=` the module start against a ready module.|
+|**HAL.BOOTSEQ.3** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state.|systemd holds units ordered `After=` this one until it receives `READY=1`, so dependents start only once the module is ready.|
 
 ---
 
@@ -121,11 +121,12 @@ ExecStart=/usr/bin/<module> --port %i --hfp ${HFP_FILE}
 
 ### HFP Delivery Over Binder
 
-A module installs a control callback when it registers, so the configuring service drives the HFP in for a module parked in `WAITING_FOR_CONFIG`:
+A module installs a control callback when it registers, so the configuring service drives the HFP in for a module parked in `WAITING_FOR_CONFIG`. The control interface carries the HFP as an opaque payload; the shape is illustrated below:
 
 ```aidl
+// Illustrative shape, not a defined interface in this repository.
 interface IModuleControl {
-    void applyHfp(in HfpBlob cfg);
+    void applyHfp(in byte[] cfg);
 }
 ```
 

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -1,0 +1,149 @@
+# Module Boot Sequence
+
+A HAL module runs as its own process launched by [systemd](../../systemd/current/systemd.md). Each module is launched with a port and a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md):
+
+```
+<module> --port <port> --hfp <hfp-file>
+```
+
+The HFP configures the module against the vendor layer it runs on. A module reaches Binder readiness and registers with the [Service Manager](../../service_manager/current/service_manager.md) **before** it has its HFP, then completes startup once the HFP is applied. This gives one startup path whether the HFP is supplied at launch or delivered afterwards over Binder.
+
+!!! info "References"
+    |Reference|Link|
+    |-|-|
+    |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
+    |**Service Registration**|[Service Manager](../../service_manager/current/service_manager.md)|
+    |**Configuration**|[HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md)|
+    |**Initialization**|[systemd](../../systemd/current/systemd.md)|
+
+## Implementation Requirements
+
+|#|Requirement | Comments|
+|-|------------|---------|
+|**HAL.BOOTSEQ.1** |A module shall accept its listen port and HFP file location as the `--port` and `--hfp` command-line arguments.||
+|**HAL.BOOTSEQ.2** |A module shall bring up its Binder interface and register with the Service Manager before requiring an HFP, entering a registered-but-unconfigured state.|Makes a module launched without an HFP discoverable rather than failed.|
+|**HAL.BOOTSEQ.3** |A module shall resolve its HFP from, in priority order: the `--hfp` argument, the systemd-provided environment, then the kernel command line. When none supplies one, the module shall wait for an HFP delivered over Binder.|First source that yields an HFP wins.|
+|**HAL.BOOTSEQ.4** |A module shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||
+|**HAL.BOOTSEQ.5** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state, after the HFP is applied.|Dependents ordered `After=` the module start against a configured module.|
+|**HAL.BOOTSEQ.6** |A module that fails to apply its HFP shall exit non-zero, leaving recovery to the systemd restart policy.||
+|**HAL.BOOTSEQ.7** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
+
+## Startup State Machine
+
+The module reaches `REGISTERED` without the HFP, then gates the remainder of startup on the HFP arriving. A module launched with an HFP transitions straight through `APPLYING` to `RUNNING`; a module launched without one parks in `WAITING_FOR_CONFIG` until the HFP is delivered over Binder.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> STARTING
+    STARTING --> REGISTERED: binder up,<br>registered + callback
+
+    REGISTERED --> APPLYING: HFP resolved
+    REGISTERED --> WAITING_FOR_CONFIG: no HFP
+    WAITING_FOR_CONFIG --> APPLYING: applyHfp()
+
+    APPLYING --> RUNNING: success<br>sd_notify(READY=1)
+    APPLYING --> [*]: <error> exit non-zero
+
+    classDef NonTransitory fill:#1976D2, color:white, font-weight:bold;
+    classDef Transitory fill:#90CAF9, color:black, font-weight:bold;
+    class REGISTERED,WAITING_FOR_CONFIG,RUNNING NonTransitory
+    class STARTING,APPLYING Transitory
+```
+
+## HFP Resolution Order
+
+The HFP is resolved at the `REGISTERED` transition, taking the first source that yields one:
+
+|Priority|Source|Use|
+|-|------|---|
+|1|`--hfp <path>` command-line argument|An operator launching a single module by hand.|
+|2|systemd-provided environment (`EnvironmentFile`)|The on-device launch.|
+|3|Kernel command-line locator (`/proc/cmdline`)|The production default.|
+|4|Binder delivery into `WAITING_FOR_CONFIG`|The HFP is pushed after startup.|
+
+Sources 1–3 differ only in where the HFP location comes from; the same apply routine consumes all four.
+
+## Kernel Command Line to systemd
+
+The kernel command line carries an HFP **locator** — a path, partition, or URI — not the HFP contents:
+
+```
+... hfp=/firmware/active/<module>.hfp
+```
+
+A systemd generator reads `/proc/cmdline`, extracts the `hfp=` value, and writes an environment file that the templated unit consumes, so the module sees `--hfp` and never reads `/proc/cmdline` itself:
+
+```ini
+# /run/hfp/module@<port>.env  (written by the generator)
+HFP_FILE=/firmware/active/<module>.hfp
+```
+
+```ini
+# module@.service  (templated, one instance per module)
+[Service]
+Type=notify
+EnvironmentFile=-/run/hfp/module@%i.env
+ExecStart=/usr/bin/<module> --port %i --hfp ${HFP_FILE}
+```
+
+## HFP Delivery Over Binder
+
+A module installs a control callback when it registers, so the configuring service drives the HFP in for a module parked in `WAITING_FOR_CONFIG`:
+
+```aidl
+interface IModuleControl {
+    void applyHfp(in HfpBlob cfg);
+}
+```
+
+`applyHfp()` moves the module `WAITING_FOR_CONFIG` → `APPLYING` → `RUNNING`.
+
+## Boot Sequence
+
+The production boot, where the kernel command line supplies the HFP locator:
+
+```mermaid
+sequenceDiagram
+    box rgb(249,168,37) Init
+        participant Kernel as Kernel cmdline
+        participant Gen as systemd generator
+        participant Systemd as systemd
+    end
+    box rgb(30,136,229) Module Process
+        participant Module as Module
+    end
+    participant SM as Service Manager
+
+    Kernel->>Gen: hfp=/firmware/active/mod.hfp
+    Gen->>Systemd: write /run/hfp/module@5051.env
+    Systemd->>Module: ExecStart --port 5051 --hfp /firmware/active/mod.hfp
+    Module->>SM: register service + control callback
+    Note over Module: REGISTERED
+    Module->>Module: read HFP, applyHfp()
+    Note over Module: APPLYING → RUNNING
+    Module->>Systemd: sd_notify(READY=1)
+    Module->>Module: start background work
+```
+
+A module launched without an HFP, configured later over Binder:
+
+```mermaid
+sequenceDiagram
+    box rgb(30,136,229) Module Process
+        participant Module as Module
+    end
+    participant SM as Service Manager
+    participant Svc as Configuring Service
+
+    Module->>SM: register service + control callback
+    Note over Module: REGISTERED → WAITING_FOR_CONFIG
+    Svc->>SM: getService(module)
+    Svc->>Module: applyHfp(cfg)
+    Note over Module: APPLYING → RUNNING
+    Module->>Module: start background work
+```
+
+## Product Customization
+
+The HFP file is a vendor-layer deliverable describing the module's configuration on the target platform. The kernel command line `hfp=` locator and the systemd generator that turns it into `--hfp` are provided by the vendor layer.

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -4,7 +4,7 @@
 
 A HAL module runs as its own process, launched by [systemd](../../systemd/current/systemd.md). It registers its Binder interface with the [Service Manager](../../service_manager/current/service_manager.md) under its service name, at which point clients can discover and call it. A module backed by real hardware initialises from that hardware and registers over the kernel Binder driver, taking no command-line configuration.
 
-On the [vDevice](#vdevice-configuration), a module is launched with the transport port it serves on and a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md) describing the hardware it emulates, supplied with `--hfp` at launch or delivered over Binder afterwards. Because the HFP defines what the module emulates, a vDevice module completes startup only once an HFP is applied.
+On the [vDevice](#vdevice-configuration), a module runs as a vComponent and emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md). The HFP is supplied with `--hfp` at launch, or delivered afterwards as a YAML message over the control plane. Because the HFP defines what the module emulates, a vComponent completes startup only once an HFP is applied.
 
 ---
 
@@ -26,6 +26,8 @@ On the [vDevice](#vdevice-configuration), a module is launched with the transpor
     - [Systemd](../../systemd/current/systemd.md)
     - [HAL Feature Profile](../../../key_concepts/hal/hal_feature_profiles.md)
     - [AIDL and Binder](../../../introduction/aidl_and_binder.md)
+    - [vDevice Controller](../../../external_content/ut-core-wiki/5.1.0:-Standards:-vDevice-Controller.md)
+    - [vDevice Control Plane](../../../external_content/ut-core-wiki/5.1.1:-Standards:-vDevice-Control-Plane.md)
 
 ---
 
@@ -58,23 +60,25 @@ stateDiagram-v2
 
 ## vDevice Configuration
 
-On the vDevice, a module runs against a socket transport rather than the kernel Binder driver, so it is launched with the `--port` it serves on, and it emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md) given with `--hfp`. The HFP defines the capabilities the module presents, so a vDevice module registers with the Service Manager but completes startup only once an HFP is applied.
+On the vDevice, a module runs as a vComponent managed by the vDevice Controller. The Controller routes control messages to it over a control plane socket, and the vComponent emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md). It registers with the Service Manager but completes startup only once an HFP is applied.
+
+The Controller provides a common control plane socket for all vComponents. A vComponent can also run standalone with its own control plane socket — given by `--port` — to debug a single module, optionally with its HFP on the command line:
 
 ```
 <module> --port <port> --hfp <hfp-file>
 ```
 
-A vDevice module reaches `REGISTERED` without the HFP and installs a control callback there, then applies the HFP from the first source that supplies one. When no source does, it parks in `WAITING_FOR_CONFIG` until an HFP is delivered over Binder. This gives one path whether the HFP is supplied at launch or afterwards.
+A vComponent reaches `REGISTERED` without the HFP and attaches to the control plane there, then applies the HFP from `--hfp` when given. When it is not, the vComponent parks in `WAITING_FOR_CONFIG` until it receives an HFP as a control plane message. This gives one path whether the HFP is supplied at launch or afterwards.
 
 ```mermaid
 stateDiagram-v2
     direction LR
     [*] --> STARTING
-    STARTING --> REGISTERED: binder up,<br>registered + callback
+    STARTING --> REGISTERED: registered,<br>control plane attached
 
-    REGISTERED --> APPLYING: HFP resolved
+    REGISTERED --> APPLYING: HFP from --hfp
     REGISTERED --> WAITING_FOR_CONFIG: no HFP
-    WAITING_FOR_CONFIG --> APPLYING: applyHfp()
+    WAITING_FOR_CONFIG --> APPLYING: HFP control message
 
     APPLYING --> RUNNING: success<br>sd_notify(READY=1)
     APPLYING --> [*]: <error> exit non-zero
@@ -87,12 +91,12 @@ stateDiagram-v2
 
 ### HFP Resolution
 
-A vDevice module obtains its HFP from one of two sources:
+A vComponent obtains its HFP from one of two sources:
 
 |Source|When|
 |------|----|
 |`--hfp <path>` command-line argument|Present at launch.|
-|Binder delivery into `WAITING_FOR_CONFIG`|No `--hfp` at launch; the HFP is pushed after startup.|
+|Control plane message into `WAITING_FOR_CONFIG`|No `--hfp` at launch; the HFP arrives over the control plane after startup.|
 
 The module reads only `--hfp`; it does not read `/proc/cmdline`. The `--hfp` value is populated upstream — by an operator launching a single module by hand, or, in the default vDevice launch, by systemd from an environment file the generator derives from the kernel command-line `hfp=` locator.
 
@@ -119,28 +123,19 @@ EnvironmentFile=-/run/hfp/module@%i.env
 ExecStart=/usr/bin/<module> --port %i --hfp ${HFP_FILE}
 ```
 
-### HFP Delivery Over Binder
+### HFP Delivery Over the Control Plane
 
-A module installs a control callback when it registers, so the configuring service drives the HFP in for a module parked in `WAITING_FOR_CONFIG`. The control interface carries the HFP as an opaque payload; the shape is illustrated below:
-
-```aidl
-// Illustrative shape, not a defined interface in this repository.
-interface IModuleControl {
-    void applyHfp(in byte[] cfg);
-}
-```
-
-`applyHfp()` moves the module `WAITING_FOR_CONFIG` → `APPLYING` → `RUNNING`.
+A vComponent attaches to the control plane when it registers. For a vComponent parked in `WAITING_FOR_CONFIG`, the HFP arrives as a YAML control message on the control plane socket — sent by the vDevice Controller, or, for a standalone vComponent, to its own `--port` socket. Applying that message moves the vComponent `WAITING_FOR_CONFIG` → `APPLYING` → `RUNNING`.
 
 ### vDevice Requirements
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.VDEVICE.1** |A vDevice module shall accept the transport port it serves on as the `--port` command-line argument, and its HFP file location as the `--hfp` command-line argument.||
-|**HAL.VDEVICE.2** |A vDevice module shall register with the Service Manager before requiring an HFP, entering a registered-but-unconfigured state.|Makes a module launched without an HFP discoverable rather than failed.|
-|**HAL.VDEVICE.3** |A vDevice module launched without `--hfp` shall apply an HFP delivered over Binder before completing startup.|The `--hfp` value, when present, is supplied by an operator or by systemd from the kernel command-line locator.|
-|**HAL.VDEVICE.4** |A vDevice module shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||
-|**HAL.VDEVICE.5** |A vDevice module that fails to apply its HFP shall exit non-zero, leaving recovery to the systemd restart policy.||
+|**HAL.VDEVICE.1** |A standalone vComponent shall accept the control plane socket it serves on as the `--port` command-line argument, and its HFP file location as the `--hfp` command-line argument.|Under the Controller, a vComponent uses the common control plane socket instead.|
+|**HAL.VDEVICE.2** |A vComponent shall register and attach to the control plane before requiring an HFP, entering a registered-but-unconfigured state.|Makes a vComponent started without an HFP reachable rather than failed.|
+|**HAL.VDEVICE.3** |A vComponent started without `--hfp` shall apply an HFP delivered as a control plane message before completing startup.|The `--hfp` value, when present, is supplied by an operator or by systemd from the kernel command-line locator.|
+|**HAL.VDEVICE.4** |A vComponent shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||
+|**HAL.VDEVICE.5** |A vComponent that fails to apply its HFP shall exit non-zero, leaving recovery to the systemd restart policy.||
 
 ### vDevice Boot Sequence
 
@@ -153,35 +148,34 @@ sequenceDiagram
         participant Gen as systemd generator
         participant Systemd as systemd
     end
-    box rgb(30,136,229) Module Process
-        participant Module as Module
+    box rgb(30,136,229) vComponent Process
+        participant Module as vComponent
     end
     participant SM as Service Manager
 
     Kernel->>Gen: hfp=/firmware/active/mod.hfp
     Gen->>Systemd: write /run/hfp/module@5051.env
     Systemd->>Module: ExecStart --port 5051 --hfp /firmware/active/mod.hfp
-    Module->>SM: register service + control callback
+    Module->>SM: register service, attach control plane
     Note over Module: REGISTERED
-    Module->>Module: read HFP, applyHfp()
+    Module->>Module: read HFP, apply
     Note over Module: APPLYING → RUNNING
     Module->>Systemd: sd_notify(READY=1)
 ```
 
-A vDevice module launched without an HFP, configured later over Binder:
+A vComponent started without an HFP, configured later over the control plane:
 
 ```mermaid
 sequenceDiagram
-    box rgb(30,136,229) Module Process
-        participant Module as Module
+    participant Ctrl as vDevice Controller
+    box rgb(30,136,229) vComponent Process
+        participant Module as vComponent
     end
     participant SM as Service Manager
-    participant Svc as Configuring Service
 
-    Module->>SM: register service + control callback
+    Module->>SM: register service, attach control plane
     Note over Module: REGISTERED → WAITING_FOR_CONFIG
-    Svc->>SM: getService(module)
-    Svc->>Module: applyHfp(cfg)
+    Ctrl->>Module: HFP as YAML control message
     Note over Module: APPLYING → RUNNING
 ```
 

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -60,9 +60,9 @@ stateDiagram-v2
 
 ## vDevice Configuration
 
-On the vDevice, a module runs as a vComponent managed by the vDevice Controller. The Controller routes control messages to it over a control plane socket, and the vComponent emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md). It registers with the Service Manager but completes startup only once an HFP is applied.
+On the vDevice, a module runs as a vComponent managed by the vDevice Controller. Each vComponent serves its own control plane socket, and the Controller routes control messages to the right one. The vComponent emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md), and registers with the Service Manager but completes startup only once an HFP is applied.
 
-The Controller provides a common control plane socket for all vComponents. A vComponent can also run standalone with its own control plane socket — given by `--port` — to debug a single module, optionally with its HFP on the command line:
+A vComponent's control plane socket is given by `--port`. It can run standalone — launched directly to debug a single module — optionally with its HFP on the command line:
 
 ```
 <module> --port <port> --hfp <hfp-locator>
@@ -127,13 +127,13 @@ ExecStart=/usr/bin/<module> --port %i --hfp ${HFP_FILE}
 
 ### HFP Delivery Over the Control Plane
 
-A vComponent attaches to the control plane when it registers. For a vComponent parked in `WAITING_FOR_CONFIG`, the HFP arrives as a YAML control message on the control plane socket — sent by the vDevice Controller, or, for a standalone vComponent, to its own `--port` socket. Applying that message moves the vComponent `WAITING_FOR_CONFIG` → `APPLYING` → `RUNNING`.
+A vComponent attaches to its control plane socket when it registers. For a vComponent parked in `WAITING_FOR_CONFIG`, the HFP arrives there as a YAML control message — routed by the vDevice Controller, or sent directly to its `--port` socket when standalone. Applying that message moves the vComponent `WAITING_FOR_CONFIG` → `APPLYING` → `RUNNING`.
 
 ### vDevice Requirements
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.VDEVICE.1** |A standalone vComponent shall accept the control plane socket it serves on as the `--port` command-line argument, and its HFP locator as the `--hfp` command-line argument.|Under the Controller, a vComponent uses the common control plane socket instead.|
+|**HAL.VDEVICE.1** |A vComponent shall accept the control plane socket it serves on as the `--port` command-line argument, and its HFP locator as the `--hfp` command-line argument.|Each vComponent serves its own socket; the Controller routes control messages to it.|
 |**HAL.VDEVICE.2** |A vComponent shall register and attach to the control plane before requiring an HFP, entering a registered-but-unconfigured state.|Makes a vComponent started without an HFP reachable rather than failed.|
 |**HAL.VDEVICE.3** |A vComponent started without `--hfp` shall apply an HFP delivered as a control plane message before completing startup.|The `--hfp` value, when present, is supplied by an operator or by systemd from the kernel command-line locator.|
 |**HAL.VDEVICE.4** |A vComponent shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||

--- a/docs/vsi/boot_sequence/current/module_boot_sequence.md
+++ b/docs/vsi/boot_sequence/current/module_boot_sequence.md
@@ -1,36 +1,81 @@
 # Module Boot Sequence
 
-A HAL module runs as its own process launched by [systemd](../../systemd/current/systemd.md). Each module is launched with a port and a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md):
+## Overview
+
+A HAL module runs as its own process, launched by [systemd](../../systemd/current/systemd.md). It listens on a Binder port and registers its interface with the [Service Manager](../../service_manager/current/service_manager.md), at which point clients can discover and call it.
 
 ```
-<module> --port <port> --hfp <hfp-file>
+<module> --port <port>
 ```
 
-The HFP configures the module against the vendor layer it runs on. A module reaches Binder readiness and registers with the [Service Manager](../../service_manager/current/service_manager.md) **before** it has its HFP, then completes startup once the HFP is applied. This gives one startup path whether the HFP is supplied at launch or delivered afterwards over Binder.
+On the [vDevice](#vdevice-configuration), a module additionally presents the hardware capabilities declared in a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md), supplied with `--hfp`. Because the HFP defines what the module emulates, a vDevice module completes startup only once an HFP is applied. A module backed by real hardware initialises from that hardware and does not depend on an HFP.
 
-!!! info "References"
-    |Reference|Link|
+---
+
+## References
+
+!!! info References
+    |||
     |-|-|
     |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
+    |**Initialization Unit**|[systemd service](../../systemd/current/systemd.md)|
     |**Service Registration**|[Service Manager](../../service_manager/current/service_manager.md)|
-    |**Configuration**|[HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md)|
-    |**Initialization**|[systemd](../../systemd/current/systemd.md)|
+
+---
+
+## Related Pages
+
+!!! tip "Related Pages"
+    - [Service Manager](../../service_manager/current/service_manager.md)
+    - [Systemd](../../systemd/current/systemd.md)
+    - [HAL Feature Profile](../../../key_concepts/hal/hal_feature_profiles.md)
+    - [AIDL and Binder](../../../introduction/aidl_and_binder.md)
+
+---
+
+## Startup Sequence
+
+A module is launched with the Binder port it listens on:
+
+```
+<module> --port <port>
+```
+
+It brings up its Binder interface, registers with the Service Manager, initialises, and becomes ready to serve clients.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> STARTING
+    STARTING --> REGISTERED: binder up,<br>registered with Service Manager
+    REGISTERED --> RUNNING: initialised<br>sd_notify(READY=1)
+
+    classDef NonTransitory fill:#1976D2, color:white, font-weight:bold;
+    classDef Transitory fill:#90CAF9, color:black, font-weight:bold;
+    class REGISTERED,RUNNING NonTransitory
+    class STARTING Transitory
+```
 
 ## Implementation Requirements
 
 |#|Requirement | Comments|
 |-|------------|---------|
-|**HAL.BOOTSEQ.1** |A module shall accept its listen port and HFP file location as the `--port` and `--hfp` command-line arguments.||
-|**HAL.BOOTSEQ.2** |A module shall bring up its Binder interface and register with the Service Manager before requiring an HFP, entering a registered-but-unconfigured state.|Makes a module launched without an HFP discoverable rather than failed.|
-|**HAL.BOOTSEQ.3** |A module shall resolve its HFP from, in priority order: the `--hfp` argument, the systemd-provided environment, then the kernel command line. When none supplies one, the module shall wait for an HFP delivered over Binder.|First source that yields an HFP wins.|
-|**HAL.BOOTSEQ.4** |A module shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||
-|**HAL.BOOTSEQ.5** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state, after the HFP is applied.|Dependents ordered `After=` the module start against a configured module.|
-|**HAL.BOOTSEQ.6** |A module that fails to apply its HFP shall exit non-zero, leaving recovery to the systemd restart policy.||
-|**HAL.BOOTSEQ.7** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
+|**HAL.BOOTSEQ.1** |A module shall accept the Binder port it listens on as the `--port` command-line argument.||
+|**HAL.BOOTSEQ.2** |A module shall bring up its Binder interface and register with the Service Manager during startup.|Registration makes the module discoverable to clients.|
+|**HAL.BOOTSEQ.3** |A module and the services it registers with or calls shall share the same Binder domain.|For example `/dev/binder` versus `/dev/vndbinder`.|
+|**HAL.BOOTSEQ.4** |A module using `Type=notify` shall send `sd_notify(READY=1)` only on reaching the running state.|Dependents ordered `After=` the module start against a ready module.|
 
-## Startup State Machine
+---
 
-The module reaches `REGISTERED` without the HFP, then gates the remainder of startup on the HFP arriving. A module launched with an HFP transitions straight through `APPLYING` to `RUNNING`; a module launched without one parks in `WAITING_FOR_CONFIG` until the HFP is delivered over Binder.
+## vDevice Configuration
+
+On the vDevice, a module emulates the hardware described by a [HAL Feature Profile (HFP)](../../../key_concepts/hal/hal_feature_profiles.md). The HFP defines the capabilities the module presents, so a vDevice module registers with the Service Manager but completes startup only once an HFP is applied.
+
+```
+<module> --port <port> --hfp <hfp-file>
+```
+
+A vDevice module reaches `REGISTERED` without the HFP and installs a control callback there, then applies the HFP from the first source that supplies one. When no source does, it parks in `WAITING_FOR_CONFIG` until an HFP is delivered over Binder. This gives one path whether the HFP is supplied at launch or afterwards.
 
 ```mermaid
 stateDiagram-v2
@@ -51,20 +96,20 @@ stateDiagram-v2
     class STARTING,APPLYING Transitory
 ```
 
-## HFP Resolution Order
+### HFP Resolution Order
 
 The HFP is resolved at the `REGISTERED` transition, taking the first source that yields one:
 
 |Priority|Source|Use|
 |-|------|---|
 |1|`--hfp <path>` command-line argument|An operator launching a single module by hand.|
-|2|systemd-provided environment (`EnvironmentFile`)|The on-device launch.|
-|3|Kernel command-line locator (`/proc/cmdline`)|The production default.|
+|2|systemd-provided environment (`EnvironmentFile`)|The on-device vDevice launch.|
+|3|Kernel command-line locator (`/proc/cmdline`)|The default vDevice launch.|
 |4|Binder delivery into `WAITING_FOR_CONFIG`|The HFP is pushed after startup.|
 
 Sources 1–3 differ only in where the HFP location comes from; the same apply routine consumes all four.
 
-## Kernel Command Line to systemd
+### Kernel Command Line to systemd
 
 The kernel command line carries an HFP **locator** — a path, partition, or URI — not the HFP contents:
 
@@ -87,7 +132,7 @@ EnvironmentFile=-/run/hfp/module@%i.env
 ExecStart=/usr/bin/<module> --port %i --hfp ${HFP_FILE}
 ```
 
-## HFP Delivery Over Binder
+### HFP Delivery Over Binder
 
 A module installs a control callback when it registers, so the configuring service drives the HFP in for a module parked in `WAITING_FOR_CONFIG`:
 
@@ -99,9 +144,19 @@ interface IModuleControl {
 
 `applyHfp()` moves the module `WAITING_FOR_CONFIG` → `APPLYING` → `RUNNING`.
 
-## Boot Sequence
+### vDevice Requirements
 
-The production boot, where the kernel command line supplies the HFP locator:
+|#|Requirement | Comments|
+|-|------------|---------|
+|**HAL.VDEVICE.1** |A vDevice module shall accept its HFP file location as the `--hfp` command-line argument.||
+|**HAL.VDEVICE.2** |A vDevice module shall register with the Service Manager before requiring an HFP, entering a registered-but-unconfigured state.|Makes a module launched without an HFP discoverable rather than failed.|
+|**HAL.VDEVICE.3** |A vDevice module shall resolve its HFP from, in priority order: the `--hfp` argument, the systemd-provided environment, then the kernel command line. When none supplies one, the module shall wait for an HFP delivered over Binder.|First source that yields an HFP wins.|
+|**HAL.VDEVICE.4** |A vDevice module shall apply its HFP exactly once and retain that configuration for the lifetime of the process.||
+|**HAL.VDEVICE.5** |A vDevice module that fails to apply its HFP shall exit non-zero, leaving recovery to the systemd restart policy.||
+
+### vDevice Boot Sequence
+
+The default vDevice boot, where the kernel command line supplies the HFP locator:
 
 ```mermaid
 sequenceDiagram
@@ -123,10 +178,9 @@ sequenceDiagram
     Module->>Module: read HFP, applyHfp()
     Note over Module: APPLYING → RUNNING
     Module->>Systemd: sd_notify(READY=1)
-    Module->>Module: start background work
 ```
 
-A module launched without an HFP, configured later over Binder:
+A vDevice module launched without an HFP, configured later over Binder:
 
 ```mermaid
 sequenceDiagram
@@ -141,9 +195,10 @@ sequenceDiagram
     Svc->>SM: getService(module)
     Svc->>Module: applyHfp(cfg)
     Note over Module: APPLYING → RUNNING
-    Module->>Module: start background work
 ```
+
+---
 
 ## Product Customization
 
-The HFP file is a vendor-layer deliverable describing the module's configuration on the target platform. The kernel command line `hfp=` locator and the systemd generator that turns it into `--hfp` are provided by the vendor layer.
+The systemd unit that launches a module is a vendor-layer deliverable. On the vDevice, the HFP file describing the emulated hardware, the kernel command-line `hfp=` locator, and the systemd generator that turns it into `--hfp` are provided alongside it.

--- a/docs/vsi/service_manager/current/service_manager.md
+++ b/docs/vsi/service_manager/current/service_manager.md
@@ -11,6 +11,7 @@ The **Service Manager** is a crucial **Binder service** included in the vendor l
     |-|-|
     |**Interface Definition**|[IServiceManager](https://android.googlesource.com/platform/frameworks/native/+/android-13.0.0_r74/libs/binder/include/binder/IServiceManager.h)|
     |**HAL Interface Type**|[AIDL and Binder](../../../introduction/aidl_and_binder.md)|
+    |**Module Startup**|[Module Boot Sequence](../../boot_sequence/current/module_boot_sequence.md)|
 
 ## Implementation Requirements
 

--- a/docs/vsi/systemd/current/systemd.md
+++ b/docs/vsi/systemd/current/systemd.md
@@ -10,7 +10,7 @@
 ## Related Pages
 
 !!! tip "Related Pages"
-    - TBC
+    - [Module Boot Sequence](../../boot_sequence/current/module_boot_sequence.md)
 
 ## 🚧 Document Under Construction
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Bluetooth: '!include vsi/bluetooth/current/mkdocs.yml'
     - Graphics: '!include vsi/graphics/current/mkdocs.yml'
     - Service Manager: vsi/service_manager/current/service_manager.md
+    - Module Boot Sequence: vsi/boot_sequence/current/module_boot_sequence.md
     - Wi-Fi: '!include vsi/wifi/current/mkdocs.yml'
     - Systemd: vsi/systemd/current/systemd.md
     - Kernel: '!include vsi/kernel/current/mkdocs.yml'


### PR DESCRIPTION
Implements the documentation deliverable from #86: a VSI page describing how a HAL module process boots, with vDevice configuration scoped to its own section.

## Structure

`docs/vsi/boot_sequence/current/module_boot_sequence.md`, following the standard top-of-doc pattern (Overview / References / Related Pages):

**General boot sequence** (real hardware):

- Launched by systemd with no command-line configuration; registers its Binder interface with the Service Manager under its service name (standard registration mechanism), initialises, becomes ready.
- State machine `STARTING → REGISTERED → RUNNING`; signals readiness only on reaching the running state (e.g. `sd_notify(READY=1)` under `Type=notify`); shared Binder domain.
- Requirements `HAL.BOOTSEQ.1`–`HAL.BOOTSEQ.3`.

**vDevice Configuration** (vComponent-specific):

- A module runs as a vComponent under the vDevice Controller. Each vComponent serves its own control plane socket (`--port`); the Controller routes control messages to it. The vComponent emulates the hardware declared in an HFP (`--hfp` locator).
- The default boot configures every module from a single HFP covering all modules; each vComponent applies the section for its own domain.
- HFP locator is a URL (an HTTP file in a git repo, resolved by ut-control), passed launcher → bootloader → kernel command line and fetched at boot.
- Post-startup HFP delivery is a YAML control message on the vComponent's control plane socket — there is no Binder path for HFP delivery.
- Requirements `HAL.VDEVICE.1`–`HAL.VDEVICE.5`; state machine + two sequence diagrams.

Nav entry under **Vendor System Interfaces (VSI)**, cross-linked from the Service Manager and Systemd pages.

## Validation

`mkdocs build --strict` passes (exit 0); no warnings on the new page or links.

Refs #86 — delivers the module boot sequence scope added to #86 (see the scope comment there). The QEMU/Ubuntu vDevice doc refresh in the original #86 text is separate and not included here, so this PR does not auto-close it.
