### PR TITLE
feat(sensor)!: add MotionEvent parcelable carrying monotonic timestamp (#393)

### DIFF
--- a/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorEventListener.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/IMotionSensorEventListener.aidl
@@ -23,13 +23,16 @@
  */
 package com.rdk.hal.sensor.motion;
 
-import com.rdk.hal.sensor.motion.OperationalMode;
+import com.rdk.hal.sensor.motion.MotionEvent;
 
 @VintfStability
 oneway interface IMotionSensorEventListener {
     /**
      * @brief Invoked when the sensor detects an event that matches the active operational mode.
-     * @param mode The active mode whose condition was met (MOTION or NO_MOTION).
+     * @param event Event payload carrying the active mode and a monotonic
+     *              timestamp for ordering and correlation with other
+     *              system events (thermal, deep sleep, etc.).
+     * @see MotionEvent
      */
-    void onEvent(in OperationalMode mode);
+    void onEvent(in MotionEvent event);
 }

--- a/sensor/current/com/rdk/hal/sensor/motion/MotionEvent.aidl
+++ b/sensor/current/com/rdk/hal/sensor/motion/MotionEvent.aidl
@@ -1,0 +1,55 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file MotionEvent.aidl
+ * @brief Event payload delivered to motion sensor event listeners.
+ */
+package com.rdk.hal.sensor.motion;
+
+import com.rdk.hal.sensor.motion.OperationalMode;
+
+/**
+ * @brief Event payload delivered to motion sensor event listeners.
+ *
+ * @details
+ * Provides context for a motion-state change event:
+ *  - The active operational mode whose condition was met
+ *  - A monotonic timestamp for event ordering and correlation with
+ *    other system events (thermal, deep sleep, etc.)
+ *
+ * Mirrors the shape of `ActionEvent` on the thermal sensor side so
+ * downstream listeners that consume both sensors get a consistent
+ * payload contract.
+ */
+@VintfStability
+parcelable MotionEvent {
+    /**
+     * @brief The active mode whose condition was met (MOTION or NO_MOTION).
+     */
+    OperationalMode mode;
+
+    /**
+     * @brief Monotonic timestamp (ms) when the event occurred.
+     * @details Use monotonic time for event ordering; not wall-clock time.
+     *          Sourced from `CLOCK_MONOTONIC` (or equivalent) at the
+     *          point the vendor layer detects the state change.
+     */
+    long timestampMonotonicMs;
+}

--- a/sensor/metadata.yaml
+++ b/sensor/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: sensor
-version: 0.1.0.0
+version: 0.2.0.0
 status: GREEN
 description: "Hardware sensor data acquisition and monitoring"
 type: OEM


### PR DESCRIPTION
## Summary

Adds a monotonic timestamp to the motion sensor event payload, aligning with the thermal sensor's `ActionEvent` pattern.

## Changes

1. **New parcelable** `sensor/current/com/rdk/hal/sensor/motion/MotionEvent.aidl`:

   ```aidl
   @VintfStability
   parcelable MotionEvent {
       OperationalMode mode;
       long timestampMonotonicMs;
   }
   ```

2. **Updated listener signature** in `IMotionSensorEventListener.aidl`:

   ```aidl
   void onEvent(in MotionEvent event);   // was: void onEvent(in OperationalMode mode);
   ```

3. **Version bump** `sensor/metadata.yaml`: `0.1.0.0` → `0.2.0.0` (generation — breaking).

## Why

- Event ordering when multiple listeners process asynchronously
- Correlating motion events with other system events (thermal, deep sleep, etc.)
- Diagnostics / telemetry that rely on event timing
- Consistency with thermal sensor's `ActionEvent` (which already carries `timestampMonotonicMs`)

## Breaking change scope

Existing `IMotionSensorEventListener` implementations must update their `onEvent()` to take `MotionEvent` instead of `OperationalMode`. Access the mode via `event.mode` and the timestamp via `event.timestampMonotonicMs`.

## Build verification

`./build_modules.sh all --clean` → **exit 0**, 21/21 `lib*-vcurrent-cpp.so` built.

Closes #393.