### PR TITLE
docs(avbuffer): clarify pool lifecycle, reuse pattern, vendor implementation boundary (#372)

### DIFF
--- a/avbuffer/current/com/rdk/hal/avbuffer/IAVBuffer.aidl
+++ b/avbuffer/current/com/rdk/hal/avbuffer/IAVBuffer.aidl
@@ -59,9 +59,24 @@ interface IAVBuffer
 
     /**
      * Creates a video memory buffer pool of a secure or non-secure type from which allocations can be made.
-     * 
+     *
+     * @note Pools are intended to be **long-lived**: create once per pipeline
+     *       session (e.g. at decoder open), reuse the returned `Pool` handle
+     *       for all `alloc()` / `free()` calls during that session, and call
+     *       `destroyPool()` once at teardown. Calling `createVideoPool()` per
+     *       decode operation is incorrect — see `HAL.AVBUF.10`.
+     * @note The pool size is determined by the vendor implementation from the
+     *       `videoDecoderId` — the API takes no size parameter and exposes no
+     *       method to query the pool's capacity. Pool sizing, handle assignment,
+     *       and internal memory management are vendor-specific behind the binder.
+     * @note The returned `Pool` handle is an opaque token. Callers MUST NOT
+     *       interpret or derive meaning from its value; comparison is limited
+     *       to **equality only**. The vendor MAY reassign a destroyed handle's
+     *       numeric value to a new pool, so callers MUST drop destroyed
+     *       handles immediately.
+     *
      * If the `videoDecoderId` is invalid then the `binder::Status EX_ILLEGAL_ARGUMENT` exception status is returned.
-     * 
+     *
      * If the platform has exhausted all available memory from the requested heap then the exception status
      * `binder::Status::Exception::EX_SERVICE_SPECIFIC` is returned (out-of-memory).
      *
@@ -72,7 +87,7 @@ interface IAVBuffer
      * @param[in] videoDecoderId        The id of the video decoder resource.
      * @param[in] listener              Listener for space available callbacks.
      *
-     * @returns A new `Pool` object with a valid handle.
+     * @returns A new `Pool` object with a valid handle, intended for the full lifetime of the pipeline session.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT  if videoDecoderId is invalid
@@ -86,14 +101,29 @@ interface IAVBuffer
     Pool createVideoPool(in boolean secureHeap, in IVideoDecoder.Id videoDecoderId, in IAVBufferSpaceListener listener);
 
     /**
-     * Creates a audio memory buffer pool of a secure or non-secure type from which allocations can be made.
-     * 
-     * If the audio pool is for audio data not destinated for a vendor audio decoder
+     * Creates an audio memory buffer pool of a secure or non-secure type from which allocations can be made.
+     *
+     * @note Pools are intended to be **long-lived**: create once per pipeline
+     *       session (e.g. at decoder open), reuse the returned `Pool` handle
+     *       for all `alloc()` / `free()` calls during that session, and call
+     *       `destroyPool()` once at teardown. Calling `createAudioPool()` per
+     *       decode operation is incorrect — see `HAL.AVBUF.10`.
+     * @note The pool size is determined by the vendor implementation from the
+     *       `audioDecoderId` — the API takes no size parameter and exposes no
+     *       method to query the pool's capacity. Pool sizing, handle assignment,
+     *       and internal memory management are vendor-specific behind the binder.
+     * @note The returned `Pool` handle is an opaque token. Callers MUST NOT
+     *       interpret or derive meaning from its value; comparison is limited
+     *       to **equality only**. The vendor MAY reassign a destroyed handle's
+     *       numeric value to a new pool, so callers MUST drop destroyed
+     *       handles immediately.
+     *
+     * If the audio pool is for audio data not destined for a vendor audio decoder
      * (e.g. system audio PCM) then the ID must be IAudioDecoder.Id.UNDEFINED.
-     * 
+     *
      * If the platform has exhausted all available memory from the requested heap then the exception status
      * `binder::Status::Exception::EX_SERVICE_SPECIFIC` is returned (out-of-memory).
-     * 
+     *
      * If a `secureHeap` is created and the audio decoder has not been configured then the exception status
      * `binder::Status::Exception::EX_ILLEGAL_STATE` is returned.
      *
@@ -103,7 +133,7 @@ interface IAVBuffer
      * @param[in] audioDecoderId        The ID of the audio decoder resource.
      * @param[in] listener              Listener for space available callbacks.
      *
-     * @returns A new `Pool` object with a valid handle.
+     * @returns A new `Pool` object with a valid handle, intended for the full lifetime of the pipeline session.
      *
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if audioDecoderId is invalid

--- a/avbuffer/current/docs/av_buffer.md
+++ b/avbuffer/current/docs/av_buffer.md
@@ -42,6 +42,7 @@ The **AV Buffer HAL** manages both secure and non-secure memory heaps and pools 
 |**HAL.AVBUF.7**|Memory buffers allocated from a secure memory pool cannot be mapped into the address space of unprivileged processes and must meet secure video path or secure audio path requirements.| Only vendor layer trusted entities can access secure memory (e.g. TA or secure hardware peripheral).|
 |**HAL.AVBUF.8**|The size of the heaps and pools shall be determined by the vendor to meet the platform and product requirements for audio and video.|
 |**HAL.AVBUF.9**|A helper library shall be provided to allow middleware processes to map and unmap non-secure buffers, and copy data to secure and non-secure buffers.|
+|**HAL.AVBUF.10**|Clients shall create a memory pool **once per pipeline session** via `createAudioPool()` or `createVideoPool()` and **reuse the returned pool handle** for all `alloc()` / `free()` calls during that session. Calling `createAudioPool()` / `createVideoPool()` per decode operation is incorrect — pools are long-lived; allocations within a pool are short-lived.|
 
 ## Interface Definition
 
@@ -112,7 +113,31 @@ A memory pool is created by a client to make buffer allocations from either the 
 
 The size of the memory pool is determined by the vendor layer implementation when the client passes a video or audio resource ID in to `createVideoPool()` or `createAudioPool()`.
 
-Once a pool is created it is referenced by an Pool handle. When the client has finished with a pool it calls destroyPool() with the Pool handle.
+Once a pool is created it is referenced by a Pool handle. When the client has finished with the pool it calls `destroyPool()` with the Pool handle.
+
+**Pools are long-lived; allocations are short-lived.** A pool is created **once per pipeline session** (e.g. at decoder open) and reused for all `alloc()` / `free()` calls during that session. Calling `createAudioPool()` / `createVideoPool()` per decode operation is incorrect — it defeats the vendor's pool-internal memory management and may exhaust the heap. The intended pattern is:
+
+```
+createVideoPool(videoDecoderId)            // once at pipeline setup
+  → alloc / free / alloc / free / ...      // many times during the session
+  → ...                                    // for the lifetime of the decoder
+destroyPool(poolHandle)                    // once at pipeline teardown
+```
+
+This matches the sequence shown in the [Media Pipeline Example](#media-pipeline-example) below.
+
+### Vendor Implementation Boundary
+
+The AV Buffer HAL is intentionally narrow. The API contract covers only **create / destroy / alloc / free / metrics**. Everything else — pool sizing, handle assignment, internal memory layout, allocation strategy — is **vendor-specific implementation detail** behind the binder.
+
+The architectural principles:
+
+- **Handles are opaque tokens.** Middleware MUST NOT interpret or derive meaning from Pool handle values; comparison is limited to **equality only**. A handle is valid from `createAudioPool()` / `createVideoPool()` until the matching `destroyPool()` returns; after that, the handle no longer refers to that pool. The vendor MAY subsequently reassign the same numeric handle value to a different pool (see `### Pool Handles` below for wrap/reuse rules), so middleware MUST drop destroyed handles immediately.
+- **Pool sizing is the vendor's decision.** `createAudioPool()` / `createVideoPool()` take a decoder ID — not a size — because the vendor decides how much memory each decoder's pool needs based on its hardware constraints, codec capabilities, and product configuration. The API intentionally provides no size parameter and no method to query a pool's capacity.
+- **Internal memory management is the vendor's responsibility.** Pool fragmentation, allocation ordering, recycling, alignment, contiguity — all decided by the vendor's implementation. Middleware sees only `alloc()` returning a buffer handle, `free()` releasing it, and `getPoolMetrics()` reporting aggregate usage.
+- **Handle management is the middleware's responsibility.** The middleware creates a pool, holds the handle for the session, hands buffer handles around between its components as needed, and destroys the pool at teardown. There is no "get the existing pool for decoder ID X" API because pool-handle ownership is the middleware's bookkeeping, not the vendor's.
+
+This split keeps the API stable across vendor implementations while leaving each vendor maximum freedom to optimize memory behaviour for their hardware.
 
 ### Pool Handles
 

--- a/avbuffer/metadata.yaml
+++ b/avbuffer/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avbuffer
-version: 0.1.0.0
+version: 0.1.0.1
 status: GREEN
 description: "AV buffer allocation and secure video path management"
 type: SOC


### PR DESCRIPTION
## Summary

Resolves the documentation gaps flagged in #371 / #372 around AVBuffer pool lifecycle and the vendor implementation boundary. Doc-only (no AIDL signature changes); `metadata.yaml` patch bump.

## Changes

### `avbuffer/current/docs/av_buffer.md`

1. **Pool Lifecycle** — explicitly states pools are long-lived (one per pipeline session), allocations are short-lived. Includes the intended create/alloc/free/destroy sequence and links to the existing Media Pipeline Example.
2. **New Vendor Implementation Boundary section** — captures the four architectural principles:
   - Handles are opaque tokens (middleware must not interpret values)
   - Pool sizing is the vendor's decision (no size param, no capacity query)
   - Internal memory management is the vendor's responsibility (fragmentation, ordering, alignment)
   - Pool-handle management is the middleware's responsibility (no "get-existing-pool" API)
3. **New requirement `HAL.AVBUF.10`** — mandates per-session pool reuse: "Clients shall create a memory pool once per pipeline session... and reuse the returned pool handle for all alloc() / free() calls during that session."

### `avbuffer/current/com/rdk/hal/avbuffer/IAVBuffer.aidl`

`@note` blocks added to `createVideoPool()` and `createAudioPool()` covering long-lived intent, vendor-determined sizing, and handle opacity. Cross-references `HAL.AVBUF.10`. `@returns` text now notes the pool is intended for the full pipeline-session lifetime.

### Version

`avbuffer/metadata.yaml`: `0.1.0.0` → `0.1.0.1` (patch — documentation only).

## Why

From #371: a reader of `createAudioPool()` / `createVideoPool()` API docs alone could miss that pools are intended to be reused. The Media Pipeline Example shows the correct pattern, but it's not connected to the API doc. This change makes the intended pattern explicit in three places — the doc section, the API doc-comment, and a versioned requirement — so the contract is discoverable from any entry point.

## Build verification

`./build_modules.sh all --clean` → **exit 0**, 21/21 `lib*-vcurrent-cpp.so` built.

Closes #372.