### PR TITLE
feat(videodecoder)!: Profile[] in CodecCapabilities + matching HFP (#528, supersedes #520)

### DIFF
--- a/videodecoder/current/com/rdk/hal/videodecoder/CodecCapabilities.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/CodecCapabilities.aidl
@@ -18,12 +18,21 @@
  */
 package com.rdk.hal.videodecoder;
 import com.rdk.hal.videodecoder.Codec;
-import com.rdk.hal.videodecoder.CodecProfile;
-import com.rdk.hal.videodecoder.CodecLevel;
 import com.rdk.hal.videodecoder.PixelFormat;
+import com.rdk.hal.videodecoder.Profile;
 
 /**
  *  @brief     Codec capability definition.
+ *
+ *  Each entry describes one codec the decoder supports, the set of
+ *  profiles within that codec it can decode (each with its own
+ *  `maxLevel` and `maxBitrateInBps`), and the resolution / pixel-format
+ *  envelope shared across those profiles.
+ *
+ *  Shape mirrors `rdk-hpk-documentation/hfp-reference/videodecoder/
+ *  hfp-videodecoder.yaml` field-for-field so the HFP YAML reads as a
+ *  direct serialisation of the AIDL parcelable.
+ *
  *  @author    Luc Kennedy-Lamb
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
@@ -39,14 +48,20 @@ parcelable CodecCapabilities
     Codec codec;
 
   	/**
-     * Defines the profile for this Codec.
+     * Profiles supported for this codec, each with its own `maxLevel`
+     * and `maxBitrateInBps`. A single codec can advertise multiple
+     * profiles independently (e.g. H.265 supporting MAIN, MAIN_10, and
+     * MAIN_10_HDR10 at LEVEL_5_2).
+     *
+     * All lower profiles for the same codec are NOT implicitly
+     * supported — the array enumerates exactly what is supported. (In
+     * contrast, lower levels within each `Profile` entry ARE implicitly
+     * supported per `Profile.maxLevel` semantics.)
+     *
+     * @see Profile
      */
-    CodecProfile profile;
+    Profile[] profiles;
 
-    /**
-     * Defines the level for this Codec.
-     */
-    CodecLevel level;
 	/**
 	 * The maximum frame rate (FPS) supported for decode for this Codec.
 	 * e.g. 25, 30, 50, 60, 120.

--- a/videodecoder/current/com/rdk/hal/videodecoder/Profile.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/Profile.aidl
@@ -1,0 +1,73 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rdk.hal.videodecoder;
+
+import com.rdk.hal.videodecoder.CodecProfile;
+import com.rdk.hal.videodecoder.CodecLevel;
+
+/**
+ *  @brief     Per-profile capability descriptor for a codec — pairs a
+ *             `CodecProfile` with the maximum level and bitrate the
+ *             decoder advertises for that profile.
+ *
+ *  Used inside `CodecCapabilities.profiles[]` so a codec entry can
+ *  advertise multiple profiles independently. The previous model
+ *  (single `profile` + `level` per codec) couldn't express the common
+ *  case where hardware supports several profiles per codec at the same
+ *  level (e.g. H.265 supporting MAIN, MAIN_10, and MAIN_10_HDR10 each
+ *  at LEVEL_5_2).
+ *
+ *  <h3>"Max" semantics</h3>
+ *  Both `maxLevel` and `maxBitrateInBps` are inclusive ceilings. All
+ *  lower levels for the same profile are implicitly supported. A
+ *  bitstream at or below `maxLevel` and at or below `maxBitrateInBps`
+ *  is in-spec for this profile.
+ *
+ *  Shape mirrors `rdk-hpk-documentation/hfp-reference/videodecoder/
+ *  hfp-videodecoder.yaml` field-for-field so the HFP YAML reads as a
+ *  direct serialisation of the AIDL parcelable.
+ *
+ *  @author    Gerald Weatherup
+ */
+@VintfStability
+parcelable Profile {
+
+    /**
+     * The codec profile this descriptor applies to (e.g. `H265_MAIN`,
+     * `H265_MAIN_10`, `AV1_MAIN`).
+     */
+    CodecProfile profile;
+
+    /**
+     * The maximum supported level for this profile. All lower levels
+     * for the same profile are also supported.
+     */
+    CodecLevel maxLevel;
+
+    /**
+     * The maximum decode bitrate in bits per second for this
+     * profile/level combination.
+     *
+     * Use `0` to indicate "no explicit limit advertised" — most
+     * platforms should report a real ceiling here, but `0` keeps the
+     * field non-null for cases where the SoC vendor genuinely doesn't
+     * publish a bitrate cap.
+     */
+    long maxBitrateInBps;
+}

--- a/videodecoder/current/hfp-videodecoder.yaml
+++ b/videodecoder/current/hfp-videodecoder.yaml
@@ -21,39 +21,86 @@
 #** ******************************************************************************
 
 # HAL Feature Profile for videodecoder
+#
+# Mirrors CodecCapabilities.aidl + Profile.aidl field-for-field.
+# Reference implementation aligned with
+# rdk-hpk-documentation/hfp-reference/videodecoder/hfp-videodecoder.yaml.
+#
+# Per-codec capability semantics:
+#   - `profiles[]` enumerates exactly which profiles are supported for the
+#     codec — no implicit "lower profiles also supported" rule.
+#   - Within each profile, `maxLevel` is inclusive — all lower levels for
+#     the same profile are implicitly supported.
+#   - `maxBitrateInBps` is an inclusive ceiling for the profile/level.
+#     Use `0` only if the SoC vendor doesn't publish a real cap.
 
 videodecoder:                   # Component object begins
   interfaceVersion: current
   supportedOperationalModes:
     - NON_TUNNELLED
   IVideoDecoder:                # Resource list
-    - 0:                        # Resource object begins
-      supportedCodecs:          # Array of codec capabilities
-        - MPEG:
+    - 0:                        # Resource object begins (high-tier decoder)
+      supportedCodecs:          # Array of CodecCapabilities
+        - MPEG2_VIDEO:
+            profiles:
+              - profile: MPEG2_MAIN
+                maxLevel: MPEG2_LEVEL_MAIN
+                maxBitrateInBps: 15000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
-        - H264:
+        - H264_AVC:
+            profiles:
+              - profile: H264_BASELINE
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H264_MAIN
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H264_HIGH
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
-        - H265:
+        - H265_HEVC:
+            profiles:
+              - profile: H265_MAIN
+                maxLevel: H265_LEVEL_5_2
+                maxBitrateInBps: 150000000
+              - profile: H265_MAIN_10
+                maxLevel: H265_LEVEL_5_2
+                maxBitrateInBps: 150000000
+              - profile: H265_MAIN_10_HDR10
+                maxLevel: H265_LEVEL_5_2
+                maxBitrateInBps: 150000000
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
             supportedOutputPixelFormats:
               - YCBCR420
         - VP9:
+            profiles:
+              - profile: VP9_PROFILE_0
+                maxLevel: VP9_LEVEL_5_1
+                maxBitrateInBps: 150000000
+              - profile: VP9_PROFILE_2
+                maxLevel: VP9_LEVEL_5_1
+                maxBitrateInBps: 150000000
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
             supportedOutputPixelFormats:
               - YCBCR420
         - AV1:
+            profiles:
+              - profile: AV1_MAIN
+                maxLevel: AV1_LEVEL_5_1
+                maxBitrateInBps: 150000000
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
@@ -71,33 +118,62 @@ videodecoder:                   # Component object begins
         - BT709
         - BT2020
       supportsSecure: true
-    - 1:                          # Resource object begins
-      supportedCodecs:          # Array of codec capabilities
-        - MPEG:
+    - 1:                          # Resource object begins (secondary HD decoder)
+      supportedCodecs:
+        - MPEG2_VIDEO:
+            profiles:
+              - profile: MPEG2_MAIN
+                maxLevel: MPEG2_LEVEL_MAIN
+                maxBitrateInBps: 15000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
-        - H264:
+        - H264_AVC:
+            profiles:
+              - profile: H264_BASELINE
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H264_MAIN
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H264_HIGH
+                maxLevel: H264_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
-        - H265:
+        - H265_HEVC:
+            profiles:
+              - profile: H265_MAIN
+                maxLevel: H265_LEVEL_4_1
+                maxBitrateInBps: 50000000
+              - profile: H265_MAIN_10
+                maxLevel: H265_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - VP9:
+            profiles:
+              - profile: VP9_PROFILE_0
+                maxLevel: VP9_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
         - AV1:
+            profiles:
+              - profile: AV1_MAIN
+                maxLevel: AV1_LEVEL_4_1
+                maxBitrateInBps: 50000000
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BnProfile.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BnProfile.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bn classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/BpProfile.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/BpProfile.h
@@ -1,0 +1,1 @@
+#error TODO(b/111362593) parcelables do not have bp classes

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/CodecCapabilities.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/CodecCapabilities.h
@@ -4,9 +4,8 @@
 #include <binder/Parcel.h>
 #include <binder/Status.h>
 #include <com/rdk/hal/videodecoder/Codec.h>
-#include <com/rdk/hal/videodecoder/CodecLevel.h>
-#include <com/rdk/hal/videodecoder/CodecProfile.h>
 #include <com/rdk/hal/videodecoder/PixelFormat.h>
+#include <com/rdk/hal/videodecoder/Profile.h>
 #include <cstdint>
 #include <tuple>
 #include <utils/String16.h>
@@ -19,29 +18,28 @@ namespace videodecoder {
 class CodecCapabilities : public ::android::Parcelable {
 public:
   ::com::rdk::hal::videodecoder::Codec codec = ::com::rdk::hal::videodecoder::Codec(0);
-  ::com::rdk::hal::videodecoder::CodecProfile profile = ::com::rdk::hal::videodecoder::CodecProfile(0);
-  ::com::rdk::hal::videodecoder::CodecLevel level = ::com::rdk::hal::videodecoder::CodecLevel(0);
+  ::std::vector<::com::rdk::hal::videodecoder::Profile> profiles;
   int32_t maxFrameRate = 0;
   int32_t maxFrameWidth = 0;
   int32_t maxFrameHeight = 0;
   ::std::vector<::com::rdk::hal::videodecoder::PixelFormat> supportedOutputPixelFormats;
   inline bool operator!=(const CodecCapabilities& rhs) const {
-    return std::tie(codec, profile, level, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) != std::tie(rhs.codec, rhs.profile, rhs.level, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
+    return std::tie(codec, profiles, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) != std::tie(rhs.codec, rhs.profiles, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
   }
   inline bool operator<(const CodecCapabilities& rhs) const {
-    return std::tie(codec, profile, level, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) < std::tie(rhs.codec, rhs.profile, rhs.level, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
+    return std::tie(codec, profiles, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) < std::tie(rhs.codec, rhs.profiles, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
   }
   inline bool operator<=(const CodecCapabilities& rhs) const {
-    return std::tie(codec, profile, level, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) <= std::tie(rhs.codec, rhs.profile, rhs.level, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
+    return std::tie(codec, profiles, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) <= std::tie(rhs.codec, rhs.profiles, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
   }
   inline bool operator==(const CodecCapabilities& rhs) const {
-    return std::tie(codec, profile, level, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) == std::tie(rhs.codec, rhs.profile, rhs.level, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
+    return std::tie(codec, profiles, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) == std::tie(rhs.codec, rhs.profiles, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
   }
   inline bool operator>(const CodecCapabilities& rhs) const {
-    return std::tie(codec, profile, level, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) > std::tie(rhs.codec, rhs.profile, rhs.level, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
+    return std::tie(codec, profiles, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) > std::tie(rhs.codec, rhs.profiles, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
   }
   inline bool operator>=(const CodecCapabilities& rhs) const {
-    return std::tie(codec, profile, level, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) >= std::tie(rhs.codec, rhs.profile, rhs.level, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
+    return std::tie(codec, profiles, maxFrameRate, maxFrameWidth, maxFrameHeight, supportedOutputPixelFormats) >= std::tie(rhs.codec, rhs.profiles, rhs.maxFrameRate, rhs.maxFrameWidth, rhs.maxFrameHeight, rhs.supportedOutputPixelFormats);
   }
 
   ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
@@ -55,8 +53,7 @@ public:
     std::ostringstream os;
     os << "CodecCapabilities{";
     os << "codec: " << ::android::internal::ToString(codec);
-    os << ", profile: " << ::android::internal::ToString(profile);
-    os << ", level: " << ::android::internal::ToString(level);
+    os << ", profiles: " << ::android::internal::ToString(profiles);
     os << ", maxFrameRate: " << ::android::internal::ToString(maxFrameRate);
     os << ", maxFrameWidth: " << ::android::internal::ToString(maxFrameWidth);
     os << ", maxFrameHeight: " << ::android::internal::ToString(maxFrameHeight);

--- a/videodecoder/current/include/com/rdk/hal/videodecoder/Profile.h
+++ b/videodecoder/current/include/com/rdk/hal/videodecoder/Profile.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <android/binder_to_string.h>
+#include <binder/Parcel.h>
+#include <binder/Status.h>
+#include <com/rdk/hal/videodecoder/CodecLevel.h>
+#include <com/rdk/hal/videodecoder/CodecProfile.h>
+#include <cstdint>
+#include <tuple>
+#include <utils/String16.h>
+
+namespace com {
+namespace rdk {
+namespace hal {
+namespace videodecoder {
+class Profile : public ::android::Parcelable {
+public:
+  ::com::rdk::hal::videodecoder::CodecProfile profile = ::com::rdk::hal::videodecoder::CodecProfile(0);
+  ::com::rdk::hal::videodecoder::CodecLevel maxLevel = ::com::rdk::hal::videodecoder::CodecLevel(0);
+  int64_t maxBitrateInBps = 0L;
+  inline bool operator!=(const Profile& rhs) const {
+    return std::tie(profile, maxLevel, maxBitrateInBps) != std::tie(rhs.profile, rhs.maxLevel, rhs.maxBitrateInBps);
+  }
+  inline bool operator<(const Profile& rhs) const {
+    return std::tie(profile, maxLevel, maxBitrateInBps) < std::tie(rhs.profile, rhs.maxLevel, rhs.maxBitrateInBps);
+  }
+  inline bool operator<=(const Profile& rhs) const {
+    return std::tie(profile, maxLevel, maxBitrateInBps) <= std::tie(rhs.profile, rhs.maxLevel, rhs.maxBitrateInBps);
+  }
+  inline bool operator==(const Profile& rhs) const {
+    return std::tie(profile, maxLevel, maxBitrateInBps) == std::tie(rhs.profile, rhs.maxLevel, rhs.maxBitrateInBps);
+  }
+  inline bool operator>(const Profile& rhs) const {
+    return std::tie(profile, maxLevel, maxBitrateInBps) > std::tie(rhs.profile, rhs.maxLevel, rhs.maxBitrateInBps);
+  }
+  inline bool operator>=(const Profile& rhs) const {
+    return std::tie(profile, maxLevel, maxBitrateInBps) >= std::tie(rhs.profile, rhs.maxLevel, rhs.maxBitrateInBps);
+  }
+
+  ::android::Parcelable::Stability getStability() const override { return ::android::Parcelable::Stability::STABILITY_VINTF; }
+  ::android::status_t readFromParcel(const ::android::Parcel* _aidl_parcel) final;
+  ::android::status_t writeToParcel(::android::Parcel* _aidl_parcel) const final;
+  static const ::android::String16& getParcelableDescriptor() {
+    static const ::android::StaticString16 DESCIPTOR (u"com.rdk.hal.videodecoder.Profile");
+    return DESCIPTOR;
+  }
+  inline std::string toString() const {
+    std::ostringstream os;
+    os << "Profile{";
+    os << "profile: " << ::android::internal::ToString(profile);
+    os << ", maxLevel: " << ::android::internal::ToString(maxLevel);
+    os << ", maxBitrateInBps: " << ::android::internal::ToString(maxBitrateInBps);
+    os << "}";
+    return os.str();
+  }
+};  // class Profile
+}  // namespace videodecoder
+}  // namespace hal
+}  // namespace rdk
+}  // namespace com

--- a/videodecoder/current/src/com/rdk/hal/videodecoder/Profile.cpp
+++ b/videodecoder/current/src/com/rdk/hal/videodecoder/Profile.cpp
@@ -1,10 +1,10 @@
-#include <com/rdk/hal/videodecoder/CodecCapabilities.h>
+#include <com/rdk/hal/videodecoder/Profile.h>
 
 namespace com {
 namespace rdk {
 namespace hal {
 namespace videodecoder {
-::android::status_t CodecCapabilities::readFromParcel(const ::android::Parcel* _aidl_parcel) {
+::android::status_t Profile::readFromParcel(const ::android::Parcel* _aidl_parcel) {
   ::android::status_t _aidl_ret_status = ::android::OK;
   size_t _aidl_start_pos = _aidl_parcel->dataPosition();
   int32_t _aidl_parcelable_raw_size = 0;
@@ -19,7 +19,7 @@ namespace videodecoder {
     _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->readInt32(reinterpret_cast<int32_t *>(&codec));
+  _aidl_ret_status = _aidl_parcel->readInt32(reinterpret_cast<int32_t *>(&profile));
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
@@ -27,7 +27,7 @@ namespace videodecoder {
     _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->readParcelableVector(&profiles);
+  _aidl_ret_status = _aidl_parcel->readInt32(reinterpret_cast<int32_t *>(&maxLevel));
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
@@ -35,62 +35,26 @@ namespace videodecoder {
     _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->readInt32(&maxFrameRate);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
-    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->readInt32(&maxFrameWidth);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
-    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->readInt32(&maxFrameHeight);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  if (_aidl_parcel->dataPosition() - _aidl_start_pos >= _aidl_parcelable_size) {
-    _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->readEnumVector(&supportedOutputPixelFormats);
+  _aidl_ret_status = _aidl_parcel->readInt64(&maxBitrateInBps);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
   _aidl_parcel->setDataPosition(_aidl_start_pos + _aidl_parcelable_size);
   return _aidl_ret_status;
 }
-::android::status_t CodecCapabilities::writeToParcel(::android::Parcel* _aidl_parcel) const {
+::android::status_t Profile::writeToParcel(::android::Parcel* _aidl_parcel) const {
   ::android::status_t _aidl_ret_status = ::android::OK;
   auto _aidl_start_pos = _aidl_parcel->dataPosition();
   _aidl_parcel->writeInt32(0);
-  _aidl_ret_status = _aidl_parcel->writeInt32(static_cast<int32_t>(codec));
+  _aidl_ret_status = _aidl_parcel->writeInt32(static_cast<int32_t>(profile));
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->writeParcelableVector(profiles);
+  _aidl_ret_status = _aidl_parcel->writeInt32(static_cast<int32_t>(maxLevel));
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }
-  _aidl_ret_status = _aidl_parcel->writeInt32(maxFrameRate);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->writeInt32(maxFrameWidth);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->writeInt32(maxFrameHeight);
-  if (((_aidl_ret_status) != (::android::OK))) {
-    return _aidl_ret_status;
-  }
-  _aidl_ret_status = _aidl_parcel->writeEnumVector(supportedOutputPixelFormats);
+  _aidl_ret_status = _aidl_parcel->writeInt64(maxBitrateInBps);
   if (((_aidl_ret_status) != (::android::OK))) {
     return _aidl_ret_status;
   }


### PR DESCRIPTION
Aligns \`CodecCapabilities\` with the per-codec multi-profile shape the HFP YAML and the [hpk-reference](https://github.com/rdkcentral/rdk-hpk-documentation/blob/main/hfp-reference/videodecoder/hfp-videodecoder.yaml) describe.

**Closes #528** (the AIDL change), **#520** (the simpler incremental HFP fix — superseded), and **#171** (the original HFP gap that surfaced this).

## Why

Old \`CodecCapabilities\` modelled a single \`profile\` + \`level\` per codec — couldn't express the common case where hardware supports several profiles per codec at the same level (H.265 supporting MAIN, MAIN_10, MAIN_10_HDR10 each at LEVEL_5_2), and had no bitrate ceiling at all.

## New shape

New [\`Profile.aidl\`](videodecoder/current/com/rdk/hal/videodecoder/Profile.aidl) parcelable carries one profile's capability tuple:

\`\`\`aidl
parcelable Profile {
    CodecProfile profile;
    CodecLevel   maxLevel;
    long         maxBitrateInBps;
}
\`\`\`

[\`CodecCapabilities.aidl\`](videodecoder/current/com/rdk/hal/videodecoder/CodecCapabilities.aidl) replaces the single \`profile\` + \`level\` fields with a \`Profile[]\` array:

\`\`\`aidl
parcelable CodecCapabilities {
    Codec         codec;
    Profile[]     profiles;
    int           maxFrameRate;
    int           maxFrameWidth;
    int           maxFrameHeight;
    PixelFormat[] supportedOutputPixelFormats;
}
\`\`\`

### Semantics

- \`profiles[]\` **enumerates exactly** which profiles are supported — no implicit "lower profiles also supported" rule.
- Within each \`Profile\` entry, \`maxLevel\` is **inclusive** — all lower levels for the same profile are implicitly supported.
- \`maxBitrateInBps\` is an inclusive ceiling for that profile.

## HFP YAML restructured

[\`videodecoder/current/hfp-videodecoder.yaml\`](videodecoder/current/hfp-videodecoder.yaml) rewritten so each codec carries a \`profiles:\` array matching the AIDL parcelable field-for-field. Reference values aligned with hpk-reference:

| Codec | High-tier resource | Secondary HD resource |
|---|---|---|
| MPEG | MPEG2_MAIN @ MAIN, 15 Mbps | same |
| H.264 | BASELINE / MAIN / HIGH each @ L4.1, 50 Mbps | same |
| H.265 | MAIN / MAIN_10 / MAIN_10_HDR10 each @ L5.2, 150 Mbps | MAIN / MAIN_10 each @ L4.1, 50 Mbps |
| VP9 | PROFILE_0 / PROFILE_2 each @ L5.1, 150 Mbps | PROFILE_0 @ L4.1, 50 Mbps |
| AV1 | AV1_MAIN @ L5.1, 150 Mbps | AV1_MAIN @ L4.1, 50 Mbps |

SoC vendors override per platform.

## Versioning

\`videodecoder/metadata.yaml\`: \`0.2.0.0\` → \`0.3.0.0\` (generation; breaking — field rename + structural change in CodecCapabilities).

## Verification

Build clean on \`videodecoder\` + downstream consumers (\`videosink\`, \`planecontrol\`, \`panel\`, \`avbuffer\`). HFP YAML parses as valid YAML.