### PR TITLE
feat(videodecoder)!: VideoDecoderStreamConfig + InputBufferMetadata overrides (#539)

### DIFF
--- a/videodecoder/current/com/rdk/hal/videodecoder/DolbyVisionLayerFlags.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/DolbyVisionLayerFlags.aidl
@@ -1,0 +1,49 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     Dolby Vision dual-layer presence flags.
+ *
+ *  Indicates whether a Dolby Vision Base Layer (BL) and/or Enhancement
+ *  Layer (EL) are present in the bitstream, as signalled in the container.
+ *  This lets the decoder configure the correct dual-stream DV decode mode
+ *  before decoding begins.
+ *
+ *  A BL-only stream is a standard HEVC/AVC-compatible stream with Dolby
+ *  Vision RPU metadata. A BL+EL stream carries an additional enhancement
+ *  layer for full Dolby Vision quality.
+ *
+ *  Only applicable when the stream DynamicRange is DOLBY_VISION.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+parcelable DolbyVisionLayerFlags {
+
+    /**
+     * true if a Dolby Vision Base Layer is present.
+     */
+    boolean blPresent;
+
+    /**
+     * true if a Dolby Vision Enhancement Layer is present.
+     */
+    boolean elPresent;
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/Fraction.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/Fraction.aidl
@@ -1,0 +1,48 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     Rational number expressed as numerator / denominator.
+ *
+ *  Used wherever a structured rational is required in place of two loose
+ *  `int` parameters — frame rate (e.g. 30000/1001 for 29.97 fps), pixel
+ *  aspect ratio (e.g. 10/11 for NTSC), or any other ratio.
+ *
+ *  Carrying APIs document their own rules for `0/0` ("unknown") and
+ *  zero-denominator handling. As a base contract:
+ *  - `denominator` MUST be > 0 unless the carrying API explicitly permits
+ *    `0/0` to encode "unknown".
+ *  - `numerator` MUST be >= 0.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+parcelable Fraction {
+
+    /**
+     * Numerator. Must be >= 0.
+     */
+    int numerator;
+
+    /**
+     * Denominator. Must be > 0 unless the carrying API permits 0/0.
+     */
+    int denominator;
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
@@ -23,6 +23,7 @@ import com.rdk.hal.videodecoder.MasteringDisplayInfo;
 import com.rdk.hal.videodecoder.ContentLightLevel;
 import com.rdk.hal.videodecoder.Colorimetry;
 import com.rdk.hal.videodecoder.InputBufferMetadata;
+import com.rdk.hal.videodecoder.VideoDecoderStreamConfig;
 import com.rdk.hal.PropertyValue;
 
 /**
@@ -269,214 +270,48 @@ interface IVideoDecoderController
     boolean parseCodecSpecificData(in CSDVideoFormat csdVideoFormat, in byte[] codecData);
 
     /**
-     * Sets the mastering display colour volume metadata for the stream (SMPTE ST 2086).
+     * Atomically applies a batch of container/manifest-derived
+     * stream-configuration hints in a single binder transaction. This is
+     * the canonical surface for setting all `VideoDecoderStreamConfig`
+     * fields — there are no individual typed setters; every field is
+     * configured through this call.
      *
-     * Provides the display primaries, white point, and peak/floor luminance of the
-     * mastering display. This is typically sourced from container-level metadata
-     * (e.g. MP4/ISOBMFF 'mdcv' box, DASH MPD) before SEI messages arrive in the stream.
-     *
-     * Pass null to clear any previously set value and revert to stream-signalled metadata.
+     * <h4>Atomicity</h4>
+     * Either every non-null field is applied or none are. If any field fails
+     * validation, the call returns `EX_ILLEGAL_ARGUMENT` and the decoder
+     * state is unchanged from before the call.
      *
      * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived metadata (H.264/HEVC SEI payload type 137 — "mastering display
-     * colour volume") takes precedence over this hint when present; the hint is the
-     * fallback used only when the bitstream is silent.
-     * The value the decoder actually used is reported via
-     * `FrameMetadata.masteringDisplayInfo`. The hint persists across `flush()` and
-     * is cleared on `close()`.
+     * Bitstream-derived metadata wins over the hint when present; the hint
+     * is the fallback used only when the bitstream is silent. The values the
+     * decoder actually used are reported via `FrameMetadata`. Hints persist
+     * across `flush()` and are cleared on `close()`.
      *
-     * @param[in] info  Mastering display metadata, or null to clear.
+     * <h4>Per-field application</h4>
+     * Each non-null field is applied to the decoder's stream-config state:
+     * - `resolution`           — pre-allocation seed for frame buffers
+     * - `frameRate`            — pipeline timing seed
+     * - `pixelAspectRatio`     — PAR fallback when bitstream VUI omits it
+     * - `colorimetry`          — colour primaries / matrix fallback
+     * - `masteringDisplayInfo` — SMPTE ST 2086 fallback (HEVC SEI type 137)
+     * - `contentLightLevel`    — CTA-861.3 MaxCLL/MaxFALL fallback (SEI 144)
+     * - `dolbyVisionLayerFlags`— BL/EL presence; only meaningful for DOLBY_VISION
+     *
+     * @param[in] config  Stream-configuration batch. Fields set to `null`
+     *                    are ignored (no change). Fields with values are
+     *                    applied as hints; see `VideoDecoderStreamConfig`
+     *                    for per-field validation rules.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if any field fails validation
+     *            (e.g. `resolution.width <= 0`, `frameRate.denominator == 0`
+     *            while `numerator != 0`, exactly one of `pixelAspectRatio.numerator` /
+     *            `denominator` is 0).
      *
      * @pre The resource must be in State::READY.
      *
-     * @see MasteringDisplayInfo, FrameMetadata.masteringDisplayInfo
+     * @see VideoDecoderStreamConfig, FrameMetadata
      */
-    void setMasteringDisplayInfo(in @nullable MasteringDisplayInfo info);
-
-    /**
-     * Sets the content light level metadata for the stream (CTA-861.3 / H.264/HEVC SEI
-     * payload type 144 — "content light level information").
-     *
-     * Provides the MaxCLL and MaxFALL values as CTA-861.3 static metadata. This is typically
-     * sourced from container-level metadata (e.g. MP4/ISOBMFF 'clli' box, DASH MPD) before
-     * SEI messages arrive in the stream.
-     *
-     * Pass null to clear any previously set value and revert to stream-signalled metadata.
-     *
-     * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived metadata (H.264/HEVC SEI payload type 144 — "content light level
-     * information") takes precedence over this hint when present; the hint is the fallback
-     * used only when the bitstream is silent.
-     * The value the decoder actually used is reported via
-     * `FrameMetadata.contentLightLevel`. The hint persists across `flush()` and
-     * is cleared on `close()`.
-     *
-     * @param[in] info  Content light level metadata, or null to clear.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     *
-     * @pre The resource must be in State::READY.
-     *
-     * @see ContentLightLevel, FrameMetadata.contentLightLevel
-     */
-    void setContentLightLevel(in @nullable ContentLightLevel info);
-
-    /**
-     * Sets the colorimetry (colour primaries and matrix) for the stream.
-     *
-     * Identifies the colour space of the video content. This is typically derived
-     * from container or manifest metadata and used to configure the downstream
-     * display pipeline before decoding begins.
-     *
-     * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived colorimetry (H.264/HEVC VUI `colour_description_present_flag`
-     * and friends) takes precedence over this hint when present; the hint is the
-     * fallback used only when the bitstream is silent. The value the decoder actually
-     * used is reported via `FrameMetadata.colorimetry`. The hint persists across
-     * `flush()` and is cleared on `close()`.
-     *
-     * @param[in] colorimetry  The colorimetry of the stream. Use Colorimetry::UNKNOWN
-     *                         if not signalled.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     *
-     * @pre The resource must be in State::READY.
-     *
-     * @see Colorimetry, FrameMetadata.colorimetry
-     */
-    void setColorimetry(in Colorimetry colorimetry);
-
-    /**
-     * Sets the stream resolution hint before decoding begins.
-     *
-     * Provides the coded frame dimensions sourced from container metadata
-     * (e.g. MP4/ISOBMFF track header, DASH MPD). Allows the decoder to
-     * pre-allocate frame buffers at the correct size before the first frame
-     * is decoded.
-     *
-     * <h4>Hint precedence and persistence</h4>
-     * The decoder uses the actual coded dimensions from the bitstream once
-     * decoding starts; this hint is only the pre-allocation seed. If they differ,
-     * `FrameMetadata.codedWidth`/`codedHeight` reflects the true decoded dimensions.
-     * The hint persists across `flush()` and is cleared on `close()`.
-     *
-     * @param[in] width   Coded frame width in pixels. Must be > 0.
-     * @param[in] height  Coded frame height in pixels. Must be > 0.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if width or height is <= 0.
-     *
-     * @pre The resource must be in State::READY.
-     *
-     * @see FrameMetadata.codedWidth, FrameMetadata.codedHeight
-     */
-    void setStreamResolution(in int width, in int height);
-
-    /**
-     * Sets the stream frame rate hint before decoding begins.
-     *
-     * Provides the frame rate as a rational number (numerator/denominator)
-     * sourced from container metadata. Allows the decoder and downstream
-     * pipeline to configure timing before the first frame is decoded.
-     *
-     * e.g. 24fps = 24/1, 29.97fps = 30000/1001, 59.94fps = 60000/1001
-     *
-     * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived frame rate (H.264/HEVC VUI `vui_timing_info_present_flag`)
-     * takes precedence over this hint when present; the hint is the fallback used
-     * only when the bitstream is silent. The decoder reports the value it actually
-     * used in `FrameMetadata.frameRateNumerator` / `frameRateDenominator`. The hint
-     * persists across `flush()` and is cleared on `close()`.
-     *
-     * @param[in] numerator    Frame rate numerator. Must be >= 0. Use 0/0 if unknown.
-     * @param[in] denominator  Frame rate denominator. Must be > 0 unless numerator is 0.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if denominator is 0 and numerator is non-zero.
-     *
-     * @pre The resource must be in State::READY.
-     *
-     * @see FrameMetadata.frameRateNumerator, FrameMetadata.frameRateDenominator
-     */
-    void setFrameRate(in int numerator, in int denominator);
-
-    /**
-     * Sets the Dolby Vision layer configuration for the stream.
-     *
-     * Indicates whether a Dolby Vision Base Layer (BL) and/or Enhancement
-     * Layer (EL) are present in the bitstream, as signalled in the container.
-     * This allows the decoder to configure the correct dual-stream DV decode
-     * mode before decoding begins.
-     *
-     * A BL-only stream is a standard HEVC/AVC-compatible stream with DV
-     * RPU metadata. A BL+EL stream carries an additional enhancement layer
-     * for full Dolby Vision quality.
-     *
-     * Only applicable when the stream DynamicRange is DOLBY_VISION.
-     *
-     * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived layer signalling (DV RPU SEI) takes precedence over this hint
-     * when present; the hint is the fallback used only when the bitstream is silent.
-     * The hint persists across `flush()` and is cleared on `close()`.
-     *
-     * @param[in] blPresent  true if a Dolby Vision Base Layer is present.
-     * @param[in] elPresent  true if a Dolby Vision Enhancement Layer is present.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     *
-     * @pre The resource must be in State::READY.
-     *
-     * @see DynamicRange::DOLBY_VISION
-     */
-    void setDolbyVisionLayerFlags(in boolean blPresent, in boolean elPresent);
-
-    /**
-     * Sets the pixel aspect ratio (PAR) hint before decoding begins.
-     *
-     * Provides the pixel aspect ratio as a rational number (parX/parY)
-     * sourced from container metadata or GstCaps (`pixel-aspect-ratio` field,
-     * MP4/ISOBMFF `pasp` box). This allows the decoder and downstream
-     * pipeline (HAL / display) to correctly derive the Display Aspect Ratio
-     * (DAR) for streams that don't carry PAR in the bitstream VUI (legacy
-     * SD MPEG-2, some packagers' H.264 output, etc.).
-     *
-     * Examples:
-     *   - Square pixels        : 1/1
-     *   - NTSC 480i (Rec.601)  : 10/11
-     *   - PAL 576i (Rec.601)   : 59/54
-     *
-     * If the pixel aspect ratio is unknown or not present, callers MUST
-     * pass 0/0. This is the only valid "unknown" encoding — `parX == 0` with
-     * `parY != 0` is rejected as an illegal argument. The decoder treats
-     * 0/0 identically to "hint not set" and falls back to bitstream VUI or
-     * the decoder default (square pixels) per the precedence rules below.
-     *
-     * <h4>Hint precedence and persistence</h4>
-     * Bitstream-derived PAR (H.264/HEVC VUI `aspect_ratio_info_present_flag`)
-     * takes precedence over this hint when present; the hint is the fallback
-     * used only when the bitstream is silent. The decoder reports the value it
-     * actually used in `FrameMetadata.parX` / `FrameMetadata.parY`. The hint
-     * persists across `flush()` and is cleared on `close()`.
-     *
-     * @param[in] parX  Pixel aspect ratio numerator. Must be >= 0. Use 0 (with parY = 0) if unknown.
-     * @param[in] parY  Pixel aspect ratio denominator. Must be > 0 unless parX is also 0.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if either parameter is negative,
-     *            or if exactly one of parX / parY is 0 (the only valid "unknown" encoding is 0/0).
-     *
-     * @pre The resource must be in State::READY.
-     *
-     * @see FrameMetadata.parX, FrameMetadata.parY
-     */
-    void setPixelAspectRatio(in int parX, in int parY);
+    void setStreamConfig(in VideoDecoderStreamConfig config);
 }

--- a/videodecoder/current/com/rdk/hal/videodecoder/InputBufferMetadata.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/InputBufferMetadata.aidl
@@ -18,19 +18,67 @@
  */
 package com.rdk.hal.videodecoder;
 
+import com.rdk.hal.videodecoder.Fraction;
+import com.rdk.hal.videodecoder.Colorimetry;
+import com.rdk.hal.videodecoder.MasteringDisplayInfo;
+import com.rdk.hal.videodecoder.ContentLightLevel;
+import com.rdk.hal.videodecoder.DolbyVisionLayerFlags;
+
 /**
  *  @brief     Per-buffer metadata carried with input buffers submitted via
  *             `IVideoDecoderController.decodeBufferWithMetadata()`.
  *
  *  Describes properties of the encoded frame that cannot be derived from the
- *  buffer contents alone, such as its presentation time.
+ *  buffer contents alone, such as its presentation time, plus optional
+ *  container-derived metadata overrides that apply from this frame onward.
  *
- *  Each `decodeBufferWithMetadata()` call is self-describing: the HAL MUST NOT
- *  carry state from this parcelable across calls. A subsequent call with
- *  default-valued fields replaces, it does not preserve, the previous call's
- *  values.
+ *  <h3>Field semantics</h3>
+ *  The fields fall into two categories with distinct semantics:
+ *
+ *  <h4>Non-nullable per-buffer fields (`nsPresentationTime`, `discontinuity`)</h4>
+ *  These describe the encoded frame itself. Each `decodeBufferWithMetadata()`
+ *  call is self-describing for these fields: the HAL MUST NOT carry state
+ *  from this parcelable across calls. A subsequent call with default-valued
+ *  fields replaces, it does not preserve, the previous call's values.
+ *
+ *  <h4>Override fields (`colorimetry`, `masteringDisplayInfo`,
+ *  `contentLightLevel`, `dolbyVisionLayerFlags`, `pixelAspectRatio`)</h4>
+ *  All five are `@nullable` except `colorimetry`, which uses
+ *  `Colorimetry::UNKNOWN` as the "no change" sentinel because AIDL
+ *  enums cannot be `@nullable`.
+ *  These mirror the matching fields on `VideoDecoderStreamConfig` and let
+ *  middleware push container-derived metadata that changes mid-stream
+ *  (e.g. ABR per-Period HDR transition, SSAI ad insertion, live→VOD switch).
+ *
+ *  - non-null                — apply this override from this buffer onward;
+ *                              persists for subsequent buffers until a later
+ *                              override (or a `setStreamConfig()` call)
+ *                              replaces it.
+ *  - null                    — no change for this field; the previously
+ *                              applied override (or the value set in
+ *                              `State::READY` via `setStreamConfig()`)
+ *                              remains in effect.
+ *  - `Colorimetry::UNKNOWN`  — the "no change" form for `colorimetry`
+ *                              (which is non-nullable because AIDL enums
+ *                              cannot be `@nullable`). Semantics match
+ *                              the `null` form above for the other four
+ *                              fields.
+ *
+ *  Override precedence and persistence matches the `VideoDecoderStreamConfig`
+ *  contract: bitstream-derived metadata still wins over the override;
+ *  overrides are the fallback used only when the bitstream is silent.
+ *  Overrides persist across `flush()` and are cleared on `close()`.
+ *
+ *  <h3>Scope</h3>
+ *  Bitstream-driven properties (resolution / frame rate) are intentionally
+ *  omitted from the override fields — on modern codecs these are signalled
+ *  per-SPS in the bitstream and middleware should not override them
+ *  mid-stream. Codec or encryption-mode changes are also out of scope and
+ *  require a decoder teardown / `IVideoDecoder.open()` cycle.
  *
  *  @see IVideoDecoderController.decodeBufferWithMetadata()
+ *  @see IVideoDecoderController.setStreamConfig()
+ *  @see VideoDecoderStreamConfig
  *
  *  @author    Gerald Weatherup
  */
@@ -53,4 +101,50 @@ parcelable InputBufferMetadata {
      * @see IVideoDecoderController.signalDiscontinuity()
      */
     boolean discontinuity;
+
+    /**
+     * Optional colorimetry override applied from this buffer onward.
+     * AIDL enums cannot be `@nullable`, so this
+     * field uses `Colorimetry::UNKNOWN` (the default for an unset enum)
+     * to encode "no change". Any other value applies as an override.
+     *
+     * @see VideoDecoderStreamConfig.colorimetry, IVideoDecoderController.setStreamConfig()
+     */
+    Colorimetry colorimetry = Colorimetry.UNKNOWN;
+
+    /**
+     * Optional mastering display colour volume override (SMPTE ST 2086)
+     * applied from this buffer onward. null = no change.
+     *
+     * @see VideoDecoderStreamConfig.masteringDisplayInfo, IVideoDecoderController.setStreamConfig()
+     */
+    @nullable MasteringDisplayInfo masteringDisplayInfo;
+
+    /**
+     * Optional content light level override (CTA-861.3 MaxCLL / MaxFALL)
+     * applied from this buffer onward. null = no change.
+     *
+     * @see VideoDecoderStreamConfig.contentLightLevel, IVideoDecoderController.setStreamConfig()
+     */
+    @nullable ContentLightLevel contentLightLevel;
+
+    /**
+     * Optional Dolby Vision layer-flags override applied from this buffer
+     * onward. Only meaningful when the stream DynamicRange is
+     * DOLBY_VISION.
+     * null = no change.
+     *
+     * @see VideoDecoderStreamConfig.dolbyVisionLayerFlags, IVideoDecoderController.setStreamConfig()
+     */
+    @nullable DolbyVisionLayerFlags dolbyVisionLayerFlags;
+
+    /**
+     * Optional pixel aspect ratio override applied from this buffer onward.
+     * 0/0 encodes "unknown" (matching the
+     * `VideoDecoderStreamConfig.pixelAspectRatio` rule).
+     * null = no change.
+     *
+     * @see VideoDecoderStreamConfig.pixelAspectRatio, IVideoDecoderController.setStreamConfig()
+     */
+    @nullable Fraction pixelAspectRatio;
 }

--- a/videodecoder/current/com/rdk/hal/videodecoder/Resolution.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/Resolution.aidl
@@ -1,0 +1,47 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     Two-dimensional pixel resolution.
+ *
+ *  Carries a `{width, height}` pair in pixels. Used wherever a structured
+ *  resolution is required in place of two loose `int` parameters — for
+ *  example, batched stream-configuration parcelables and capability
+ *  descriptors.
+ *
+ *  Both fields are integer pixel counts and MUST be > 0 when the
+ *  resolution is used as a hint or target. Container types that allow
+ *  "unknown" must document that convention on the carrying field.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+parcelable Resolution {
+
+    /**
+     * Frame width in pixels. Must be > 0.
+     */
+    int width;
+
+    /**
+     * Frame height in pixels. Must be > 0.
+     */
+    int height;
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.aidl
@@ -1,0 +1,119 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+import com.rdk.hal.videodecoder.Resolution;
+import com.rdk.hal.videodecoder.Fraction;
+import com.rdk.hal.videodecoder.Colorimetry;
+import com.rdk.hal.videodecoder.MasteringDisplayInfo;
+import com.rdk.hal.videodecoder.ContentLightLevel;
+import com.rdk.hal.videodecoder.DolbyVisionLayerFlags;
+
+/**
+ *  @brief     Atomic stream-configuration batch for the video decoder.
+ *
+ *  Carries the full set of container/manifest-derived stream-description
+ *  hints in a single parcelable. Submitted via
+ *  `IVideoDecoderController.setStreamConfig()` in `State::READY`, before
+ *  decoding starts, as one atomic transaction.
+ *
+ *  Fields are `@nullable` except `colorimetry`, which carries its own
+ *  `UNKNOWN` sentinel because AIDL does not permit `@nullable` on enums.
+ *  Semantics:
+ *  - non-null (or `colorimetry` ≠ `UNKNOWN`) — apply this value as the hint
+ *  - null (or `colorimetry == UNKNOWN`)      — leave the existing hint
+ *                                              unchanged (no-op for that field)
+ *
+ *  The "no change" semantics let clients send partial updates without
+ *  having to repeat values they have already configured.
+ *
+ *  <h3>Hint precedence and persistence</h3>
+ *  - Bitstream-derived metadata wins over the hint when both are present;
+ *    the hint is the fallback used only when the bitstream is silent.
+ *  - The decoder reports the value it actually used in `FrameMetadata`.
+ *  - Hints persist across `flush()` and are cleared on `close()`.
+ *
+ *  <h3>Validation</h3>
+ *  - `resolution`        — `width` and `height` MUST be > 0.
+ *  - `frameRate`         — `denominator` MUST be > 0 unless `numerator`
+ *                          is also 0 (encodes "unknown").
+ *  - `pixelAspectRatio`  — both fields MUST be >= 0; the only valid
+ *                          "unknown" encoding is 0/0.
+ *
+ *  @see IVideoDecoderController.setStreamConfig()
+ *  @see Resolution
+ *  @see Fraction
+ *  @see Colorimetry
+ *  @see MasteringDisplayInfo
+ *  @see ContentLightLevel
+ *  @see DolbyVisionLayerFlags
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+parcelable VideoDecoderStreamConfig {
+
+    /**
+     * Coded frame dimensions.
+     * null = leave existing resolution hint unchanged.
+     */
+    @nullable Resolution resolution;
+
+    /**
+     * Stream frame rate as numerator / denominator.
+     * 0/0 encodes "unknown".
+     * null = leave existing frame rate hint unchanged.
+     */
+    @nullable Fraction frameRate;
+
+    /**
+     * Pixel aspect ratio as numerator / denominator.
+     * 0/0 encodes "unknown".
+     * null = leave existing PAR hint unchanged.
+     */
+    @nullable Fraction pixelAspectRatio;
+
+    /**
+     * Colorimetry (colour primaries and matrix) for the stream.
+     * AIDL enums cannot be `@nullable`,
+     * so this field uses `Colorimetry::UNKNOWN` (the default for an unset
+     * enum) to encode "leave existing colorimetry hint unchanged".
+     * Any other value applies as a hint.
+     */
+    Colorimetry colorimetry = Colorimetry.UNKNOWN;
+
+    /**
+     * Mastering display colour volume metadata (SMPTE ST 2086).
+     * null = leave existing mastering display hint unchanged.
+     */
+    @nullable MasteringDisplayInfo masteringDisplayInfo;
+
+    /**
+     * Content light level metadata (CTA-861.3 MaxCLL / MaxFALL).
+     * null = leave existing content light level hint unchanged.
+     */
+    @nullable ContentLightLevel contentLightLevel;
+
+    /**
+     * Dolby Vision layer presence flags. Only applicable when the
+     * stream DynamicRange is DOLBY_VISION.
+     * null = leave existing Dolby Vision layer hint unchanged.
+     */
+    @nullable DolbyVisionLayerFlags dolbyVisionLayerFlags;
+}

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnDolbyVisionLayerFlags.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnDolbyVisionLayerFlags.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnFraction.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnFraction.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnResolution.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnResolution.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnVideoDecoderController.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnVideoDecoderController.h
@@ -17,13 +17,7 @@ public:
   static constexpr uint32_t TRANSACTION_signalDiscontinuity = ::android::IBinder::FIRST_CALL_TRANSACTION + 5;
   static constexpr uint32_t TRANSACTION_signalEndOfStream = ::android::IBinder::FIRST_CALL_TRANSACTION + 6;
   static constexpr uint32_t TRANSACTION_parseCodecSpecificData = ::android::IBinder::FIRST_CALL_TRANSACTION + 7;
-  static constexpr uint32_t TRANSACTION_setMasteringDisplayInfo = ::android::IBinder::FIRST_CALL_TRANSACTION + 8;
-  static constexpr uint32_t TRANSACTION_setContentLightLevel = ::android::IBinder::FIRST_CALL_TRANSACTION + 9;
-  static constexpr uint32_t TRANSACTION_setColorimetry = ::android::IBinder::FIRST_CALL_TRANSACTION + 10;
-  static constexpr uint32_t TRANSACTION_setStreamResolution = ::android::IBinder::FIRST_CALL_TRANSACTION + 11;
-  static constexpr uint32_t TRANSACTION_setFrameRate = ::android::IBinder::FIRST_CALL_TRANSACTION + 12;
-  static constexpr uint32_t TRANSACTION_setDolbyVisionLayerFlags = ::android::IBinder::FIRST_CALL_TRANSACTION + 13;
-  static constexpr uint32_t TRANSACTION_setPixelAspectRatio = ::android::IBinder::FIRST_CALL_TRANSACTION + 14;
+  static constexpr uint32_t TRANSACTION_setStreamConfig = ::android::IBinder::FIRST_CALL_TRANSACTION + 8;
   static constexpr uint32_t TRANSACTION_getInterfaceVersion = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777214;
   static constexpr uint32_t TRANSACTION_getInterfaceHash = ::android::IBinder::FIRST_CALL_TRANSACTION + 16777213;
   explicit BnVideoDecoderController();
@@ -60,26 +54,8 @@ public:
   ::android::binder::Status parseCodecSpecificData(::com::rdk::hal::videodecoder::CSDVideoFormat csdVideoFormat, const ::std::vector<uint8_t>& codecData, bool* _aidl_return) override {
     return _aidl_delegate->parseCodecSpecificData(csdVideoFormat, codecData, _aidl_return);
   }
-  ::android::binder::Status setMasteringDisplayInfo(const ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo>& info) override {
-    return _aidl_delegate->setMasteringDisplayInfo(info);
-  }
-  ::android::binder::Status setContentLightLevel(const ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel>& info) override {
-    return _aidl_delegate->setContentLightLevel(info);
-  }
-  ::android::binder::Status setColorimetry(::com::rdk::hal::videodecoder::Colorimetry colorimetry) override {
-    return _aidl_delegate->setColorimetry(colorimetry);
-  }
-  ::android::binder::Status setStreamResolution(int32_t width, int32_t height) override {
-    return _aidl_delegate->setStreamResolution(width, height);
-  }
-  ::android::binder::Status setFrameRate(int32_t numerator, int32_t denominator) override {
-    return _aidl_delegate->setFrameRate(numerator, denominator);
-  }
-  ::android::binder::Status setDolbyVisionLayerFlags(bool blPresent, bool elPresent) override {
-    return _aidl_delegate->setDolbyVisionLayerFlags(blPresent, elPresent);
-  }
-  ::android::binder::Status setPixelAspectRatio(int32_t parX, int32_t parY) override {
-    return _aidl_delegate->setPixelAspectRatio(parX, parY);
+  ::android::binder::Status setStreamConfig(const ::com::rdk::hal::videodecoder::VideoDecoderStreamConfig& config) override {
+    return _aidl_delegate->setStreamConfig(config);
   }
   int32_t getInterfaceVersion() override {
     int32_t _delegator_ver = BnVideoDecoderController::getInterfaceVersion();

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnVideoDecoderStreamConfig.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnVideoDecoderStreamConfig.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpDolbyVisionLayerFlags.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpDolbyVisionLayerFlags.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpFraction.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpFraction.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpResolution.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpResolution.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpVideoDecoderController.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpVideoDecoderController.h
@@ -22,13 +22,7 @@ public:
   ::android::binder::Status signalDiscontinuity() override;
   ::android::binder::Status signalEndOfStream() override;
   ::android::binder::Status parseCodecSpecificData(::com::rdk::hal::videodecoder::CSDVideoFormat csdVideoFormat, const ::std::vector<uint8_t>& codecData, bool* _aidl_return) override;
-  ::android::binder::Status setMasteringDisplayInfo(const ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo>& info) override;
-  ::android::binder::Status setContentLightLevel(const ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel>& info) override;
-  ::android::binder::Status setColorimetry(::com::rdk::hal::videodecoder::Colorimetry colorimetry) override;
-  ::android::binder::Status setStreamResolution(int32_t width, int32_t height) override;
-  ::android::binder::Status setFrameRate(int32_t numerator, int32_t denominator) override;
-  ::android::binder::Status setDolbyVisionLayerFlags(bool blPresent, bool elPresent) override;
-  ::android::binder::Status setPixelAspectRatio(int32_t parX, int32_t parY) override;
+  ::android::binder::Status setStreamConfig(const ::com::rdk::hal::videodecoder::VideoDecoderStreamConfig& config) override;
   int32_t getInterfaceVersion() override;
   std::string getInterfaceHash() override;
 private:

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpVideoDecoderStreamConfig.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpVideoDecoderStreamConfig.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/DolbyVisionLayerFlags.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/DolbyVisionLayerFlags.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <tuple>
+#include <utils/String16.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+class DolbyVisionLayerFlags : public ::android::Parcelable {
+public:
+  bool blPresent = false;
+  bool elPresent = false;
+  inline bool operator!=(const DolbyVisionLayerFlags& rhs) const {
+    return std::tie(blPresent, elPresent) != std::tie(rhs.blPresent, rhs.elPresent);
+  }
+  inline bool operator<(const DolbyVisionLayerFlags& rhs) const {
+    return std::tie(blPresent, elPresent) < std::tie(rhs.blPresent, rhs.elPresent);
+  }
+  inline bool operator<=(const DolbyVisionLayerFlags& rhs) const {
+    return std::tie(blPresent, elPresent) <= std::tie(rhs.blPresent, rhs.elPresent);
+  }
+  inline bool operator==(const DolbyVisionLayerFlags& rhs) const {
+    return std::tie(blPresent, elPresent) == std::tie(rhs.blPresent, rhs.elPresent);
+  }
+  inline bool operator>(const DolbyVisionLayerFlags& rhs) const {
+    return std::tie(blPresent, elPresent) > std::tie(rhs.blPresent, rhs.elPresent);
+  }
+  inline bool operator>=(const DolbyVisionLayerFlags& rhs) const {
+    return std::tie(blPresent, elPresent) >= std::tie(rhs.blPresent, rhs.elPresent);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.videodecoder.DolbyVisionLayerFlags");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "DolbyVisionLayerFlags{";
+    os << "blPresent: " << ::android::internal::ToString(blPresent);
+    os << ", elPresent: " << ::android::internal::ToString(elPresent);
+    os << "}";
+    return os.str();
+  }
+};  // class DolbyVisionLayerFlags
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/Fraction.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/Fraction.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <cstdint>
+#include <tuple>
+#include <utils/String16.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+class Fraction : public ::android::Parcelable {
+public:
+  int32_t numerator = 0;
+  int32_t denominator = 0;
+  inline bool operator!=(const Fraction& rhs) const {
+    return std::tie(numerator, denominator) != std::tie(rhs.numerator, rhs.denominator);
+  }
+  inline bool operator<(const Fraction& rhs) const {
+    return std::tie(numerator, denominator) < std::tie(rhs.numerator, rhs.denominator);
+  }
+  inline bool operator<=(const Fraction& rhs) const {
+    return std::tie(numerator, denominator) <= std::tie(rhs.numerator, rhs.denominator);
+  }
+  inline bool operator==(const Fraction& rhs) const {
+    return std::tie(numerator, denominator) == std::tie(rhs.numerator, rhs.denominator);
+  }
+  inline bool operator>(const Fraction& rhs) const {
+    return std::tie(numerator, denominator) > std::tie(rhs.numerator, rhs.denominator);
+  }
+  inline bool operator>=(const Fraction& rhs) const {
+    return std::tie(numerator, denominator) >= std::tie(rhs.numerator, rhs.denominator);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.videodecoder.Fraction");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "Fraction{";
+    os << "numerator: " << ::android::internal::ToString(numerator);
+    os << ", denominator: " << ::android::internal::ToString(denominator);
+    os << "}";
+    return os.str();
+  }
+};  // class Fraction
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/IVideoDecoderController.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/IVideoDecoderController.h
@@ -5,13 +5,10 @@
 #include <binder/Status.h>
 #include <com/rdk/hal/PropertyValue.h>
 #include <com/rdk/hal/videodecoder/CSDVideoFormat.h>
-#include <com/rdk/hal/videodecoder/Colorimetry.h>
-#include <com/rdk/hal/videodecoder/ContentLightLevel.h>
 #include <com/rdk/hal/videodecoder/InputBufferMetadata.h>
-#include <com/rdk/hal/videodecoder/MasteringDisplayInfo.h>
 #include <com/rdk/hal/videodecoder/Property.h>
+#include <com/rdk/hal/videodecoder/VideoDecoderStreamConfig.h>
 #include <cstdint>
-#include <optional>
 #include <utils/String16.h>
 #include <utils/StrongPointer.h>
 #include <vector>
@@ -34,13 +31,7 @@ public:
   virtual ::android::binder::Status signalDiscontinuity() = 0;
   virtual ::android::binder::Status signalEndOfStream() = 0;
   virtual ::android::binder::Status parseCodecSpecificData(::com::rdk::hal::videodecoder::CSDVideoFormat csdVideoFormat, const ::std::vector<uint8_t>& codecData, bool* _aidl_return) = 0;
-  virtual ::android::binder::Status setMasteringDisplayInfo(const ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo>& info) = 0;
-  virtual ::android::binder::Status setContentLightLevel(const ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel>& info) = 0;
-  virtual ::android::binder::Status setColorimetry(::com::rdk::hal::videodecoder::Colorimetry colorimetry) = 0;
-  virtual ::android::binder::Status setStreamResolution(int32_t width, int32_t height) = 0;
-  virtual ::android::binder::Status setFrameRate(int32_t numerator, int32_t denominator) = 0;
-  virtual ::android::binder::Status setDolbyVisionLayerFlags(bool blPresent, bool elPresent) = 0;
-  virtual ::android::binder::Status setPixelAspectRatio(int32_t parX, int32_t parY) = 0;
+  virtual ::android::binder::Status setStreamConfig(const ::com::rdk::hal::videodecoder::VideoDecoderStreamConfig& config) = 0;
   virtual int32_t getInterfaceVersion() = 0;
   virtual std::string getInterfaceHash() = 0;
 };  // class IVideoDecoderController
@@ -74,25 +65,7 @@ public:
   ::android::binder::Status parseCodecSpecificData(::com::rdk::hal::videodecoder::CSDVideoFormat /*csdVideoFormat*/, const ::std::vector<uint8_t>& /*codecData*/, bool* /*_aidl_return*/) override {
     return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
   }
-  ::android::binder::Status setMasteringDisplayInfo(const ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo>& /*info*/) override {
-    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
-  }
-  ::android::binder::Status setContentLightLevel(const ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel>& /*info*/) override {
-    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
-  }
-  ::android::binder::Status setColorimetry(::com::rdk::hal::videodecoder::Colorimetry /*colorimetry*/) override {
-    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
-  }
-  ::android::binder::Status setStreamResolution(int32_t /*width*/, int32_t /*height*/) override {
-    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
-  }
-  ::android::binder::Status setFrameRate(int32_t /*numerator*/, int32_t /*denominator*/) override {
-    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
-  }
-  ::android::binder::Status setDolbyVisionLayerFlags(bool /*blPresent*/, bool /*elPresent*/) override {
-    return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
-  }
-  ::android::binder::Status setPixelAspectRatio(int32_t /*parX*/, int32_t /*parY*/) override {
+  ::android::binder::Status setStreamConfig(const ::com::rdk::hal::videodecoder::VideoDecoderStreamConfig& /*config*/) override {
     return ::android::binder::Status::fromStatusT(::android::UNKNOWN_TRANSACTION);
   }
   int32_t getInterfaceVersion() override {

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/InputBufferMetadata.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/InputBufferMetadata.h
@@ -3,7 +3,13 @@
 #include <android/binder_to_string.h>
 #include <binder/Parcel.h>
 #include <binder/Status.h>
+#include <com/rdk/hal/videodecoder/Colorimetry.h>
+#include <com/rdk/hal/videodecoder/ContentLightLevel.h>
+#include <com/rdk/hal/videodecoder/DolbyVisionLayerFlags.h>
+#include <com/rdk/hal/videodecoder/Fraction.h>
+#include <com/rdk/hal/videodecoder/MasteringDisplayInfo.h>
 #include <cstdint>
+#include <optional>
 #include <tuple>
 #include <utils/String16.h>
 
@@ -15,23 +21,28 @@ class InputBufferMetadata : public ::android::Parcelable {
 public:
   int64_t nsPresentationTime = 0L;
   bool discontinuity = false;
+  ::com::rdk::hal::videodecoder::Colorimetry colorimetry = ::com::rdk::hal::videodecoder::Colorimetry::UNKNOWN;
+  ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo> masteringDisplayInfo;
+  ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel> contentLightLevel;
+  ::std::optional<::com::rdk::hal::videodecoder::DolbyVisionLayerFlags> dolbyVisionLayerFlags;
+  ::std::optional<::com::rdk::hal::videodecoder::Fraction> pixelAspectRatio;
   inline bool operator!=(const InputBufferMetadata& rhs) const {
-    return std::tie(nsPresentationTime, discontinuity) != std::tie(rhs.nsPresentationTime, rhs.discontinuity);
+    return std::tie(nsPresentationTime, discontinuity, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags, pixelAspectRatio) != std::tie(rhs.nsPresentationTime, rhs.discontinuity, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags, rhs.pixelAspectRatio);
   }
   inline bool operator<(const InputBufferMetadata& rhs) const {
-    return std::tie(nsPresentationTime, discontinuity) < std::tie(rhs.nsPresentationTime, rhs.discontinuity);
+    return std::tie(nsPresentationTime, discontinuity, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags, pixelAspectRatio) < std::tie(rhs.nsPresentationTime, rhs.discontinuity, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags, rhs.pixelAspectRatio);
   }
   inline bool operator<=(const InputBufferMetadata& rhs) const {
-    return std::tie(nsPresentationTime, discontinuity) <= std::tie(rhs.nsPresentationTime, rhs.discontinuity);
+    return std::tie(nsPresentationTime, discontinuity, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags, pixelAspectRatio) <= std::tie(rhs.nsPresentationTime, rhs.discontinuity, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags, rhs.pixelAspectRatio);
   }
   inline bool operator==(const InputBufferMetadata& rhs) const {
-    return std::tie(nsPresentationTime, discontinuity) == std::tie(rhs.nsPresentationTime, rhs.discontinuity);
+    return std::tie(nsPresentationTime, discontinuity, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags, pixelAspectRatio) == std::tie(rhs.nsPresentationTime, rhs.discontinuity, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags, rhs.pixelAspectRatio);
   }
   inline bool operator>(const InputBufferMetadata& rhs) const {
-    return std::tie(nsPresentationTime, discontinuity) > std::tie(rhs.nsPresentationTime, rhs.discontinuity);
+    return std::tie(nsPresentationTime, discontinuity, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags, pixelAspectRatio) > std::tie(rhs.nsPresentationTime, rhs.discontinuity, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags, rhs.pixelAspectRatio);
   }
   inline bool operator>=(const InputBufferMetadata& rhs) const {
-    return std::tie(nsPresentationTime, discontinuity) >= std::tie(rhs.nsPresentationTime, rhs.discontinuity);
+    return std::tie(nsPresentationTime, discontinuity, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags, pixelAspectRatio) >= std::tie(rhs.nsPresentationTime, rhs.discontinuity, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags, rhs.pixelAspectRatio);
   }
 
   ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
@@ -46,6 +57,11 @@ public:
     os << "InputBufferMetadata{";
     os << "nsPresentationTime: " << ::android::internal::ToString(nsPresentationTime);
     os << ", discontinuity: " << ::android::internal::ToString(discontinuity);
+    os << ", colorimetry: " << ::android::internal::ToString(colorimetry);
+    os << ", masteringDisplayInfo: " << ::android::internal::ToString(masteringDisplayInfo);
+    os << ", contentLightLevel: " << ::android::internal::ToString(contentLightLevel);
+    os << ", dolbyVisionLayerFlags: " << ::android::internal::ToString(dolbyVisionLayerFlags);
+    os << ", pixelAspectRatio: " << ::android::internal::ToString(pixelAspectRatio);
     os << "}";
     return os.str();
   }

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/Resolution.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/Resolution.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <cstdint>
+#include <tuple>
+#include <utils/String16.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+class Resolution : public ::android::Parcelable {
+public:
+  int32_t width = 0;
+  int32_t height = 0;
+  inline bool operator!=(const Resolution& rhs) const {
+    return std::tie(width, height) != std::tie(rhs.width, rhs.height);
+  }
+  inline bool operator<(const Resolution& rhs) const {
+    return std::tie(width, height) < std::tie(rhs.width, rhs.height);
+  }
+  inline bool operator<=(const Resolution& rhs) const {
+    return std::tie(width, height) <= std::tie(rhs.width, rhs.height);
+  }
+  inline bool operator==(const Resolution& rhs) const {
+    return std::tie(width, height) == std::tie(rhs.width, rhs.height);
+  }
+  inline bool operator>(const Resolution& rhs) const {
+    return std::tie(width, height) > std::tie(rhs.width, rhs.height);
+  }
+  inline bool operator>=(const Resolution& rhs) const {
+    return std::tie(width, height) >= std::tie(rhs.width, rhs.height);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.videodecoder.Resolution");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "Resolution{";
+    os << "width: " << ::android::internal::ToString(width);
+    os << ", height: " << ::android::internal::ToString(height);
+    os << "}";
+    return os.str();
+  }
+};  // class Resolution
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/videodecoder/Colorimetry.h>
+#include <com/rdk/hal/videodecoder/ContentLightLevel.h>
+#include <com/rdk/hal/videodecoder/DolbyVisionLayerFlags.h>
+#include <com/rdk/hal/videodecoder/Fraction.h>
+#include <com/rdk/hal/videodecoder/MasteringDisplayInfo.h>
+#include <com/rdk/hal/videodecoder/Resolution.h>
+#include <optional>
+#include <tuple>
+#include <utils/String16.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+class VideoDecoderStreamConfig : public ::android::Parcelable {
+public:
+  ::std::optional<::com::rdk::hal::videodecoder::Resolution> resolution;
+  ::std::optional<::com::rdk::hal::videodecoder::Fraction> frameRate;
+  ::std::optional<::com::rdk::hal::videodecoder::Fraction> pixelAspectRatio;
+  ::com::rdk::hal::videodecoder::Colorimetry colorimetry = ::com::rdk::hal::videodecoder::Colorimetry::UNKNOWN;
+  ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo> masteringDisplayInfo;
+  ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel> contentLightLevel;
+  ::std::optional<::com::rdk::hal::videodecoder::DolbyVisionLayerFlags> dolbyVisionLayerFlags;
+  inline bool operator!=(const VideoDecoderStreamConfig& rhs) const {
+    return std::tie(resolution, frameRate, pixelAspectRatio, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags) != std::tie(rhs.resolution, rhs.frameRate, rhs.pixelAspectRatio, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags);
+  }
+  inline bool operator<(const VideoDecoderStreamConfig& rhs) const {
+    return std::tie(resolution, frameRate, pixelAspectRatio, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags) < std::tie(rhs.resolution, rhs.frameRate, rhs.pixelAspectRatio, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags);
+  }
+  inline bool operator<=(const VideoDecoderStreamConfig& rhs) const {
+    return std::tie(resolution, frameRate, pixelAspectRatio, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags) <= std::tie(rhs.resolution, rhs.frameRate, rhs.pixelAspectRatio, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags);
+  }
+  inline bool operator==(const VideoDecoderStreamConfig& rhs) const {
+    return std::tie(resolution, frameRate, pixelAspectRatio, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags) == std::tie(rhs.resolution, rhs.frameRate, rhs.pixelAspectRatio, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags);
+  }
+  inline bool operator>(const VideoDecoderStreamConfig& rhs) const {
+    return std::tie(resolution, frameRate, pixelAspectRatio, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags) > std::tie(rhs.resolution, rhs.frameRate, rhs.pixelAspectRatio, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags);
+  }
+  inline bool operator>=(const VideoDecoderStreamConfig& rhs) const {
+    return std::tie(resolution, frameRate, pixelAspectRatio, colorimetry, masteringDisplayInfo, contentLightLevel, dolbyVisionLayerFlags) >= std::tie(rhs.resolution, rhs.frameRate, rhs.pixelAspectRatio, rhs.colorimetry, rhs.masteringDisplayInfo, rhs.contentLightLevel, rhs.dolbyVisionLayerFlags);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.videodecoder.VideoDecoderStreamConfig");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "VideoDecoderStreamConfig{";
+    os << "resolution: " << ::android::internal::ToString(resolution);
+    os << ", frameRate: " << ::android::internal::ToString(frameRate);
+    os << ", pixelAspectRatio: " << ::android::internal::ToString(pixelAspectRatio);
+    os << ", colorimetry: " << ::android::internal::ToString(colorimetry);
+    os << ", masteringDisplayInfo: " << ::android::internal::ToString(masteringDisplayInfo);
+    os << ", contentLightLevel: " << ::android::internal::ToString(contentLightLevel);
+    os << ", dolbyVisionLayerFlags: " << ::android::internal::ToString(dolbyVisionLayerFlags);
+    os << "}";
+    return os.str();
+  }
+};  // class VideoDecoderStreamConfig
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/DolbyVisionLayerFlags.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/DolbyVisionLayerFlags.cpp
@@ -1,0 +1,58 @@
+#include <com/rdk/hal/videodecoder/DolbyVisionLayerFlags.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+::android::status_t DolbyVisionLayerFlags::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readBool(&blPresent);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readBool(&elPresent);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t DolbyVisionLayerFlags::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeBool(blPresent);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeBool(elPresent);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/Fraction.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/Fraction.cpp
@@ -1,0 +1,58 @@
+#include <com/rdk/hal/videodecoder/Fraction.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+::android::status_t Fraction::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&numerator);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&denominator);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t Fraction::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeInt32(numerator);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt32(denominator);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/IVideoDecoderController.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/IVideoDecoderController.cpp
@@ -295,7 +295,7 @@ BpVideoDecoderController::BpVideoDecoderController(const ::android::sp<::android
   return _aidl_status;
 }
 
-::android::binder::Status BpVideoDecoderController::setMasteringDisplayInfo(const ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo>& info) {
+::android::binder::Status BpVideoDecoderController::setStreamConfig(const ::com::rdk::hal::videodecoder::VideoDecoderStreamConfig& config) {
   ::android::Parcel _aidl_data;
   _aidl_data.markForBinder(remoteStrong());
   ::android::Parcel _aidl_reply;
@@ -305,227 +305,13 @@ BpVideoDecoderController::BpVideoDecoderController(const ::android::sp<::android
   if (((_aidl_ret_status) != (::android::OK))) {
     goto _aidl_error;
   }
-  _aidl_ret_status = _aidl_data.writeNullableParcelable(info);
+  _aidl_ret_status = _aidl_data.writeParcelable(config);
   if (((_aidl_ret_status) != (::android::OK))) {
     goto _aidl_error;
   }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setMasteringDisplayInfo, _aidl_data, &_aidl_reply, 0);
+  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setStreamConfig, _aidl_data, &_aidl_reply, 0);
   if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setMasteringDisplayInfo(info);
-  }
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  if (!_aidl_status.isOk()) {
-    return _aidl_status;
-  }
-  _aidl_error:
-  _aidl_status.setFromStatusT(_aidl_ret_status);
-  return _aidl_status;
-}
-
-::android::binder::Status BpVideoDecoderController::setContentLightLevel(const ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel>& info) {
-  ::android::Parcel _aidl_data;
-  _aidl_data.markForBinder(remoteStrong());
-  ::android::Parcel _aidl_reply;
-  ::android::status_t _aidl_ret_status = ::android::OK;
-  ::android::binder::Status _aidl_status;
-  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeNullableParcelable(info);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setContentLightLevel, _aidl_data, &_aidl_reply, 0);
-  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setContentLightLevel(info);
-  }
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  if (!_aidl_status.isOk()) {
-    return _aidl_status;
-  }
-  _aidl_error:
-  _aidl_status.setFromStatusT(_aidl_ret_status);
-  return _aidl_status;
-}
-
-::android::binder::Status BpVideoDecoderController::setColorimetry(::com::rdk::hal::videodecoder::Colorimetry colorimetry) {
-  ::android::Parcel _aidl_data;
-  _aidl_data.markForBinder(remoteStrong());
-  ::android::Parcel _aidl_reply;
-  ::android::status_t _aidl_ret_status = ::android::OK;
-  ::android::binder::Status _aidl_status;
-  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(static_cast<int32_t>(colorimetry));
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setColorimetry, _aidl_data, &_aidl_reply, 0);
-  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setColorimetry(colorimetry);
-  }
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  if (!_aidl_status.isOk()) {
-    return _aidl_status;
-  }
-  _aidl_error:
-  _aidl_status.setFromStatusT(_aidl_ret_status);
-  return _aidl_status;
-}
-
-::android::binder::Status BpVideoDecoderController::setStreamResolution(int32_t width, int32_t height) {
-  ::android::Parcel _aidl_data;
-  _aidl_data.markForBinder(remoteStrong());
-  ::android::Parcel _aidl_reply;
-  ::android::status_t _aidl_ret_status = ::android::OK;
-  ::android::binder::Status _aidl_status;
-  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(width);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(height);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setStreamResolution, _aidl_data, &_aidl_reply, 0);
-  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setStreamResolution(width, height);
-  }
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  if (!_aidl_status.isOk()) {
-    return _aidl_status;
-  }
-  _aidl_error:
-  _aidl_status.setFromStatusT(_aidl_ret_status);
-  return _aidl_status;
-}
-
-::android::binder::Status BpVideoDecoderController::setFrameRate(int32_t numerator, int32_t denominator) {
-  ::android::Parcel _aidl_data;
-  _aidl_data.markForBinder(remoteStrong());
-  ::android::Parcel _aidl_reply;
-  ::android::status_t _aidl_ret_status = ::android::OK;
-  ::android::binder::Status _aidl_status;
-  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(numerator);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(denominator);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setFrameRate, _aidl_data, &_aidl_reply, 0);
-  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setFrameRate(numerator, denominator);
-  }
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  if (!_aidl_status.isOk()) {
-    return _aidl_status;
-  }
-  _aidl_error:
-  _aidl_status.setFromStatusT(_aidl_ret_status);
-  return _aidl_status;
-}
-
-::android::binder::Status BpVideoDecoderController::setDolbyVisionLayerFlags(bool blPresent, bool elPresent) {
-  ::android::Parcel _aidl_data;
-  _aidl_data.markForBinder(remoteStrong());
-  ::android::Parcel _aidl_reply;
-  ::android::status_t _aidl_ret_status = ::android::OK;
-  ::android::binder::Status _aidl_status;
-  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeBool(blPresent);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeBool(elPresent);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setDolbyVisionLayerFlags, _aidl_data, &_aidl_reply, 0);
-  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setDolbyVisionLayerFlags(blPresent, elPresent);
-  }
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_status.readFromParcel(_aidl_reply);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  if (!_aidl_status.isOk()) {
-    return _aidl_status;
-  }
-  _aidl_error:
-  _aidl_status.setFromStatusT(_aidl_ret_status);
-  return _aidl_status;
-}
-
-::android::binder::Status BpVideoDecoderController::setPixelAspectRatio(int32_t parX, int32_t parY) {
-  ::android::Parcel _aidl_data;
-  _aidl_data.markForBinder(remoteStrong());
-  ::android::Parcel _aidl_reply;
-  ::android::status_t _aidl_ret_status = ::android::OK;
-  ::android::binder::Status _aidl_status;
-  _aidl_ret_status = _aidl_data.writeInterfaceToken(getInterfaceDescriptor());
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(parX);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = _aidl_data.writeInt32(parY);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    goto _aidl_error;
-  }
-  _aidl_ret_status = remote()->transact(BnVideoDecoderController::TRANSACTION_setPixelAspectRatio, _aidl_data, &_aidl_reply, 0);
-  if (UNLIKELY(_aidl_ret_status == ::android::UNKNOWN_TRANSACTION && IVideoDecoderController::getDefaultImpl())) {
-     return IVideoDecoderController::getDefaultImpl()->setPixelAspectRatio(parX, parY);
+     return IVideoDecoderController::getDefaultImpl()->setStreamConfig(config);
   }
   if (((_aidl_ret_status) != (::android::OK))) {
     goto _aidl_error;
@@ -793,14 +579,14 @@ BnVideoDecoderController::BnVideoDecoderController()
     }
   }
   break;
-  case BnVideoDecoderController::TRANSACTION_setMasteringDisplayInfo:
+  case BnVideoDecoderController::TRANSACTION_setStreamConfig:
   {
-    ::std::optional<::com::rdk::hal::videodecoder::MasteringDisplayInfo> in_info;
+    ::com::rdk::hal::videodecoder::VideoDecoderStreamConfig in_config;
     if (!(_aidl_data.checkInterface(this))) {
       _aidl_ret_status = ::android::BAD_TYPE;
       break;
     }
-    _aidl_ret_status = _aidl_data.readParcelable(&in_info);
+    _aidl_ret_status = _aidl_data.readParcelable(&in_config);
     if (((_aidl_ret_status) != (::android::OK))) {
       break;
     }
@@ -808,177 +594,7 @@ BnVideoDecoderController::BnVideoDecoderController()
       _aidl_ret_status = st.writeToParcel(_aidl_reply);
       break;
     }
-    ::android::binder::Status _aidl_status(setMasteringDisplayInfo(in_info));
-    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (!_aidl_status.isOk()) {
-      break;
-    }
-  }
-  break;
-  case BnVideoDecoderController::TRANSACTION_setContentLightLevel:
-  {
-    ::std::optional<::com::rdk::hal::videodecoder::ContentLightLevel> in_info;
-    if (!(_aidl_data.checkInterface(this))) {
-      _aidl_ret_status = ::android::BAD_TYPE;
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readParcelable(&in_info);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
-      _aidl_ret_status = st.writeToParcel(_aidl_reply);
-      break;
-    }
-    ::android::binder::Status _aidl_status(setContentLightLevel(in_info));
-    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (!_aidl_status.isOk()) {
-      break;
-    }
-  }
-  break;
-  case BnVideoDecoderController::TRANSACTION_setColorimetry:
-  {
-    ::com::rdk::hal::videodecoder::Colorimetry in_colorimetry;
-    if (!(_aidl_data.checkInterface(this))) {
-      _aidl_ret_status = ::android::BAD_TYPE;
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(reinterpret_cast<int32_t *>(&in_colorimetry));
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
-      _aidl_ret_status = st.writeToParcel(_aidl_reply);
-      break;
-    }
-    ::android::binder::Status _aidl_status(setColorimetry(in_colorimetry));
-    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (!_aidl_status.isOk()) {
-      break;
-    }
-  }
-  break;
-  case BnVideoDecoderController::TRANSACTION_setStreamResolution:
-  {
-    int32_t in_width;
-    int32_t in_height;
-    if (!(_aidl_data.checkInterface(this))) {
-      _aidl_ret_status = ::android::BAD_TYPE;
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(&in_width);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(&in_height);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
-      _aidl_ret_status = st.writeToParcel(_aidl_reply);
-      break;
-    }
-    ::android::binder::Status _aidl_status(setStreamResolution(in_width, in_height));
-    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (!_aidl_status.isOk()) {
-      break;
-    }
-  }
-  break;
-  case BnVideoDecoderController::TRANSACTION_setFrameRate:
-  {
-    int32_t in_numerator;
-    int32_t in_denominator;
-    if (!(_aidl_data.checkInterface(this))) {
-      _aidl_ret_status = ::android::BAD_TYPE;
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(&in_numerator);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(&in_denominator);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
-      _aidl_ret_status = st.writeToParcel(_aidl_reply);
-      break;
-    }
-    ::android::binder::Status _aidl_status(setFrameRate(in_numerator, in_denominator));
-    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (!_aidl_status.isOk()) {
-      break;
-    }
-  }
-  break;
-  case BnVideoDecoderController::TRANSACTION_setDolbyVisionLayerFlags:
-  {
-    bool in_blPresent;
-    bool in_elPresent;
-    if (!(_aidl_data.checkInterface(this))) {
-      _aidl_ret_status = ::android::BAD_TYPE;
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readBool(&in_blPresent);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readBool(&in_elPresent);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
-      _aidl_ret_status = st.writeToParcel(_aidl_reply);
-      break;
-    }
-    ::android::binder::Status _aidl_status(setDolbyVisionLayerFlags(in_blPresent, in_elPresent));
-    _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (!_aidl_status.isOk()) {
-      break;
-    }
-  }
-  break;
-  case BnVideoDecoderController::TRANSACTION_setPixelAspectRatio:
-  {
-    int32_t in_parX;
-    int32_t in_parY;
-    if (!(_aidl_data.checkInterface(this))) {
-      _aidl_ret_status = ::android::BAD_TYPE;
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(&in_parX);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    _aidl_ret_status = _aidl_data.readInt32(&in_parY);
-    if (((_aidl_ret_status) != (::android::OK))) {
-      break;
-    }
-    if (auto st = _aidl_data.enforceNoDataAvail(); !st.isOk()) {
-      _aidl_ret_status = st.writeToParcel(_aidl_reply);
-      break;
-    }
-    ::android::binder::Status _aidl_status(setPixelAspectRatio(in_parX, in_parY));
+    ::android::binder::Status _aidl_status(setStreamConfig(in_config));
     _aidl_ret_status = _aidl_status.writeToParcel(_aidl_reply);
     if (((_aidl_ret_status) != (::android::OK))) {
       break;

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/Resolution.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/Resolution.cpp
@@ -1,0 +1,58 @@
+#include <com/rdk/hal/videodecoder/Resolution.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+::android::status_t Resolution::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  size_t _aidl_start_pos = _aidl_parcel->dataPosition();
+  int32_t _aidl_parcelable_raw_size = 0;
+  _aidl_ret_status = _aidl_parcel->readInt32(&_aidl_parcelable_raw_size);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcelable_raw_size < 4) return ::android::BAD_VALUE;
+  size_t _aidl_parcelable_size = static_cast<size_t>(_aidl_parcelable_raw_size);
+  if (_aidl_start_pos > SIZE_MAX - _aidl_parcelable_size) return ::android::BAD_VALUE;
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&width);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readInt32(&height);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+  return _aidl_ret_status;
+}
+::android::status_t Resolution::writeToParcel(::android::Parcel* _aidl_parcel) const {
+  ::android::status_t _aidl_ret_status = ::android::OK;
+  auto _aidl_start_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->writeInt32(0);
+  _aidl_ret_status = _aidl_parcel->writeInt32(width);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeInt32(height);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  auto _aidl_end_pos = _aidl_parcel->dataPosition();
+  _aidl_parcel->setDataPosition(_aidl_start_pos);
+  _aidl_parcel->writeInt32(_aidl_end_pos - _aidl_start_pos);
+  _aidl_parcel->setDataPosition(_aidl_end_pos);
+  return _aidl_ret_status;
+}
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.cpp
@@ -1,10 +1,10 @@
-#include <com/rdk/hal/videodecoder/InputBufferMetadata.h>
+#include <com/rdk/hal/videodecoder/VideoDecoderStreamConfig.h>
 
 namespace com {
 namespace rdk {
 namespace hal {
 namespace videodecoder {
-::android::status_t InputBufferMetadata::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+::android::status_t VideoDecoderStreamConfig::readFromParcel(const ::android::Parcel* _aidl_parcel) {
   ::android::status_t _aidl_ret_status = ::android::OK;
   size_t _aidl_start_pos = _aidl_parcel->dataPosition();
   int32_t _aidl_parcelable_raw_size = 0;
@@ -19,7 +19,7 @@ namespace videodecoder {
     _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->readInt64(&nsPresentationTime);
+  _aidl_ret_status = _aidl_parcel->readParcelable(&resolution);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
@@ -27,7 +27,15 @@ namespace videodecoder {
     _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->readBool(&discontinuity);
+  _aidl_ret_status = _aidl_parcel->readParcelable(&frameRate);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
+    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->readParcelable(&pixelAspectRatio);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
@@ -63,26 +71,22 @@ namespace videodecoder {
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
-  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
-    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->readParcelable(&pixelAspectRatio);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
   _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
   return _aidl_ret_status;
 }
-::android::status_t InputBufferMetadata::writeToParcel(::android::Parcel* _aidl_parcel) const {
+::android::status_t VideoDecoderStreamConfig::writeToParcel(::android::Parcel* _aidl_parcel) const {
   ::android::status_t _aidl_ret_status = ::android::OK;
   auto _aidl_start_pos = _aidl_parcel->dataPosition();
   _aidl_parcel->writeInt32(0);
-  _aidl_ret_status = _aidl_parcel->writeInt64(nsPresentationTime);
+  _aidl_ret_status = _aidl_parcel->writeNullableParcelable(resolution);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->writeBool(discontinuity);
+  _aidl_ret_status = _aidl_parcel->writeNullableParcelable(frameRate);
+  if (((_aidl_ret_status) != (::android::OK))) {
+    return _aidl_ret_status;
+  }
+  _aidl_ret_status = _aidl_parcel->writeNullableParcelable(pixelAspectRatio);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
@@ -99,10 +103,6 @@ namespace videodecoder {
     return _aidl_ret_status;
   }
   _aidl_ret_status = _aidl_parcel->writeNullableParcelable(dolbyVisionLayerFlags);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->writeNullableParcelable(pixelAspectRatio);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videodecoder
-version: 0.2.0.0
+version: 0.3.0.0
 status: GREEN
 description: "Video decoder resource management and codec support"
 type: SOC


### PR DESCRIPTION
## Summary

Implements the two-surface design agreed in [discussion #484](https://github.com/rdkcentral/rdk-halif-aidl/discussions/484) / [issue #539](https://github.com/rdkcentral/rdk-halif-aidl/issues/539) — atomic stream-config batching and per-buffer container-derived metadata overrides on the video decoder.

cc @shafi12 @hari22yuva @srinivasgtl @outdooruseonly

## Surface 1 — `VideoDecoderStreamConfig` (READY-state, atomic setup batching)

New parcelable + new method on the controller:

```aidl
@VintfStability
parcelable VideoDecoderStreamConfig {
    @nullable Resolution            resolution;
    @nullable Fraction              frameRate;
    @nullable Fraction              pixelAspectRatio;
              Colorimetry           colorimetry = Colorimetry.UNKNOWN;
    @nullable MasteringDisplayInfo  masteringDisplayInfo;
    @nullable ContentLightLevel     contentLightLevel;
    @nullable DolbyVisionLayerFlags dolbyVisionLayerFlags;
}

// On IVideoDecoderController:
void setStreamConfig(in VideoDecoderStreamConfig config);  // @pre State::READY
```

- **Atomic** — all fields land in one binder transaction (replaces 7 separate transactions)
- **Partial** — `null` = no change; clients send only what changed
- **Equivalent semantics** — each non-null field applies exactly like the prior typed setter did (precedence: bitstream wins; persistence: across `flush()`, cleared on `close()`)
- **Validation** — field-level checks match the prior typed setters; atomic — if any field fails, the call returns `EX_ILLEGAL_ARGUMENT` and decoder state is unchanged
- **Colorimetry exception** — AIDL enums cannot be `@nullable`, so `Colorimetry::UNKNOWN` (the default for an unset enum) encodes "no change" for that one field

### Typed setters — clean-break removal

The 7 typed setters (`setStreamResolution`, `setFrameRate`, `setPixelAspectRatio`, `setColorimetry`, `setMasteringDisplayInfo`, `setContentLightLevel`, `setDolbyVisionLayerFlags`) are **removed**. `setStreamConfig()` is the only stream-config write path on the interface. Pre-baseline (`0.<g>.<m>.<p>`) generation bumps allow clean removal rather than carrying deprecated aliases forward.

## Surface 2 — Extended `InputBufferMetadata` (STARTED-state, per-buffer overrides)

Adds 5 `@nullable` override fields (plus `colorimetry` as a non-null enum with UNKNOWN-as-sentinel) for container-derived metadata that changes mid-stream:

```aidl
@VintfStability
parcelable InputBufferMetadata {
    long nsPresentationTime;        // unchanged
    boolean discontinuity;          // unchanged (reserved per v1 contract)

    // NEW — overrides applied from this buffer onward.
              Colorimetry           colorimetry = Colorimetry.UNKNOWN;
    @nullable MasteringDisplayInfo  masteringDisplayInfo;
    @nullable ContentLightLevel     contentLightLevel;
    @nullable DolbyVisionLayerFlags dolbyVisionLayerFlags;
    @nullable Fraction              pixelAspectRatio;
}
```

- **null / `Colorimetry::UNKNOWN`** = no change for that field
- **non-null** = apply this override from this buffer onward; persists for subsequent buffers
- **Precedence** = bitstream still wins; override is the fallback (matches Surface 1 contract)
- **Resolution / frameRate intentionally omitted** — these are bitstream-driven on modern codecs (per-SPS); middleware shouldn't override them mid-stream

The pre-existing per-buffer fields (`nsPresentationTime`, `discontinuity`) keep their existing self-describing semantics — the new nullable overrides are layered on top with their own persistence rules, documented inline on the parcelable.

## New parcelables — videodecoder-local

| Type | Replaces | Used by |
|---|---|---|
| `Resolution` (`int width, height`) | raw `int width, int height` in the prior `setStreamResolution()` | Surface 1 |
| `Fraction` (`int numerator, denominator`) | raw `int numerator, denominator` in the prior `setFrameRate()` / `setPixelAspectRatio()` | Surface 1 + Surface 2 |
| `DolbyVisionLayerFlags` (`boolean blPresent, elPresent`) | raw two-flag tuple in the prior `setDolbyVisionLayerFlags()` | Surface 1 + Surface 2 |

`Fraction` documents the `0/0`-as-unknown convention used by both `frameRate` and `pixelAspectRatio` fields.

All three live under `videodecoder/current/com/rdk/hal/videodecoder/` (package `com.rdk.hal.videodecoder`) — they are videodecoder-specific and consumed only by Surface 1 and Surface 2 here. No `common/` types are introduced or modified.

## Versions bumped per the subsume rule

| Component | From | To | Reason |
|---|---|---|---|
| `videodecoder` | 0.2.0.0 | 0.3.0.0 | Generation — removed 7 typed setters + added `setStreamConfig()` + new parcelables `VideoDecoderStreamConfig`, `Resolution`, `Fraction`, `DolbyVisionLayerFlags` + extended `InputBufferMetadata` |

`common/` is **unchanged** — no version bump.

## Coverage matrix (from issue)

| Scenario | Solved by |
|---|---|
| Atomic initial config (the original #484 problem) | Surface 1 — `setStreamConfig()` |
| ABR resolution / framerate change | Already works — bitstream-derived (SPS), no API needed |
| ABR HDR profile change per DASH Period | Surface 2 — per-buffer overrides |
| SSAI ad insertion (same codec, same encryption) | Surface 2 — per-buffer overrides on the ad boundary frame |
| SSAI with codec or encryption-mode change | Out of scope — decoder restart by middleware policy |
| Live→VOD transition | Surface 2 — per-buffer overrides |
| In-stream HDR SEI changes | Already works — decoder picks up from bitstream |

## Build / verification

Built clean: `./build_modules.sh all --clean` produces 21/21 `lib*-vcurrent-cpp.so` post-rebase onto current `develop`.

## Acceptance (from issue)

### Surface 1
- [x] `VideoDecoderStreamConfig.aidl` parcelable added under `videodecoder/current/`
- [x] `setStreamConfig(in VideoDecoderStreamConfig config)` added to `IVideoDecoderController`, `@pre State::READY`
- [x] Typed setters removed (clean break, generation bump)
- [x] Regenerated C++ matches
- [x] Build clean
- [x] `videodecoder/metadata.yaml` version bumped (0.2.0.0 → 0.3.0.0, generation)

### Surface 2
- [x] `InputBufferMetadata.aidl` extended with the nullable override fields
- [x] Doc-comment makes precedence explicit (bitstream wins, overrides are hints)
- [x] Doc-comment makes persistence explicit (apply from this buffer onward)
- [x] Doc-comment covers the `Colorimetry::UNKNOWN` sentinel alongside `null`
- [x] Regenerated C++ matches
- [x] Build clean

### Follow-ups not in this PR
- [ ] Tests / fixtures updated (no test fixtures exist yet for this surface in the repo)
- [ ] Update `videodecoder/current/docs/video_decoder.md` (separate docs PR — keeps review focus on AIDL surface here)

Closes #539.
