### PR TITLE
feat(videodecoder)!: expand Colorimetry to 4 independent axes (#367)

### DIFF
--- a/videodecoder/current/com/rdk/hal/videodecoder/ColorMatrix.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/ColorMatrix.aidl
@@ -1,0 +1,77 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     YCbCr → RGB conversion matrix coefficients.
+ *
+ *  Identifies the matrix used to derive luma and chroma from the
+ *  red/green/blue components (and the inverse for display). Enum ordinals
+ *  are aligned with ITU-T H.273 / ISO/IEC 23091-2 `MatrixCoefficients`
+ *  (CICP) so middleware can forward bitstream VUI values verbatim by
+ *  casting to `int`. The `UNKNOWN` sentinel uses `-1` (repo convention,
+ *  see `hdmiinput.SignalState.UNKNOWN`).
+ *
+ *  Critical distinction for HDR: `BT2020_NCL` (non-constant luminance)
+ *  and `BT2020_CL` (constant luminance) differ — the bitstream signals
+ *  which is in use. PQ/HLG HDR streams typically use `BT2020_NCL`.
+ *
+ *  CICP values not listed here (2 = unspecified, 3 = reserved, 4 = FCC,
+ *  8 = YCgCo, 11 = SMPTE 2085, 12–14 = chroma-derived variants) are
+ *  uncommon in distribution-grade content and are omitted; add them on
+ *  demand.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+@Backing(type="int")
+enum ColorMatrix {
+
+    /** Matrix not signalled / unknown. */
+    UNKNOWN = -1,
+
+    /** Identity (RGB / GBR) — no YCbCr conversion. CICP value 0. */
+    IDENTITY = 0,
+
+    /** ITU-R BT.709 / SMPTE RP 177. CICP value 1. */
+    BT709 = 1,
+
+    /**
+     * Unspecified by the bitstream — distinct from UNKNOWN. The stream
+     * explicitly signalled "unspecified" (CICP value 2); downstream code
+     * should apply a default. UNKNOWN by contrast means no signal was
+     * carried at all (no AIDL override sent, no VUI in the bitstream).
+     */
+    UNSPECIFIED = 2,
+
+    /** ITU-R BT.601-7 625-line (PAL/SECAM). CICP value 5. */
+    BT601_625 = 5,
+
+    /** ITU-R BT.601-7 525-line / SMPTE 170M (NTSC). CICP value 6. */
+    BT601_525 = 6,
+
+    /** SMPTE 240M. CICP value 7. */
+    SMPTE240M = 7,
+
+    /** ITU-R BT.2020 non-constant luminance. CICP value 9. */
+    BT2020_NCL = 9,
+
+    /** ITU-R BT.2020 constant luminance. CICP value 10. */
+    BT2020_CL = 10,
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/ColorPrimaries.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/ColorPrimaries.aidl
@@ -1,0 +1,86 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     CIE chromaticity coordinates of the display primaries (the
+ *             "colour gamut" of the stream).
+ *
+ *  Enum ordinals are aligned with ITU-T H.273 / ISO/IEC 23091-2
+ *  `ColourPrimaries` (CICP) so middleware can forward bitstream VUI
+ *  values verbatim by casting to `int`. The `UNKNOWN` sentinel uses `-1`
+ *  (repo convention, see `hdmiinput.SignalState.UNKNOWN`).
+ *
+ *  In HDR signalling, primaries are typically `BT2020` while the transfer
+ *  function (`TransferCharacteristics`) distinguishes the HDR system in use
+ *  (PQ vs HLG).
+ *
+ *  CICP values 0 (reserved), 2 (unspecified), 3 (reserved), and 13–21
+ *  (reserved) are omitted; the rest match their CICP code points.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+@Backing(type="int")
+enum ColorPrimaries {
+
+    /** Primaries not signalled / unknown. */
+    UNKNOWN = -1,
+
+    /** ITU-R BT.709 / SMPTE RP 177. CICP value 1. */
+    BT709 = 1,
+
+    /**
+     * Unspecified by the bitstream — distinct from UNKNOWN. The stream
+     * explicitly signalled "unspecified" (CICP value 2); downstream code
+     * should apply a default. UNKNOWN by contrast means no signal was
+     * carried at all (no AIDL override sent, no VUI in the bitstream).
+     */
+    UNSPECIFIED = 2,
+
+    /** ITU-R BT.470 System M. CICP value 4. */
+    BT470M = 4,
+
+    /** ITU-R BT.470 System B/G (PAL/SECAM). CICP value 5. */
+    BT470BG = 5,
+
+    /** SMPTE 170M / ITU-R BT.601 525-line (NTSC). CICP value 6. */
+    BT601_525 = 6,
+
+    /** SMPTE 240M. CICP value 7. */
+    SMPTE240M = 7,
+
+    /** Generic film (Illuminant C). CICP value 8. */
+    FILM = 8,
+
+    /** ITU-R BT.2020 / BT.2100. CICP value 9. */
+    BT2020 = 9,
+
+    /** SMPTE ST 428-1 / DCDM. CICP value 10. */
+    SMPTE428 = 10,
+
+    /** DCI-P3 with D60 white point (theatrical). CICP value 11. */
+    DCI_P3_D60 = 11,
+
+    /** Display P3 — DCI-P3 with D65 white point (home video / streaming). CICP value 12. */
+    DISPLAY_P3 = 12,
+
+    /** EBU Tech 3213-E. CICP value 22. */
+    EBU3213 = 22,
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/ColorRange.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/ColorRange.aidl
@@ -1,0 +1,51 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     Video sample range — limited (studio) vs full (computer)
+ *             quantisation.
+ *
+ *  Enum ordinals are aligned with ITU-T H.273 / ISO/IEC 23091-2
+ *  `video_full_range_flag` (CICP VideoFullRangeFlag) so middleware can
+ *  forward the bitstream value verbatim by casting to `int`. The
+ *  `UNKNOWN` sentinel uses `-1` (repo convention, see
+ *  `hdmiinput.SignalState.UNKNOWN`).
+ *
+ *  - `LIMITED` is the standard studio (head/foot-room) range:
+ *      8-bit  → 16..235 (luma), 16..240 (chroma)
+ *      10-bit → 64..940 (luma), 64..960 (chroma)
+ *  - `FULL` uses the full code range (0..255 / 0..1023). Common for
+ *    sRGB content, JPEG-derived imagery, and some HDR mastering pipes.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+@Backing(type="int")
+enum ColorRange {
+
+    /** Range not signalled / unknown. */
+    UNKNOWN = -1,
+
+    /** Limited / studio / head-room range. CICP `video_full_range_flag` = 0. */
+    LIMITED = 0,
+
+    /** Full / PC / 0..255 (8-bit) range. CICP `video_full_range_flag` = 1. */
+    FULL = 1,
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/Colorimetry.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/Colorimetry.aidl
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,69 +18,71 @@
  */
 package com.rdk.hal.videodecoder;
 
+import com.rdk.hal.videodecoder.ColorRange;
+import com.rdk.hal.videodecoder.ColorMatrix;
+import com.rdk.hal.videodecoder.TransferCharacteristics;
+import com.rdk.hal.videodecoder.ColorPrimaries;
+
 /**
- *  @brief     Colorimetry (colour primaries and matrix) of a video stream.
+ *  @brief     Full colorimetry signalling for a video stream — the four
+ *             independent axes carried by the bitstream VUI / container
+ *             metadata.
  *
- *  Identifies the colour space of the decoded video content. This is distinct
- *  from the HDMI output colorimetry signalling (hdmioutput.Colorimetry), which
- *  describes how the signal is carried over the HDMI link.
+ *  Replaces the prior single-enum `Colorimetry` (which conflated all four
+ *  axes into a single "BT709 / BT2020 / ..." label and could not, e.g.,
+ *  distinguish PQ from HLG when primaries are the same). Field shape
+ *  matches:
  *
- *  Values correspond to ITU-R and SMPTE colour primaries standards as
- *  referenced in ISO/IEC 23091-2 (CICP colour primaries).
+ *  - ITU-T H.273 / ISO/IEC 23091-2 CICP (the H.264/HEVC VUI carries these
+ *    four values as `video_full_range_flag`, `matrix_coefficients`,
+ *    `transfer_characteristics`, `colour_primaries`).
+ *  - GStreamer `GstVideoColorimetry` — middleware extracts the same four
+ *    values from caps' `colorimetry` field. See issue #367 for the
+ *    extraction pattern (`vci.range`, `vci.matrix`, `vci.transfer`,
+ *    `vci.primaries`).
+ *
+ *  <h3>Default values</h3>
+ *  All four fields default to their `UNKNOWN` sentinel so an unset
+ *  parcelable equals "no colorimetry signalled". Carriers using this
+ *  parcelable as an `@nullable` field can additionally distinguish
+ *  "no override" (null) from "explicitly all UNKNOWN" (non-null with
+ *  every field = UNKNOWN).
+ *
+ *  <h3>Common configurations</h3>
+ *  - SDR BT.709 :  range=LIMITED, matrix=BT709,      transfer=BT709,            primaries=BT709
+ *  - SDR BT.601 :  range=LIMITED, matrix=BT601_525,  transfer=SMPTE170M,        primaries=BT601_525  (NTSC)
+ *  - HDR10 (PQ) :  range=LIMITED, matrix=BT2020_NCL, transfer=SMPTE2084_PQ,     primaries=BT2020
+ *  - HLG        :  range=LIMITED, matrix=BT2020_NCL, transfer=ARIB_STD_B67_HLG, primaries=BT2020
+ *  - sRGB       :  range=FULL,    matrix=IDENTITY,   transfer=SRGB,             primaries=BT709
  *
  *  @author    Gerald Weatherup
  */
-
 @VintfStability
-@Backing(type="int")
-enum Colorimetry {
+parcelable Colorimetry {
 
     /**
-     * Colorimetry is unknown or not signalled in the stream.
+     * Sample quantisation range (limited / studio vs full / computer).
+     * GStreamer mapping: `GstVideoColorimetry.range` → `hdrColorimetry[0]`.
      */
-    UNKNOWN = 0,
+    ColorRange range = ColorRange.UNKNOWN;
 
     /**
-     * ITU-R BT.601 525-line (NTSC).
-     * Used for standard-definition NTSC content.
+     * YCbCr → RGB conversion matrix coefficients.
+     * GStreamer mapping: `GstVideoColorimetry.matrix` → `hdrColorimetry[1]`.
      */
-    BT601_525 = 1,
+    ColorMatrix matrix = ColorMatrix.UNKNOWN;
 
     /**
-     * ITU-R BT.601 625-line (PAL/SECAM).
-     * Used for standard-definition PAL and SECAM content.
+     * Opto-electrical transfer function (gamma / HDR curve).
+     * GStreamer mapping: `GstVideoColorimetry.transfer` → `hdrColorimetry[2]`.
+     * This is the field that distinguishes HDR systems (PQ vs HLG) when
+     * primaries are the same.
      */
-    BT601_625 = 2,
+    TransferCharacteristics transfer = TransferCharacteristics.UNKNOWN;
 
     /**
-     * ITU-R BT.709.
-     * Used for high-definition content. The default for most HD streams.
+     * Colour primaries (the gamut chromaticities).
+     * GStreamer mapping: `GstVideoColorimetry.primaries` → `hdrColorimetry[3]`.
      */
-    BT709 = 3,
-
-    /**
-     * ITU-R BT.2020 (non-constant luminance).
-     * Used for ultra-high-definition HDR content including HDR10 and HLG.
-     * @see DynamicRange::HDR10, DynamicRange::HLG
-     */
-    BT2020 = 4,
-
-    /**
-     * ITU-R BT.2020 (constant luminance).
-     * Variant of BT.2020 using a constant-luminance signal encoding.
-     */
-    BT2020_CL = 5,
-
-    /**
-     * DCI-P3 with D65 white point.
-     * Used for HDR content mastered for home video display (HDR Blu-ray,
-     * streaming with P3 mastering).
-     */
-    DCI_P3_D65 = 6,
-
-    /**
-     * DCI-P3 with D60 white point.
-     * Used for content mastered for theatrical presentation.
-     */
-    DCI_P3_D60 = 7,
+    ColorPrimaries primaries = ColorPrimaries.UNKNOWN;
 }

--- a/videodecoder/current/com/rdk/hal/videodecoder/FrameMetadata.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/FrameMetadata.aidl
@@ -141,8 +141,10 @@ parcelable FrameMetadata {
 	boolean lowLatency;
 
 	/**
-	 * Colorimetry (colour primaries and matrix) of the video frame as reported by the decoder.
-	 * Set to Colorimetry::UNKNOWN if not signalled in the stream.
+	 * Colorimetry (range / matrix / transfer / primaries) of the video
+	 * frame as reported by the decoder. Each axis is set to its `UNKNOWN`
+	 * sentinel when not signalled in the stream; the parcelable itself is
+	 * never null on the frame-output path.
 	 */
 	Colorimetry colorimetry;
 

--- a/videodecoder/current/com/rdk/hal/videodecoder/InputBufferMetadata.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/InputBufferMetadata.aidl
@@ -43,9 +43,13 @@ import com.rdk.hal.videodecoder.DolbyVisionLayerFlags;
  *
  *  <h4>Override fields (`colorimetry`, `masteringDisplayInfo`,
  *  `contentLightLevel`, `dolbyVisionLayerFlags`, `pixelAspectRatio`)</h4>
- *  All five are `@nullable` except `colorimetry`, which uses
- *  `Colorimetry::UNKNOWN` as the "no change" sentinel because AIDL
- *  enums cannot be `@nullable`.
+ *  All five are `@nullable`. For `colorimetry`, sub-axes the caller
+ *  doesn't want to override are left at their `UNKNOWN` sentinel within
+ *  a non-null parcelable — e.g. setting `colorimetry.matrix` to
+ *  `BT2020_NCL` while leaving `range`/`transfer`/`primaries` at
+ *  `UNKNOWN` overrides only the matrix axis. (Pass `null` to leave all
+ *  four axes unchanged from the prior override / setStreamConfig
+ *  state.)
  *  These mirror the matching fields on `VideoDecoderStreamConfig` and let
  *  middleware push container-derived metadata that changes mid-stream
  *  (e.g. ABR per-Period HDR transition, SSAI ad insertion, live→VOD switch).
@@ -58,11 +62,6 @@ import com.rdk.hal.videodecoder.DolbyVisionLayerFlags;
  *                              applied override (or the value set in
  *                              `State::READY` via `setStreamConfig()`)
  *                              remains in effect.
- *  - `Colorimetry::UNKNOWN`  — the "no change" form for `colorimetry`
- *                              (which is non-nullable because AIDL enums
- *                              cannot be `@nullable`). Semantics match
- *                              the `null` form above for the other four
- *                              fields.
  *
  *  Override precedence and persistence matches the `VideoDecoderStreamConfig`
  *  contract: bitstream-derived metadata still wins over the override;
@@ -104,13 +103,13 @@ parcelable InputBufferMetadata {
 
     /**
      * Optional colorimetry override applied from this buffer onward.
-     * AIDL enums cannot be `@nullable`, so this
-     * field uses `Colorimetry::UNKNOWN` (the default for an unset enum)
-     * to encode "no change". Any other value applies as an override.
+     * null = no change. Non-null applies the override; sub-axes the
+     * caller doesn't want to override are left at their `UNKNOWN`
+     * sentinel within the non-null parcelable.
      *
      * @see VideoDecoderStreamConfig.colorimetry, IVideoDecoderController.setStreamConfig()
      */
-    Colorimetry colorimetry = Colorimetry.UNKNOWN;
+    @nullable Colorimetry colorimetry;
 
     /**
      * Optional mastering display colour volume override (SMPTE ST 2086)

--- a/videodecoder/current/com/rdk/hal/videodecoder/TransferCharacteristics.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/TransferCharacteristics.aidl
@@ -1,0 +1,101 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+/**
+ *  @brief     Opto-electrical transfer function (OETF / EOTF) — the
+ *             gamma / HDR curve of the stream.
+ *
+ *  Enum ordinals are aligned with ITU-T H.273 / ISO/IEC 23091-2
+ *  `TransferCharacteristics` (CICP) so middleware can forward bitstream
+ *  VUI values verbatim by casting to `int`. The `UNKNOWN` sentinel uses
+ *  `-1` (repo convention, see `hdmiinput.SignalState.UNKNOWN`).
+ *
+ *  This is the field that distinguishes HDR from SDR even when primaries
+ *  are the same: HDR10 uses `SMPTE2084_PQ`, HLG uses
+ *  `ARIB_STD_B67_HLG`, while their primaries are typically `BT.2020`.
+ *
+ *  CICP values 0 (reserved), 2 (unspecified), and 3 (reserved) are
+ *  omitted; the rest are present and equal their CICP code points.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+@Backing(type="int")
+enum TransferCharacteristics {
+
+    /** Transfer characteristics not signalled / unknown. */
+    UNKNOWN = -1,
+
+    /** ITU-R BT.709 / BT.601 / BT.2020 10-bit SDR. CICP value 1. */
+    BT709 = 1,
+
+    /**
+     * Unspecified by the bitstream — distinct from UNKNOWN. The stream
+     * explicitly signalled "unspecified" (CICP value 2); downstream code
+     * should apply a default. UNKNOWN by contrast means no signal was
+     * carried at all (no AIDL override sent, no VUI in the bitstream).
+     */
+    UNSPECIFIED = 2,
+
+    /** ITU-R BT.470 System M. Assumed display gamma 2.2. CICP value 4. */
+    BT470M_GAMMA22 = 4,
+
+    /** ITU-R BT.470 System B/G (PAL/SECAM). Assumed display gamma 2.8. CICP value 5. */
+    BT470BG_GAMMA28 = 5,
+
+    /** SMPTE 170M (NTSC). CICP value 6. */
+    SMPTE170M = 6,
+
+    /** SMPTE 240M. CICP value 7. */
+    SMPTE240M = 7,
+
+    /** Linear (no transfer). CICP value 8. */
+    LINEAR = 8,
+
+    /** Logarithmic, 100:1 contrast range. CICP value 9. */
+    LOG_100 = 9,
+
+    /** Logarithmic, 316.2:1 contrast range. CICP value 10. */
+    LOG_316 = 10,
+
+    /** IEC 61966-2-4 (xvYCC). CICP value 11. */
+    IEC61966_2_4 = 11,
+
+    /** ITU-R BT.1361 extended colour gamut. CICP value 12. */
+    BT1361 = 12,
+
+    /** IEC 61966-2-1 sRGB / sYCC. CICP value 13. */
+    SRGB = 13,
+
+    /** ITU-R BT.2020 10-bit SDR. CICP value 14. */
+    BT2020_10 = 14,
+
+    /** ITU-R BT.2020 12-bit SDR. CICP value 15. */
+    BT2020_12 = 15,
+
+    /** SMPTE ST 2084 (Perceptual Quantiser) — HDR10. CICP value 16. */
+    SMPTE2084_PQ = 16,
+
+    /** SMPTE ST 428-1 / DCDM. CICP value 17. */
+    SMPTE428 = 17,
+
+    /** ARIB STD-B67 (Hybrid Log-Gamma) — HLG. CICP value 18. */
+    ARIB_STD_B67_HLG = 18,
+}

--- a/videodecoder/current/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/VideoDecoderStreamConfig.aidl
@@ -90,13 +90,13 @@ parcelable VideoDecoderStreamConfig {
     @nullable Fraction pixelAspectRatio;
 
     /**
-     * Colorimetry (colour primaries and matrix) for the stream.
-     * AIDL enums cannot be `@nullable`,
-     * so this field uses `Colorimetry::UNKNOWN` (the default for an unset
-     * enum) to encode "leave existing colorimetry hint unchanged".
-     * Any other value applies as a hint.
+     * Colorimetry (range / matrix / transfer / primaries — the four
+     * independent axes carried by the bitstream VUI / container).
+     * null = leave existing colorimetry hint unchanged. Non-null applies
+     * the hint; sub-axes the caller doesn't want to override are left
+     * at their `UNKNOWN` sentinel within the non-null parcelable.
      */
-    Colorimetry colorimetry = Colorimetry.UNKNOWN;
+    @nullable Colorimetry colorimetry;
 
     /**
      * Mastering display colour volume metadata (SMPTE ST 2086).


### PR DESCRIPTION
## Summary

Replaces the single \`Colorimetry\` enum with a **parcelable carrying four independent sub-enums** that match the ITU-T H.273 / ISO/IEC 23091-2 CICP fields the bitstream VUI signals and the GStreamer \`GstVideoColorimetry\` struct that middleware extracts from caps. The old single-enum form (\`BT709\`, \`BT2020\`, \`BT2020_CL\`, …) conflated all four axes and couldn't, for example, distinguish PQ from HLG when primaries are the same.

Closes #367.

## New shape

\`\`\`aidl
@VintfStability
parcelable Colorimetry {
    ColorRange              range     = ColorRange.UNKNOWN;
    ColorMatrix             matrix    = ColorMatrix.UNKNOWN;
    TransferCharacteristics transfer  = TransferCharacteristics.UNKNOWN;
    ColorPrimaries          primaries = ColorPrimaries.UNKNOWN;
}
\`\`\`

GStreamer mapping (the original ask in #367):

| Field | GStreamer | \`hdrColorimetry[N]\` |
|---|---|---|
| \`range\` | \`GstVideoColorimetry.range\` | \`[0]\` |
| \`matrix\` | \`GstVideoColorimetry.matrix\` | \`[1]\` |
| \`transfer\` | \`GstVideoColorimetry.transfer\` | \`[2]\` |
| \`primaries\` | \`GstVideoColorimetry.primaries\` | \`[3]\` |

## New sub-enum files

| File | Values |
|---|---|
| \`ColorRange.aidl\` | \`UNKNOWN\`, \`LIMITED\`, \`FULL\` |
| \`ColorMatrix.aidl\` | CICP MatrixCoefficients — \`IDENTITY\`, \`BT709\`, \`BT601_525/625\`, \`SMPTE240M\`, \`BT2020_NCL/CL\` |
| \`TransferCharacteristics.aidl\` | CICP TransferCharacteristics — \`BT709\`, \`BT470M_GAMMA22\`, \`BT470BG_GAMMA28\`, \`SMPTE170M/240M\`, \`LINEAR\`, \`LOG_100/316\`, \`IEC61966_2_4\`, \`BT1361\`, \`SRGB\`, \`BT2020_10/12\`, **\`SMPTE2084_PQ\`**, \`SMPTE428\`, **\`ARIB_STD_B67_HLG\`** |
| \`ColorPrimaries.aidl\` | CICP ColourPrimaries — \`BT709\`, \`BT470M\`, \`BT470BG\`, \`BT601_525\`, \`SMPTE240M\`, \`FILM\`, \`BT2020\`, \`SMPTE428\`, \`DCI_P3_D60\`, \`DISPLAY_P3\`, \`EBU3213\` |

Values are aligned to CICP code points so middleware can forward bitstream VUI values verbatim (or via a small translation table where the AIDL enum value differs from the CICP ordinal).

## Common configurations the new shape expresses precisely

| Scenario | range | matrix | transfer | primaries |
|---|---|---|---|---|
| SDR BT.709 | LIMITED | BT709 | BT709 | BT709 |
| SDR BT.601 NTSC | LIMITED | BT601_525 | SMPTE170M | BT601_525 |
| **HDR10 (PQ)** | LIMITED | BT2020_NCL | **SMPTE2084_PQ** | BT2020 |
| **HLG** | LIMITED | BT2020_NCL | **ARIB_STD_B67_HLG** | BT2020 |
| sRGB | FULL | IDENTITY | SRGB | BT709 |

The PQ vs HLG distinction — invisible to the old single-enum \`BT2020\` value — is now first-class.

## Consumer-side changes

- \`IVideoDecoderController.setColorimetry()\` parameter is now \`@nullable Colorimetry\` — pass \`null\` to clear the hint and revert to bitstream signalling. (\`Colorimetry::UNKNOWN\` doesn't exist anymore; the per-axis \`UNKNOWN\` sentinels live on the sub-enums.)
- \`FrameMetadata.colorimetry\` remains non-null — the decoder reports a parcelable with every axis populated (per-axis \`UNKNOWN\` when the bitstream is silent on that axis).

## Versioning

- \`videodecoder/metadata.yaml\`: \`0.2.0.0\` → \`0.3.0.0\` (generation; breaking — \`Colorimetry\`'s shape changes from enum to parcelable)
- \`breaking-change\` label on this PR

## Verification

\`./build_interfaces.sh\` clean on:

- \`videodecoder\` ✅
- \`videosink\` ✅ (downstream consumer)
- \`planecontrol\` ✅ (downstream consumer)
- \`panel\` ✅ (downstream consumer)
- \`avbuffer\` ✅ (downstream consumer)

## Notes

- This PR is **independent** of #543 (which removes the typed setters and adds \`setStreamConfig\`). They touch the same lines in \`IVideoDecoderController.aidl\` and the same \`videodecoder@0.3.0.0\` generation bump; whichever lands first, the other will need a small rebase to either:
    - drop the \`setColorimetry()\` change (if #543 merges first — \`setColorimetry\` is removed)
    - or update \`VideoDecoderStreamConfig.colorimetry\` / \`InputBufferMetadata.colorimetry\` to use the new parcelable (if #367 merges first)