### PR TITLE
feat(build): self-contained current/CMakeLists.txt for every module (#546)

### DIFF
--- a/audiodecoder/current/CMakeLists.txt
+++ b/audiodecoder/current/CMakeLists.txt
@@ -19,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(audiodecoder-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET audiodecoder)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "audiodecoder-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/audiodecoder/src/current'
-#   c. Create the library target 'audiodecoder-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh audiodecoder first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/audiomixer/current/CMakeLists.txt
+++ b/audiomixer/current/CMakeLists.txt
@@ -9,7 +9,8 @@
 # * you may not use this file except in compliance with the License.
 # * You may obtain a copy of the License at
 # *
-# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
 # *
 # * Unless required by applicable law or agreed to in writing, software
 # * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +19,101 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(audiomixer-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET audiomixer)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "audiomixer-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/audiomixer/src/current'
-#   c. Create the library target 'audiomixer-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh audiomixer first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/audiosink/current/include"
+    "${HALIF_INCLUDE_DIR}/avclock/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-vcurrent-cpp audiosink-vcurrent-cpp common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/audiosink/current/CMakeLists.txt
+++ b/audiosink/current/CMakeLists.txt
@@ -19,15 +19,100 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(audiosink-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET audiosink)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "audiosink-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/audiosink/src/current'
-#   c. Create the library target 'audiosink-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh audiosink first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/avclock/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-vcurrent-cpp avclock-vcurrent-cpp common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/avbuffer/current/CMakeLists.txt
+++ b/avbuffer/current/CMakeLists.txt
@@ -19,15 +19,100 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(avbuffer-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET avbuffer)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "avbuffer-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/avbuffer/src/current'
-#   c. Create the library target 'avbuffer-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh avbuffer first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils audiodecoder-vcurrent-cpp videodecoder-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/avclock/current/CMakeLists.txt
+++ b/avclock/current/CMakeLists.txt
@@ -19,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(avclock-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET avclock)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "avclock-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/avclock/src/current'
-#   c. Create the library target 'avclock-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh avclock first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/boot/current/CMakeLists.txt
+++ b/boot/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(boot-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET boot)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "boot-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/boot/src/current'
-#   c. Create the library target 'boot-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh boot first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/common/current/CMakeLists.txt
+++ b/common/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(common-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET common)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "common-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/common/src/current'
-#   c. Create the library target 'common-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh common first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/compositeinput/current/CMakeLists.txt
+++ b/compositeinput/current/CMakeLists.txt
@@ -9,7 +9,8 @@
 # * you may not use this file except in compliance with the License.
 # * You may obtain a copy of the License at
 # *
-# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
 # *
 # * Unless required by applicable law or agreed to in writing, software
 # * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(compositeinput-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET compositeinput)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "compositeinput-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/compositeinput/src/current'
-#   c. Create the library target 'compositeinput-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh compositeinput first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/deepsleep/current/CMakeLists.txt
+++ b/deepsleep/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(deepsleep-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET deepsleep)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "deepsleep-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/deepsleep/src/current'
-#   c. Create the library target 'deepsleep-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh deepsleep first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/deviceinfo/current/CMakeLists.txt
+++ b/deviceinfo/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(deviceinfo-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET deviceinfo)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "deviceinfo-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/deviceinfo/src/current'
-#   c. Create the library target 'deviceinfo-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh deviceinfo first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/drm/current/CMakeLists.txt
+++ b/drm/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(drm-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET drm)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "drm-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/drm/src/current'
-#   c. Create the library target 'drm-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh drm first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/firmwareupdate/current/CMakeLists.txt
+++ b/firmwareupdate/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(firmwareupdate-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET firmwareupdate)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "firmwareupdate-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/firmwareupdate/src/current'
-#   c. Create the library target 'firmwareupdate-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh firmwareupdate first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/hdmicec/current/CMakeLists.txt
+++ b/hdmicec/current/CMakeLists.txt
@@ -19,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(hdmicec-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET hdmicec)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "hdmicec-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/hdmicec/src/current'
-#   c. Create the library target 'hdmicec-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh hdmicec first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/hdmiinput/current/CMakeLists.txt
+++ b/hdmiinput/current/CMakeLists.txt
@@ -19,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(hdmiinput-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET hdmiinput)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "hdmiinput-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/hdmiinput/src/current'
-#   c. Create the library target 'hdmiinput-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh hdmiinput first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/hdmioutput/current/CMakeLists.txt
+++ b/hdmioutput/current/CMakeLists.txt
@@ -19,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(hdmioutput-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET hdmioutput)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "hdmioutput-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/hdmioutput/src/current'
-#   c. Create the library target 'hdmioutput-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh hdmioutput first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/indicator/current/CMakeLists.txt
+++ b/indicator/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(indicator-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET indicator)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "indicator-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/indicator/src/current'
-#   c. Create the library target 'indicator-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh indicator first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/panel/current/CMakeLists.txt
+++ b/panel/current/CMakeLists.txt
@@ -19,15 +19,99 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(panel-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET panel)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "panel-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/panel/src/current'
-#   c. Create the library target 'panel-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh panel first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp videodecoder-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/planecontrol/current/CMakeLists.txt
+++ b/planecontrol/current/CMakeLists.txt
@@ -19,15 +19,99 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(planecontrol-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET planecontrol)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "planecontrol-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/planecontrol/src/current'
-#   c. Create the library target 'planecontrol-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh planecontrol first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp videodecoder-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -19,15 +19,82 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(sensor-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET sensor)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "sensor-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/sensor/src/current'
-#   c. Create the library target 'sensor-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh sensor first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/videodecoder/current/CMakeLists.txt
+++ b/videodecoder/current/CMakeLists.txt
@@ -19,15 +19,98 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(videodecoder-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET videodecoder)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "videodecoder-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/videodecoder/src/current'
-#   c. Create the library target 'videodecoder-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh videodecoder first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/common/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/videosink/current/CMakeLists.txt
+++ b/videosink/current/CMakeLists.txt
@@ -19,15 +19,100 @@
 # * limitations under the License.
 # *
 #** ******************************************************************************
-cmake_minimum_required(VERSION 3.8)
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(videosink-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# 1. Define the Interface Identity
-set(INTERFACE_TARGET videosink)
-set(INTERFACE_VERSION current)
+set(LIB_NAME "videosink-vcurrent-cpp")
 
-# 2. Trigger the Build
-# This function (from CMakeLists.inc) will:
-#   a. Run 'aidl_ops -g' to generate the C++ code
-#   b. Find the generated files in 'stable/generated/videosink/src/current'
-#   c. Create the library target 'videosink-vcurrent-cpp'
-target_build_interfaces_libraries()
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh videosink first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/avclock/current/include"
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils avclock-vcurrent-cpp common-vcurrent-cpp videodecoder-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
## Summary

Replaces each component's \`<module>/current/CMakeLists.txt\` — previously a ~14-line stub that delegated to the toolchain but was never invoked by the root build path — with a **self-contained**, direct-compile CMakeLists.txt.

This is the first step toward eliminating \`out/aidl/\` ([#546](https://github.com/rdkcentral/rdk-halif-aidl/issues/546)).

Closes #546 (v1 — the asymmetry that blocked single-module standalone builds is gone; full out/aidl/ removal is the next step).

## What changes

Each new \`<module>/current/CMakeLists.txt\` mirrors the shape \`release.sh\` writes into snapshot dirs:

- No AIDL regeneration — just compile the committed \`src/\` + \`include/\` into \`lib<comp>-vcurrent-cpp.so\`
- Imports declared in \`interface.yaml\` drive the \`target_link_libraries\` list (\`<dep>-vcurrent-cpp\` for \`@current\` / bare-name pins)
- Self-documenting comment block at the top explaining inputs (\`BINDER_SDK_DIR\`, \`HALIF_LIB_DIR\`, \`HALIF_INCLUDE_DIR\`)

A downstream consumer can now build any single component from its own directory without dragging in the \`out/aidl/\` toolchain scaffold:

\`\`\`bash
cmake -S videodecoder/current -B build/videodecoder \
    -DBINDER_SDK_DIR=/path/to/out/target \
    -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
    -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
    -DHALIF_INCLUDE_DIR=/path/to/out/build/include
cmake --build build/videodecoder
\`\`\`

## What doesn't change

The repo's overall build path is **unaffected**:

- \`./build_interfaces.sh <module>\` still works as before (uses toolchain's \`CMakeLists.inc\` for regen + wiring)
- \`./build_modules.sh all\` still works as before
- \`./tests/smoke_test.sh\` still passes

The previous stubs delegated to \`target_build_interfaces_libraries()\` — a function only available inside the toolchain. So a downstream consumer **could not** actually build them standalone, despite the file existing. The new shape genuinely is self-buildable.

## Verification

| Build path | Result |
|---|---|
| \`./build_interfaces.sh videodecoder\` | ✅ unchanged behaviour |
| \`cmake -S videodecoder/current -B /tmp/test ...\` + \`cmake --build /tmp/test\` | ✅ standalone build produces \`libvideodecoder-vcurrent-cpp.so\` |

## 21 files migrated

audiodecoder, audiomixer, audiosink, avbuffer, avclock, boot, common, compositeinput, deepsleep, deviceinfo, drm, firmwareupdate, hdmicec, hdmiinput, hdmioutput, indicator, panel, planecontrol, sensor, videodecoder, videosink.

## Follow-up

- Full \`out/aidl/\` elimination (toolchain stops emitting per-module CMakeLists, dep tree derived from on-disk \`interface.yaml\` directly) — tracked in #546, to be done in a paired linux_binder_idl PR.