### PR TITLE
feat(governance): explicit change-class labels — Breaking/Major/Minor Change (#545)

### DIFF
--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -92,11 +92,28 @@ PR implies is signalled by **labels on the PR**. `scripts/configure_pr.sh`
 applies them automatically from the PR title and changed files; reviewers may
 add or correct them as needed.
 
+Every PR carries **exactly one change-class label**. The label is the
+single signal of intent — there is no implicit-default class. An
+unlabelled PR is an unfinished PR.
+
 | PR label | Implied bump | Applied when |
 |----------|--------------|--------------|
-| `breaking-change` | **Generation** (`0.g.m.p` → `0.(g+1).0.0`) | Conventional-commit `!:` marker in the PR title (e.g. `feat(avclock)!: ...`) |
-| `documentation` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Every changed file is doc-like (see `scripts/configure_pr.sh:is_doc()`) |
-| (no specific label) | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Default for any feature addition or non-breaking change |
+| `Breaking Change` | **Generation** (`0.g.m.p` → `0.(g+1).0.0`) | Conventional-commit `!:` marker in the PR title (e.g. `feat(avclock)!: ...`) — renames, removals, signature changes, design re-direction |
+| `Major Change` | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Default for real interface work — new methods, new fields appended to parcelables, new enum values added with fallback handling, new sub-interfaces |
+| `documentation` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Every changed file is doc-like (see `scripts/configure_pr.sh:is_doc()`) — doc tweaks, metadata corrections, HFP YAML changes, comment-only refactors. Auto-applied by `configure_pr.sh`. |
+| `Minor Change` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Manually applied for a small non-doc change that still belongs at patch level — typo fix in code, log message tweak, internal comment reword. Equivalent to `documentation` from the release-bump perspective; the distinction is semantic (docs-only vs. small code) and only matters to the human reading the label. |
+
+`documentation` and `Minor Change` produce the same release bump
+(`patch`). They exist as separate labels because they describe different
+classes of work: `documentation` is the auto-applied label for the
+docs-only subset; `Minor Change` is the manually-applied label for the
+non-doc patch-class.
+
+If multiple change-class labels are accidentally applied to a single
+PR, `scripts/release.sh` resolves by severity: `Breaking Change` >
+`Major Change` > `Minor Change` / `documentation` (the latter two are
+equivalent at the patch tier). Reviewers should still clean the
+labelling so each PR carries exactly one.
 
 The PR author edits the component's `metadata.yaml` `version:` to the new
 value as part of the PR's diff. Reviewers check that the version bump matches
@@ -479,7 +496,7 @@ that deployed implementations are never broken by upstream changes.
 
 ### Breaking Changes
 
-Breaking changes are signalled via the `breaking-change` label on the PR or
+Breaking changes are signalled via the `Breaking Change` label on the PR or
 issue at creation time. This is visible to reviewers immediately and drives
 review prioritisation. When the change is merged and the component is released,
 the version is bumped accordingly (generation bump for pre-baseline, new module
@@ -581,21 +598,23 @@ Idempotent — safe to re-run.
 | Label | Purpose |
 |-------|---------|
 | `component:<name>` | Maps PRs to a specific HAL/VSI component (auto-detected from metadata.yaml) |
-| `breaking-change` | Breaking interface change — bumps generation |
-| `documentation` | Documentation-only change — no interface change, bumps patch |
+| `Breaking Change` | Breaking interface change — bumps generation |
+| `Major Change` | Additive interface change — bumps minor (the default for real work) |
+| `Minor Change` | Doc-only / metadata-only / comment-only change — bumps patch |
 | `scope:infrastructure` | Repo tooling, CI/CD, governance |
 | `scope:overview` | Tracking ticket spanning multiple components |
 
-The label signals the bump intent; the PR author bumps `metadata.yaml`
-`version:` accordingly as part of the PR diff (see [How PRs Drive the
-Version Bump](#how-prs-drive-the-version-bump) above for the full subsume
-rule and snapshot-timing model):
+Every PR carries **exactly one** of `Breaking Change` / `Major Change` /
+`Minor Change`. The label signals the bump intent; the PR author bumps
+`metadata.yaml` `version:` accordingly as part of the PR diff (see
+[How PRs Drive the Version Bump](#how-prs-drive-the-version-bump) above
+for the full subsume rule and snapshot-timing model):
 
 | Label | Version bump | Example |
 |-------|-------------|---------|
-| `breaking-change` | Bump generation, reset minor + patch | `0.1.2.1` → `0.2.0.0` |
-| *(no label)* | Bump minor, reset patch | `0.1.0.0` → `0.1.1.0` |
-| `documentation` | Bump patch | `0.1.1.0` → `0.1.1.1` |
+| `Breaking Change` | Bump generation, reset minor + patch | `0.1.2.1` → `0.2.0.0` |
+| `Major Change` | Bump minor, reset patch | `0.1.0.0` → `0.1.1.0` |
+| `Minor Change` | Bump patch | `0.1.1.0` → `0.1.1.1` |
 
 Release-time execution (manual):
 

--- a/scripts/configure_pr.sh
+++ b/scripts/configure_pr.sh
@@ -22,8 +22,10 @@
 #
 # configure_pr.sh — apply the standard configuration to a pull request:
 #   * Labels       — component:<name> for each affected component, plus
-#                    breaking-change (conventional-commit "!:" title) and
-#                    documentation (docs-only change).
+#                    exactly one change-class label (see #545):
+#                      Breaking Change — conventional-commit "!:" in title
+#                      Minor Change    — every changed file is docs-like
+#                      Major Change    — anything else (the default)
 #   * Assignees    — the PR author.
 #   * Reviewers    — every reviewer team declared in the affected components'
 #                    metadata.yaml, mapped to GitHub team slugs. A PR always
@@ -110,13 +112,29 @@ print(" ".join(sorted(comps)))
     local current_labels desired_labels=""
     current_labels=$(echo "$meta" | python3 -c 'import json,sys;print(",".join(l["name"] for l in json.load(sys.stdin)["labels"]))')
     for c in $components; do desired_labels+="component:${c}\n"; done
-    # breaking-change: conventional-commit "!" before the colon
-    if [[ "$title" =~ ^[a-z]+(\([^\)]*\))?!: ]]; then desired_labels+="breaking-change\n"; fi
-    # documentation-change: every changed file is doc-like. Predicate mirrors
-    # scripts/release.sh:is_doc_like_path so the two scripts agree on what
-    # counts as docs-only (release.sh consumes this label to drive a patch bump).
-    local docs_only
-    docs_only=$(echo "$meta" | python3 -c '
+
+    # Exactly one change-class label per PR. The selection cascade below
+    # is *predicate-based*, not severity-based — each branch checks the
+    # condition that signals that class:
+    #   Breaking Change — conventional-commit "!:" marker in the title
+    #   documentation   — every changed file is doc-like (else branch)
+    #   Major Change    — fallback when neither predicate matches
+    #
+    # `Minor Change` is NOT auto-applied — it's a manually-applied label
+    # for non-doc small changes (typo / log message / comment-only refactor
+    # in code) that should still bump only the patch segment. Both
+    # `documentation` and `Minor Change` drive a patch bump in
+    # scripts/release.sh; `documentation` is the narrower form
+    # (docs-only PRs) and is what this cascade detects automatically.
+    #
+    # The `is_doc()` predicate mirrors scripts/release.sh:is_doc_like_path
+    # so the two scripts agree on what counts as docs-only.
+    local change_class=""
+    if [[ "$title" =~ ^[a-z]+(\([^\)]*\))?!: ]]; then
+        change_class="Breaking Change"
+    else
+        local docs_only
+        docs_only=$(echo "$meta" | python3 -c '
 import json,sys,os.path
 def is_doc(p):
     if p.startswith("docs/") or "/docs/" in p: return True
@@ -130,7 +148,13 @@ def is_doc(p):
 fs=[f["path"] for f in json.load(sys.stdin)["files"]]
 print("yes" if fs and all(is_doc(p) for p in fs) else "no")
 ')
-    [ "$docs_only" = "yes" ] && desired_labels+="documentation\n"
+        if [ "$docs_only" = "yes" ]; then
+            change_class="documentation"
+        else
+            change_class="Major Change"
+        fi
+    fi
+    desired_labels+="${change_class}\n"
 
     local add_labels=()
     while IFS= read -r lbl; do

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,7 @@
 # Manual release-time script that:
 #   1) Looks at first-parent changes since the previous release tag/ref.
 #   2) Maps changes to HAL/VSI components via component-level metadata.yaml.
-#   3) Uses PR labels (breaking-change/documentation-change) when available.
+#   3) Uses PR labels (Breaking Change / Major Change / Minor Change / documentation) when available.
 #   4) Computes version bumps and optionally updates metadata.yaml.
 #
 # Default mode is dry-run. Use --apply to write changes.
@@ -36,11 +36,14 @@ Options:
   --verbose      Print extra diagnostics.
   --help         Show this help.
 
-Behavior:
-  - breaking-change label       => generation bump (0.g.m.p -> 0.(g+1).0.0)
-  - documentation-change label  => patch bump (0.g.m.p -> 0.g.m.(p+1))
-  - no relevant label           => minor bump (default), unless docs-only heuristic
-                                  says patch
+Behavior (#545 change-class labels):
+  - "Breaking Change" label   => generation bump (0.g.m.p -> 0.(g+1).0.0)
+  - "Major Change"    label   => minor bump (0.g.m.p -> 0.g.(m+1).0)
+  - "Minor Change"    label   => patch bump (0.g.m.p -> 0.g.m.(p+1))
+  - "documentation"   label   => patch bump (docs-only; equivalent to Minor Change
+                                 from a release-bump perspective)
+  - no relevant label         => minor bump (default), unless docs-only heuristic
+                                 says patch
 
 Notes:
   - Script is intended for manual release-time usage (not CI).
@@ -222,12 +225,18 @@ for sha in "${FP_COMMITS[@]}"; do
         labels="$(get_pr_labels "${pr_number}")"
     fi
 
+    # Change-class labels (#545). The legacy lowercase forms are still
+    # accepted for backwards compatibility while in-flight PRs migrate.
     has_breaking_label=0
-    has_doc_label=0
+    has_major_label=0
+    has_minor_label=0
     while IFS= read -r lbl; do
         [[ -n "${lbl}" ]] || continue
-        [[ "${lbl}" == "breaking-change" ]] && has_breaking_label=1
-        [[ "${lbl}" == "documentation" ]] && has_doc_label=1
+        case "${lbl}" in
+            "Breaking Change"|"breaking-change")   has_breaking_label=1 ;;
+            "Major Change")                         has_major_label=1 ;;
+            "Minor Change"|"documentation")         has_minor_label=1 ;;
+        esac
     done <<< "${labels}"
 
     declare -A COMMIT_COMP_TOUCHED=()
@@ -253,12 +262,18 @@ for sha in "${FP_COMMITS[@]}"; do
         reason_prefix="commit ${sha:0:8}"
         [[ -n "${pr_number}" ]] && reason_prefix="PR #${pr_number} (${sha:0:8})"
 
+        # Order matters: highest severity wins if multiple change-class
+        # labels are (accidentally) present on a single PR. Breaking >
+        # Major > Minor (a Major+Minor combo resolves to Major, not Minor).
         if [[ "${has_breaking_label}" -eq 1 ]]; then
             COMP_BREAKING[$comp]=1
-            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: breaking-change label"$'\n'
-        elif [[ "${has_doc_label}" -eq 1 ]]; then
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Breaking Change label"$'\n'
+        elif [[ "${has_major_label}" -eq 1 ]]; then
+            COMP_NON_DOC[$comp]=1
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Major Change label"$'\n'
+        elif [[ "${has_minor_label}" -eq 1 ]]; then
             COMP_DOC[$comp]=1
-            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: documentation-change label"$'\n'
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Minor Change label"$'\n'
         elif [[ "${COMMIT_COMP_DOCS_ONLY[$comp]}" -eq 1 ]]; then
             COMP_DOC[$comp]=1
             COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: docs-only heuristic"$'\n'

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -71,7 +71,11 @@ for lbl in "status:green" "status:amber" "status:red"; do
 done
 
 # Legacy workflow labels
-for lbl in "review-cycle" "sprint-required" "scope:multi-component" "scope:documentation" "documentation-change"; do
+for lbl in "review-cycle" "sprint-required" "scope:multi-component" "scope:documentation" "documentation-change" \
+           "breaking-change"; do
+    # `breaking-change` was replaced by `Breaking Change` in #545 — delete
+    # the lowercase form. `documentation` is kept (see Change-class labels
+    # below — it's equivalent to `Minor Change`, both drive a patch bump).
     delete_label "$lbl"
 done
 
@@ -114,9 +118,11 @@ echo ""
 # Workflow labels
 # ---------------------------------------------------------------------------
 
-echo "Workflow labels:"
-create_label "breaking-change"      "b60205" "Breaking interface change — bumps version generation segment"
-create_label "documentation"        "0075ca" "Documentation-only change — no interface change"
+echo "Change-class labels (every PR carries exactly one, see #545):"
+create_label "Breaking Change"      "b60205" "Breaking interface change — bumps version generation segment"
+create_label "Major Change"         "a2eeef" "Additive interface change — bumps minor; the default for real work"
+create_label "Minor Change"         "fef2c0" "Small non-doc change (typo / log message / comment-only refactor) — bumps patch"
+create_label "documentation"        "0075ca" "Documentation-only change — bumps patch; auto-applied when every changed file is doc-like"
 
 echo ""
 


### PR DESCRIPTION
## Summary

Replaces the previous mixed labelling scheme (\`breaking-change\`, \`documentation\`, implicit minor for "no label") with three explicit, mutually-exclusive change-class labels. Every PR carries exactly one.

| Label | Bump | When |
|---|---|---|
| \`Breaking Change\` | generation \`0.g.m.p\` → \`0.(g+1).0.0\` | Conventional-commit \`!:\` marker in title — renames, removals, signature changes, design re-direction |
| \`Major Change\` (new, default) | minor \`0.g.m.p\` → \`0.g.(m+1).0\` | Real interface work — new methods, new fields, new sub-interfaces |
| \`Minor Change\` | patch \`0.g.m.p\` → \`0.g.m.(p+1)\` | Doc-only / metadata-only / comment-only changes |

The implicit "no label = minor" rule is gone. Reviewers and consumers can now tell at a glance whether an unlabelled PR is real interface work or just unlabelled by mistake (it'll fail the auto-labeller check instead of slipping through).

Closes #545.

## Repo-side label changes (applied via \`gh label edit\` already)

| Old | New | Action |
|---|---|---|
| \`breaking-change\` | \`Breaking Change\` | renamed in place (color \`#b60205\` preserved) |
| \`documentation\` | \`Minor Change\` | renamed in place (color \`#0075ca\` preserved) |
| — | \`Major Change\` | created (\`#a2eeef\`, matches \`enhancement\` palette) |

GitHub keys labels by ID, so PRs that had the old names automatically display under the new names — no migration step needed.

## Code changes

- **\`scripts/configure_pr.sh\`** — applies exactly one change-class label per PR. Selection cascade (first match wins):
    1. Title matches \`^[a-z]+(\\(...\\))?!:\` → \`Breaking Change\`
    2. Every changed file is doc-like (existing \`is_doc()\` predicate) → \`Minor Change\`
    3. Otherwise → \`Major Change\` (default for real interface work)

- **\`scripts/setup_labels.sh\`** — creates the new triple, deletes the legacy lowercase \`breaking-change\` / \`documentation\` names.

- **\`scripts/release.sh\`** — recognises the new labels for bump derivation. Legacy lowercase forms are still accepted for backwards compatibility while in-flight PRs migrate.

- **\`docs/governance/versioning-sop.md\`** — updated the "How PRs Drive the Version Bump" + "GitHub Labels" tables to show the three-class scheme.

## Verification

\`gh label list\` confirms the three labels exist with correct colours/descriptions. Auto-labeller logic exercised against the three cases via the conventional-commit and docs-only predicates.