### PR TITLE
chore(imports)!: versioned imports + cohort-locked snapshot build (#538, #557)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,21 +262,28 @@ add_custom_target(stage_modules ALL
     VERBATIM
 )
 
-# Ensure staging happens after all libraries are built
+# Ensure staging happens after all libraries are built. The pattern
+# matches both current (`-vcurrent-cpp`) and frozen-snapshot
+# (`-v<X.Y.Z.W>-cpp`) target names so on-disk snapshot libraries that
+# the toolchain auto-discovers (linux_binder_idl#23 / #538) are also
+# staged alongside `current/`.
 if (INTERFACE_TARGET STREQUAL "all")
     # When building all modules, add dependencies on all library targets
     get_property(all_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
     foreach(target ${all_targets})
-        if (target MATCHES ".*-vcurrent-cpp$")
+        if (target MATCHES ".*-v[^-]+-cpp$")
             add_dependencies(stage_modules ${target})
         endif()
     endforeach()
 else()
-    # When building a specific module, depend on its library target
-    set(LIB_TARGET "${INTERFACE_TARGET}-vcurrent-cpp")
-    if (TARGET ${LIB_TARGET})
-        add_dependencies(stage_modules ${LIB_TARGET})
-    endif()
+    # When building a specific module, depend on every variant of its
+    # library target — current plus any registered snapshots.
+    get_property(all_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(target ${all_targets})
+        if (target MATCHES "^${INTERFACE_TARGET}-v[^-]+-cpp$")
+            add_dependencies(stage_modules ${target})
+        endif()
+    endforeach()
 endif()
 
 #######################################################################

--- a/audiodecoder/0.1.0.0/CMakeLists.txt
+++ b/audiodecoder/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(audiodecoder-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/audiodecoder/0.1.0.0/interface.yaml
+++ b/audiodecoder/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiodecoder/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/audiodecoder/current/interface.yaml
+++ b/audiodecoder/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiodecoder/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/audiomixer/0.1.0.1/CMakeLists.txt
+++ b/audiomixer/0.1.0.1/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.1):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(audiomixer-v0.1.0.1-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,14 +44,14 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/audiodecoder/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -61,7 +61,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-vcurrent-cpp common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-v0.1.0.0-cpp common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/audiomixer/0.1.0.1/interface.yaml
+++ b/audiomixer/0.1.0.1/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiomixer/*.aidl
   imports:
-    - audiodecoder
-    - common
+    - audiodecoder@0.1.0.0
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/audiomixer/current/interface.yaml
+++ b/audiomixer/current/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiomixer/*.aidl
   imports:
-    - audiodecoder
-    - audiosink
-    - common
+    - audiodecoder@current
+    - audiosink@current
+    - common@current
   stability: vintf
   layout: module-local

--- a/audiosink/0.1.0.0/CMakeLists.txt
+++ b/audiosink/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(audiosink-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,15 +44,15 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
-    "${HALIF_INCLUDE_DIR}/avclock/current/include"
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/audiodecoder/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/avclock/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -62,7 +62,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-vcurrent-cpp avclock-vcurrent-cpp common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-v0.1.0.0-cpp avclock-v0.1.0.0-cpp common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/audiosink/0.1.0.0/interface.yaml
+++ b/audiosink/0.1.0.0/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiosink/*.aidl
   imports:
-    - audiodecoder
-    - avclock
-    - common
+    - audiodecoder@0.1.0.0
+    - avclock@0.1.0.0
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/audiosink/current/interface.yaml
+++ b/audiosink/current/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiosink/*.aidl
   imports:
-    - audiodecoder
-    - avclock
-    - common
+    - audiodecoder@current
+    - avclock@current
+    - common@current
   stability: vintf
   layout: module-local

--- a/avbuffer/0.1.0.0/CMakeLists.txt
+++ b/avbuffer/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(avbuffer-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,14 +44,15 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
-    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+    "${HALIF_INCLUDE_DIR}/audiodecoder/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -61,7 +62,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-vcurrent-cpp videodecoder-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-v0.1.0.0-cpp videodecoder-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/avbuffer/0.1.0.0/interface.yaml
+++ b/avbuffer/0.1.0.0/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/avbuffer/*.aidl
   imports:
-    - audiodecoder
-    - videodecoder
+    - audiodecoder@0.1.0.0
+    - videodecoder@0.1.0.0
   stability: vintf
   layout: module-local

--- a/avbuffer/current/interface.yaml
+++ b/avbuffer/current/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/avbuffer/*.aidl
   imports:
-    - audiodecoder
-    - videodecoder
+    - audiodecoder@current
+    - videodecoder@current
   stability: vintf
   layout: module-local

--- a/avclock/0.1.0.0/CMakeLists.txt
+++ b/avclock/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(avclock-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/avclock/0.1.0.0/interface.yaml
+++ b/avclock/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/avclock/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/avclock/current/interface.yaml
+++ b/avclock/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/avclock/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/binder_sdk.version
+++ b/binder_sdk.version
@@ -5,9 +5,11 @@
 # clones the toolchain. Keep it pinned so the committed module-local
 # generated C++ always matches the generator that produced it.
 #
-# Pinned to release tag 2.1.0 (linux_binder_idl) which ships:
+# Pinned to release tag 2.2.0 (linux_binder_idl) which ships:
+#  - version-pinned imports in interface.yaml via name@version syntax
+#    (linux_binder_idl#23/#25, enables rdk-halif-aidl#538)
 #  - the module-local generated-output layout (linux_binder_idl#19/#20)
 #  - the always-regen-on-build fix (linux_binder_idl#21, closes rdk-halif-aidl#530)
 #
 # Override for a one-off build with:  BINDER_VERSION=<ref> ./build_binder.sh
-2.1.0
+2.2.0

--- a/boot/0.1.0.0/CMakeLists.txt
+++ b/boot/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(boot-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/cmake_stage_modules.cmake
+++ b/cmake_stage_modules.cmake
@@ -35,13 +35,16 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-# Determine module-specific subdirectory
+# Determine module-specific subdirectory. The glob picks up both current
+# (`-vcurrent-cpp.so`) and frozen-snapshot (`-v<X.Y.Z.W>-cpp.so`) library
+# names, so a single staging step covers everything the toolchain
+# auto-discovered from on-disk snapshots (linux_binder_idl#23 / #538).
 if (INTERFACE_TARGET STREQUAL "all")
     set(MODULE_SUBDIR "")
-    set(SEARCH_PATTERN "lib*-vcurrent-cpp.so")
+    set(SEARCH_PATTERN "lib*-v*-cpp.so")
 else()
     set(MODULE_SUBDIR "${INTERFACE_TARGET}")
-    set(SEARCH_PATTERN "lib${INTERFACE_TARGET}-vcurrent-cpp.so")
+    set(SEARCH_PATTERN "lib${INTERFACE_TARGET}-v*-cpp.so")
 endif()
 
 # Create output directories - separate binder and halif
@@ -90,9 +93,14 @@ endif()
 message(STATUS "Staging module headers from ${REPO_ROOT}...")
 
 # Module-local layout: generated headers live in <module>/current/include/
+# (in-development) and <module>/<X.Y.Z.W>/include/ (released snapshots).
+# Stage both so cohort-locked snapshot builds can find their transitive
+# headers at `${HALIF_INCLUDE_DIR}/<dep>/<version>/include/` (#544 / #538).
 if (INTERFACE_TARGET STREQUAL "all")
-    # Stage all module headers
-    file(GLOB MODULE_INC_DIRS LIST_DIRECTORIES true "${REPO_ROOT}/*/current/include")
+    # Stage all module headers — current/ + every snapshot version.
+    file(GLOB MODULE_INC_DIRS LIST_DIRECTORIES true
+        "${REPO_ROOT}/*/current/include"
+        "${REPO_ROOT}/*/[0-9]*.[0-9]*.[0-9]*.[0-9]*/include")
 
     set(HEADER_COUNT 0)
     foreach(inc_dir ${MODULE_INC_DIRS})
@@ -111,24 +119,29 @@ if (INTERFACE_TARGET STREQUAL "all")
 
     message(STATUS "Staged ${HEADER_COUNT} HAL interface headers to ${HALIF_INC_OUT_DIR}")
 else()
-    # Stage single module headers
-    set(MODULE_HEADER_DIR "${REPO_ROOT}/${INTERFACE_TARGET}/current/include")
+    # Stage headers for the single module — current/ + every snapshot.
+    file(GLOB MODULE_HEADER_DIRS LIST_DIRECTORIES true
+        "${REPO_ROOT}/${INTERFACE_TARGET}/current/include"
+        "${REPO_ROOT}/${INTERFACE_TARGET}/[0-9]*.[0-9]*.[0-9]*.[0-9]*/include")
 
-    if (EXISTS "${MODULE_HEADER_DIR}")
-        file(GLOB_RECURSE MODULE_HEADERS "${MODULE_HEADER_DIR}/*.h")
+    set(HEADER_COUNT 0)
+    foreach(MODULE_HEADER_DIR ${MODULE_HEADER_DIRS})
+        if (IS_DIRECTORY "${MODULE_HEADER_DIR}")
+            file(GLOB_RECURSE MODULE_HEADERS "${MODULE_HEADER_DIR}/*.h")
+            foreach(header ${MODULE_HEADERS})
+                file(RELATIVE_PATH rel_path "${REPO_ROOT}" "${header}")
+                get_filename_component(dest_dir "${HALIF_INC_OUT_DIR}/${rel_path}" DIRECTORY)
+                file(MAKE_DIRECTORY "${dest_dir}")
+                file(COPY_FILE "${header}" "${HALIF_INC_OUT_DIR}/${rel_path}")
+                math(EXPR HEADER_COUNT "${HEADER_COUNT} + 1")
+            endforeach()
+        endif()
+    endforeach()
 
-        set(HEADER_COUNT 0)
-        foreach(header ${MODULE_HEADERS})
-            file(RELATIVE_PATH rel_path "${REPO_ROOT}" "${header}")
-            get_filename_component(dest_dir "${HALIF_INC_OUT_DIR}/${rel_path}" DIRECTORY)
-            file(MAKE_DIRECTORY "${dest_dir}")
-            file(COPY_FILE "${header}" "${HALIF_INC_OUT_DIR}/${rel_path}")
-            math(EXPR HEADER_COUNT "${HEADER_COUNT} + 1")
-        endforeach()
-
-        message(STATUS "Staged ${HEADER_COUNT} headers for ${INTERFACE_TARGET} to ${HALIF_INC_OUT_DIR}")
+    if (HEADER_COUNT EQUAL 0)
+        message(WARNING "No headers found for ${INTERFACE_TARGET} under current/ or any released snapshot")
     else()
-        message(WARNING "No headers found for ${INTERFACE_TARGET} in ${MODULE_HEADER_DIR}")
+        message(STATUS "Staged ${HEADER_COUNT} headers for ${INTERFACE_TARGET} to ${HALIF_INC_OUT_DIR}")
     endif()
 endif()
 

--- a/common/0.1.0.0/CMakeLists.txt
+++ b/common/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(common-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/compositeinput/0.2.0.0/CMakeLists.txt
+++ b/compositeinput/0.2.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.2.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(compositeinput-v0.2.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/compositeinput/0.2.0.0/interface.yaml
+++ b/compositeinput/0.2.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/compositeinput/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/compositeinput/current/interface.yaml
+++ b/compositeinput/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/compositeinput/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/deepsleep/0.1.0.0/CMakeLists.txt
+++ b/deepsleep/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(deepsleep-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/deviceinfo/0.1.0.0/CMakeLists.txt
+++ b/deviceinfo/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(deviceinfo-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/drm/0.1.0.0/CMakeLists.txt
+++ b/drm/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(drm-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/hdmicec/0.1.0.0/CMakeLists.txt
+++ b/hdmicec/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(hdmicec-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/hdmicec/0.1.0.0/interface.yaml
+++ b/hdmicec/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmicec/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/hdmicec/current/interface.yaml
+++ b/hdmicec/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmicec/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/hdmiinput/0.1.0.0/CMakeLists.txt
+++ b/hdmiinput/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(hdmiinput-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/hdmiinput/0.1.0.0/interface.yaml
+++ b/hdmiinput/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmiinput/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/hdmiinput/current/interface.yaml
+++ b/hdmiinput/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmiinput/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/hdmioutput/0.1.0.0/CMakeLists.txt
+++ b/hdmioutput/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(hdmioutput-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/hdmioutput/0.1.0.0/interface.yaml
+++ b/hdmioutput/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmioutput/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/hdmioutput/current/interface.yaml
+++ b/hdmioutput/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmioutput/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/indicator/0.1.0.0/CMakeLists.txt
+++ b/indicator/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(indicator-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/panel/0.1.0.0/CMakeLists.txt
+++ b/panel/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(panel-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,14 +44,14 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include"
-    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -61,7 +61,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp videodecoder-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp videodecoder-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/panel/0.1.0.0/interface.yaml
+++ b/panel/0.1.0.0/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/panel/*.aidl
   imports:
-    - common
-    - videodecoder
+    - common@0.1.0.0
+    - videodecoder@0.1.0.0
   stability: vintf
   layout: module-local

--- a/panel/current/interface.yaml
+++ b/panel/current/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/panel/*.aidl
   imports:
-    - common
-    - videodecoder
+    - common@current
+    - videodecoder@current
   stability: vintf
   layout: module-local

--- a/planecontrol/0.1.0.0/CMakeLists.txt
+++ b/planecontrol/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(planecontrol-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,14 +44,14 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include"
-    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -61,7 +61,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp videodecoder-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp videodecoder-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/planecontrol/0.1.0.0/interface.yaml
+++ b/planecontrol/0.1.0.0/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/planecontrol/*.aidl
   imports:
-    - common
-    - videodecoder
+    - common@0.1.0.0
+    - videodecoder@0.1.0.0
   stability: vintf
   layout: module-local

--- a/planecontrol/current/interface.yaml
+++ b/planecontrol/current/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/planecontrol/*.aidl
   imports:
-    - common
-    - videodecoder
+    - common@current
+    - videodecoder@current
   stability: vintf
   layout: module-local

--- a/release.sh
+++ b/release.sh
@@ -90,7 +90,9 @@ for component in "${COMPONENTS[@]}"; do
 
     # Parse imports: from interface.yaml so the snapshot CMakeLists can link
     # against the right dependency libraries. Handles both inline (`[a, b]`)
-    # and block (`- a\n  - b`) YAML list forms.
+    # and block (`- a\n  - b`) YAML list forms. Each entry is either a bare
+    # name (legacy / deprecated) or the `name@version` form introduced in
+    # linux_binder_idl#23 — both are passed through verbatim and split here.
     deps=""
     if [ -f "${target}/interface.yaml" ]; then
         deps="$(awk '
@@ -105,13 +107,149 @@ for component in "${COMPONENTS[@]}"; do
             inmap && /^[^[:space:]-]/ { exit }
         ' "${target}/interface.yaml" | xargs)"
     fi
-    dep_libs=""
-    dep_inc_lines=""
+
+    # Rewrite any `@current` pins in the freshly-cut snapshot's
+    # interface.yaml to concrete frozen versions, so the snapshot is
+    # cohort-locked from the moment it's created (#538). For each
+    # producer, the concrete version comes from its own metadata.yaml
+    # `version:` field — i.e. whatever version that producer is at right
+    # now. This matches the "release everything at once" model used by
+    # the milestone-driven release cadence; if a producer hasn't been
+    # released and its current/ version doesn't match the cohort, the
+    # producer-side version dir simply won't exist and the toolchain
+    # will flag it at configure time.
+    rewritten_deps=""
     for d in ${deps}; do
-        dep_libs+=" ${d}-vcurrent-cpp"
-        dep_inc_lines+="
-    \"\${HALIF_INCLUDE_DIR}/${d}/current/include\""
+        name="${d%@*}"
+        ver="${d#*@}"
+        if [ "${name}" = "${d}" ]; then
+            # Bare-name form — treat as @current per the toolchain's
+            # backward-compat rule, then resolve to a concrete version.
+            ver="current"
+        fi
+        if [ "${ver}" = "current" ]; then
+            producer_metadata="${name}/metadata.yaml"
+            if [ -f "${producer_metadata}" ]; then
+                ver="$(grep -E '^version:' "${producer_metadata}" | head -1 | awk '{print $2}')"
+            fi
+            if [ -z "${ver}" ] || [ "${ver}" = "current" ]; then
+                echo "    WARN ${component}@${version} imports ${name}@current but ${name}/metadata.yaml is missing or has no version: — leaving as @current; this snapshot will silent-drift against ${name}'s current sibling."
+                ver="current"
+            fi
+        fi
+        rewritten_deps+=" ${name}@${ver}"
     done
+
+    if [ -n "${rewritten_deps}" ]; then
+        python3 - "${target}/interface.yaml" <<PY_EOF
+import re, sys
+path = sys.argv[1]
+pins = """${rewritten_deps}""".split()
+pin_map = {}
+for entry in pins:
+    n, _, v = entry.partition("@")
+    pin_map[n] = v
+with open(path) as fh: lines = fh.readlines()
+out = []
+in_imports = False
+RE = re.compile(r'^(\s*-\s*)([A-Za-z_][A-Za-z0-9_]*)(?:@[^\s]+)?\s*$')
+for line in lines:
+    s = line.strip()
+    if s.startswith("imports:"):
+        in_imports = True; out.append(line); continue
+    if in_imports:
+        if s and not s.startswith("-") and ":" in s:
+            in_imports = False
+        elif s == "":
+            pass
+        else:
+            m = RE.match(line.rstrip("\n"))
+            if m and m.group(2) in pin_map:
+                line = f"{m.group(1)}{m.group(2)}@{pin_map[m.group(2)]}\n"
+    out.append(line)
+with open(path, "w") as fh: fh.writelines(out)
+PY_EOF
+        deps="${rewritten_deps# }"
+    fi
+
+    dep_libs=""
+    # Compute the transitive closure of `deps` so the snapshot's include
+    # path picks up headers reachable via a direct dependency (e.g. avbuffer
+    # imports audiodecoder which imports common — avbuffer needs common's
+    # headers on the search path even though it doesn't import common
+    # directly). Without this, fully cohort-locked snapshot builds fail
+    # to find transitive headers because each producer's include dir is
+    # version-pinned rather than catch-all `current/`.
+    declare -a closure_order=()
+    declare -A closure_seen=()
+    _add_closure() {
+        local _name="$1" _ver="$2"
+        [ -n "${closure_seen[$_name]:-}" ] && return
+        closure_seen[$_name]=1
+        closure_order+=("${_name}@${_ver}")
+        # Recurse via the producer's own interface.yaml imports at the
+        # pinned version (which always exists on disk for a snapshot we
+        # are linking).
+        local _yaml
+        if [ "${_ver}" = "current" ]; then
+            _yaml="${_name}/current/interface.yaml"
+        else
+            _yaml="${_name}/${_ver}/interface.yaml"
+        fi
+        [ -f "${_yaml}" ] || return
+        local _inner _inner_name _inner_ver
+        for _inner in $(awk '
+            /^[[:space:]]*imports:[[:space:]]*\[/ {
+                line=$0; gsub(/.*\[|\].*/,"",line); gsub(/,/," ",line)
+                print line; exit
+            }
+            /^[[:space:]]*imports:/ { inmap=1; next }
+            inmap && /^[[:space:]]+-[[:space:]]*/ {
+                gsub(/^[[:space:]]+-[[:space:]]*/,""); printf "%s ", $0; next
+            }
+            inmap && /^[^[:space:]-]/ { exit }
+        ' "${_yaml}" | xargs); do
+            _inner_name="${_inner%@*}"
+            _inner_ver="${_inner#*@}"
+            [ "${_inner_name}" = "${_inner}" ] && _inner_ver="current"
+            _add_closure "${_inner_name}" "${_inner_ver}"
+        done
+    }
+    for d in ${deps}; do
+        name="${d%@*}"
+        ver="${d#*@}"
+        [ "${name}" = "${d}" ] && ver="current"
+        _add_closure "${name}" "${ver}"
+    done
+
+    dep_inc_lines=""
+    for entry in "${closure_order[@]}"; do
+        name="${entry%@*}"
+        ver="${entry#*@}"
+        if [ "${ver}" = "current" ]; then
+            dep_inc_lines+="
+    \"\${HALIF_INCLUDE_DIR}/${name}/current/include\""
+        else
+            dep_inc_lines+="
+    \"\${HALIF_INCLUDE_DIR}/${name}/${ver}/include\""
+        fi
+    done
+
+    # Linker line stays restricted to direct imports — transitive deps
+    # come through the linker via the direct deps' own PUBLIC link
+    # interface (matching the pattern used by `current/CMakeLists.txt`
+    # in #546).
+    for d in ${deps}; do
+        name="${d%@*}"
+        ver="${d#*@}"
+        [ "${name}" = "${d}" ] && ver="current"
+        if [ "${ver}" = "current" ]; then
+            dep_libs+=" ${name}-vcurrent-cpp"
+        else
+            dep_libs+=" ${name}-v${ver}-cpp"
+        fi
+    done
+    unset closure_order closure_seen
     # Only emit the dependency-include block when the component has imports;
     # an empty target_include_directories() call is invalid-looking noise.
     dep_include_block=""

--- a/sensor/0.1.0.0/CMakeLists.txt
+++ b/sensor/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(sensor-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,8 +44,7 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
 target_link_directories(${LIB_NAME} PRIVATE
     "${BINDER_SDK_DIR}/lib/binder"

--- a/videodecoder/0.1.0.0/CMakeLists.txt
+++ b/videodecoder/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(videodecoder-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,13 +44,13 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/current/include")
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/videodecoder/0.1.0.0/interface.yaml
+++ b/videodecoder/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/videodecoder/*.aidl
   imports:
-    - common
+    - common@0.1.0.0
   stability: vintf
   layout: module-local

--- a/videodecoder/current/interface.yaml
+++ b/videodecoder/current/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/videodecoder/*.aidl
   imports:
-    - common
+    - common@current
   stability: vintf
   layout: module-local

--- a/videosink/0.1.0.0/CMakeLists.txt
+++ b/videosink/0.1.0.0/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 # Inputs (set by the caller, typically build_modules.sh --version 0.1.0.0):
 #   BINDER_SDK_DIR  - linux_binder SDK root (lib/binder + include/binder_sdk)
-#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-vcurrent-cpp.so
+#   HALIF_LIB_DIR   - directory holding dependency lib<dep>-v<X.Y.Z.W>-cpp.so
 cmake_minimum_required(VERSION 3.8)
 project(videosink-v0.1.0.0-cpp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -35,7 +35,7 @@ if (NOT IS_DIRECTORY "${_BINDER_INC}")
     endif()
 endif()
 
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 if (NOT SRCS)
     message(FATAL_ERROR "No sources under src/. The snapshot must carry committed generated C++.")
 endif()
@@ -44,15 +44,15 @@ add_library(${LIB_NAME} SHARED ${SRCS})
 
 target_include_directories(${LIB_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${_BINDER_INC}"
-)
+    "${_BINDER_INC}")
 
-# Dependency component headers (staged by the current/ build into HALIF_INCLUDE_DIR).
+# Dependency component headers (transitive closure — covers headers reachable
+# via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/avclock/current/include"
-    "${HALIF_INCLUDE_DIR}/common/current/include"
-    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+    "${HALIF_INCLUDE_DIR}/avclock/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/0.1.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -62,7 +62,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils avclock-vcurrent-cpp common-vcurrent-cpp videodecoder-vcurrent-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils avclock-v0.1.0.0-cpp common-v0.1.0.0-cpp videodecoder-v0.1.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/videosink/0.1.0.0/interface.yaml
+++ b/videosink/0.1.0.0/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/videosink/*.aidl
   imports:
-    - avclock
-    - common
-    - videodecoder
+    - avclock@0.1.0.0
+    - common@0.1.0.0
+    - videodecoder@0.1.0.0
   stability: vintf
   layout: module-local

--- a/videosink/current/interface.yaml
+++ b/videosink/current/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/videosink/*.aidl
   imports:
-    - avclock
-    - common
-    - videodecoder
+    - avclock@current
+    - common@current
+    - videodecoder@current
   stability: vintf
   layout: module-local


### PR DESCRIPTION
Closes **#538** and **#557**. Combined PR for the AIDL-generation-layer migration **and** the build-system plumbing that interprets the new `name@version` pins — splitting these produced a chicken-and-egg state where either alone left the build broken until the other also landed.

## Two halves, one PR

### Half 1 — AIDL-generation layer (closes #538)

| Bucket | Files |
|---|---|
| 13 × `<module>/current/interface.yaml` migrated to `@current` pins | audiodecoder, audiomixer, audiosink, avbuffer, avclock, compositeinput, hdmicec, hdmiinput, hdmioutput, panel, planecontrol, videodecoder, videosink |
| 13 × `<module>/<X.Y.Z.W>/interface.yaml` snapshots migrated to concrete cohort pins (e.g. `videodecoder/0.1.0.0` → `common@0.1.0.0`) | same 13 modules |
| `binder_sdk.version`: `2.1.0` → `2.2.0` | toolchain pin required for `name@version` syntax |

### Half 2 — Build-system plumbing (closes #557)

| Piece | What it does |
|---|---|
| `release.sh` | Rewrites `@current` pins to concrete versions at snapshot-cut time. Snapshot CMakeLists.txt links cohort-locked deps. |
| Existing snapshot `CMakeLists.txt` files | All 21 regenerated with cohort-locked dep pins + transitive-import closure for include paths |
| Root `CMakeLists.txt` | Staging-target glob broadened from `-vcurrent-cpp$` → `-v[^-]+-cpp$` so snapshot libs flow into staging |
| `cmake_stage_modules.cmake` | Header staging glob extended to `<module>/<X.Y.Z.W>/include` alongside `<module>/current/include` |

## Not in scope (companion PRs)

| PR | Concern |
|---|---|
| [#562](https://github.com/rdkcentral/rdk-halif-aidl/pull/562) | Structural cleanup — `flash/0.1.0.0/` deletion + `firmwareupdate/0.2.0.0/` first release |
| [#560](https://github.com/rdkcentral/rdk-halif-aidl/pull/560) | Build-selection layer — `versions.yaml` → `versions_current.yaml` + new `versions_released.yaml` + smoke test extension |

## Verification

`./tests/smoke_test.sh` — 4/4 phases pass with both halves applied. Verified against linux_binder_idl 2.2.0.