### PR TITLE
feat(build): pre-flight checks at script entry — catch broken toolchain env with actionable error (#571)

### DIFF
--- a/build_interfaces.sh
+++ b/build_interfaces.sh
@@ -120,6 +120,38 @@ EOF
     exit 0
 fi
 
+#######################################################################
+# Pre-flight checks (#571)
+#######################################################################
+#
+# Same purpose as in build_modules.sh: surface broken-env failures as
+# a single actionable line rather than cryptic CMake / Python output
+# deep in the run. Skipped for clean / sdk-only commands which must
+# work in any state.
+
+preflight_check_interfaces() {
+    # Toolchain artefacts present. Honour BINDER_TOOLCHAIN_ROOT /
+    # BINDER_SOURCE_DIR overrides used by Yocto and cross-compile
+    # flows. The 'sdk' / 'sdk-only' commands stage the toolchain
+    # itself and bypass this check via the case statement below.
+    local toolchain_root="${BINDER_TOOLCHAIN_ROOT:-${BINDER_SOURCE_DIR:-$SCRIPT_DIR/build-tools/linux_binder_idl}}"
+    if [[ ! -f "$toolchain_root/host/aidl_ops.py" ]]; then
+        echo "❌ AIDL toolchain not found at $toolchain_root/host/aidl_ops.py." >&2
+        echo "   Fix: run ./build_interfaces.sh sdk to stage the toolchain," >&2
+        echo "        ./build_binder.sh to bootstrap, symlink build-tools/" >&2
+        echo "        from a known-good worktree, or set BINDER_TOOLCHAIN_ROOT" >&2
+        echo "        (or BINDER_SOURCE_DIR) to the toolchain location." >&2
+        exit 1
+    fi
+}
+
+# Run pre-flight unless the user asked for a clean/sdk command — those
+# must work in any environment state.
+case "${1:-}" in
+    clean|cleanstable|cleanall|sdk|sdk-only|--help|-h|"") : ;;  # skip preflight
+    *) preflight_check_interfaces ;;
+esac
+
 # Handle commands
 case "${1:-}" in
     sdk|sdk-only)

--- a/build_modules.sh
+++ b/build_modules.sh
@@ -146,6 +146,82 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 
 #######################################################################
+# Pre-flight checks (#571)
+#######################################################################
+#
+# Surface broken-environment failures as a single actionable error line
+# instead of cryptic CMake output deep in the run. Each check exits
+# non-zero with a remediation hint pointing at the actual fix.
+#
+# Skipped for clean / cleanall / help — those should work in any state.
+
+preflight_check() {
+    # Toolchain artefacts present. Honour BINDER_TOOLCHAIN_ROOT /
+    # BINDER_SOURCE_DIR / BINDER_SDK_DIR overrides used by Yocto and
+    # cross-compile flows (a non-default toolchain location is a
+    # legitimate state and shouldn't fail the local-tree check).
+    local toolchain_root="${BINDER_TOOLCHAIN_ROOT:-${BINDER_SOURCE_DIR:-$ROOT_DIR/build-tools/linux_binder_idl}}"
+    if [[ ! -f "$toolchain_root/host/aidl_ops.py" ]]; then
+        echo "❌ AIDL toolchain not found at $toolchain_root/host/aidl_ops.py." >&2
+        echo "   Fix: run ./build_binder.sh to bootstrap, symlink build-tools/" >&2
+        echo "        from a known-good worktree, or set BINDER_TOOLCHAIN_ROOT" >&2
+        echo "        (or BINDER_SOURCE_DIR) to the toolchain location." >&2
+        exit 1
+    fi
+
+    # Binder SDK runtime present (Stage 1 must have completed).
+    # Honour --sdk-dir <path> flag, BINDER_SDK_DIR env var, or the
+    # default out/target/lib/binder location in order of preference.
+    local sdk_dir="${BINDER_SDK_DIR:-}"
+    # Scan args for --sdk-dir <path>
+    local -a args=("$@")
+    local i=0
+    while [[ $i -lt ${#args[@]} ]]; do
+        if [[ "${args[$i]}" == "--sdk-dir" ]] && [[ $((i+1)) -lt ${#args[@]} ]]; then
+            sdk_dir="${args[$((i+1))]}/lib/binder"
+            break
+        fi
+        i=$((i + 1))
+    done
+    if [[ -z "$sdk_dir" ]]; then
+        sdk_dir="$ROOT_DIR/out/target/lib/binder"
+    fi
+    if [[ ! -d "$sdk_dir" ]]; then
+        echo "❌ Binder SDK runtime not found at $sdk_dir." >&2
+        echo "   Fix: run ./build_interfaces.sh <module> (stages the SDK and" >&2
+        echo "        delegates here), or ./build_binder.sh to stage it directly." >&2
+        echo "        For cross-compile / Yocto, set BINDER_SDK_DIR to the staged path" >&2
+        echo "        or pass --sdk-dir <path>." >&2
+        exit 1
+    fi
+}
+
+# Snapshot-version builds (--version <released>) and toolchain-bootstrap
+# commands (clean / cleanall / sdk / sdk-only / help) bypass preflight —
+# they either don't touch the toolchain at all or are the very mechanism
+# that stages it.
+skip_preflight=0
+case "${1:-}" in
+    clean|cleanall|sdk|sdk-only|--help|-h|--h|"") skip_preflight=1 ;;
+esac
+# Also skip when caller pinned a released snapshot via --version <X>
+# (where X != "current"): the snapshot's own pre-generated bindings are
+# all that's needed; no toolchain regen happens.
+for ((j=1; j<=$#; j++)); do
+    if [[ "${!j}" == "--version" ]]; then
+        next=$((j+1))
+        if [[ $next -le $# ]] && [[ "${!next}" != "current" ]]; then
+            skip_preflight=1
+            break
+        fi
+    fi
+done
+
+if [[ "$skip_preflight" -eq 0 ]]; then
+    preflight_check "$@"
+fi
+
+#######################################################################
 # Parse Arguments
 #######################################################################
 


### PR DESCRIPTION
## Summary

Adds pre-flight validation at the start of `build_modules.sh` and `build_interfaces.sh` so broken-environment failures surface as a **single actionable error line** instead of cryptic CMake / Python output deep in the run.

Carved from the broader script-defensiveness work in #541 (which was re-scoped to 0.22.0 after #567 made the worst failure mode structurally impossible). This PR ships the highest-value / lowest-risk subset of the remaining benefits.

Closes #571.

## What it catches

### 1. Toolchain artefacts missing

Both scripts check for `build-tools/linux_binder_idl/host/aidl_ops.py`. If absent:

```
❌ AIDL toolchain not found at build-tools/linux_binder_idl/.
   Expected file: build-tools/linux_binder_idl/host/aidl_ops.py
   Fix: run ./build_binder.sh to bootstrap, or symlink build-tools/
        from a known-good worktree.
```

Exits non-zero, ≤ 1 second.

### 2. Binder SDK runtime missing (build_modules.sh only)

`build_modules.sh` is Stage 3 (compilation only) — it requires the SDK already staged. If `out/target/lib/binder/` is absent AND `BINDER_SDK_DIR` is unset:

```
❌ Binder SDK runtime not found at out/target/lib/binder/.
   Fix: run ./build_interfaces.sh <module> (stages the Binder SDK and
        delegates here), or ./build_binder.sh to stage it directly.
        For cross-compile / Yocto, set BINDER_SDK_DIR to the staged path.
```

Skipped when `BINDER_SDK_DIR` is set (Yocto / cross-compile pattern — the SDK lives elsewhere).

## What's skipped (must work in any state)

The preflight is bypassed for commands that need to work without the toolchain present:

- `clean` / `cleanall` / `cleanstable` — cleanup commands
- `sdk` / `sdk-only` (build_interfaces.sh) — the command that *stages* the toolchain
- `--help` / `-h` / no args — help

The bypass list is explicit at the preflight invocation point — no implicit guessing.

## Verification

- `bash -n` passes on both scripts
- `--help` works unchanged in both
- `clean` bypasses preflight (verified by moving `aidl_ops.py` aside and running `./build_modules.sh clean`)
- **Broken env test:** with `aidl_ops.py` moved aside, both scripts exit ≤ 1s with the actionable error line and exit code 1
- **Healthy env test:** `./tests/smoke_test.sh` → **5/5 PASS** (build, source-only invariant, manifest released, manifest current, per-version snapshot)
- **First-build-from-scratch test (validates the SDK check works):** after `rm -rf out/`, `./build_modules.sh all` correctly blocks with the SDK-missing message; after `./build_interfaces.sh sdk`, the full smoke run passes

## Latency in healthy env

Two `stat()` calls per script invocation before the existing argument-parsing block. No measurable difference.

## Why this lands now (not deferred to 0.22.0)

Small, defensive, no risk to existing flows — and 0.21.0 release-time activity will go faster with friendlier errors when team members hit a stale build env.

## Related

- #541 — broader script-defensiveness work, re-scoped to 0.22.0 (atomic-write rework + summary-line overhaul)
- #566 / #567 — eliminated the "git captures empty state" failure mode that originally motivated #541