### PR TITLE
refactor(audiomixer): move getDolbyMs12_2_6_Dap() to IAudioOutputPortController per #591 (#593)

### DIFF
--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
@@ -23,7 +23,6 @@ import com.rdk.hal.audiomixer.IAudioCaptureListener;
 import com.rdk.hal.audiomixer.IAudioOutputPortController;
 import com.rdk.hal.audiomixer.IAudioOutputPortControllerListener;
 import com.rdk.hal.audiomixer.IAudioOutputPortListener;
-import com.rdk.hal.audiomixer.IDolbyMs12_2_6_Dap;
 import com.rdk.hal.audiomixer.OutputPortCapabilities;
 import com.rdk.hal.audiomixer.OutputPortProperty;
 import com.rdk.hal.audiomixer.State;
@@ -47,12 +46,16 @@ import com.rdk.hal.PropertyValue;
  *           state. Property writes are gated on holding the controller — see
  *           IAudioOutputPortController.setProperty().
  *
- *           In addition to property reads/writes, ports expose two factory
- *           methods to obtain feature-specific sub-interfaces:
- *             - getDolbyMs12_2_6_Dap() for MS12 2.6 DAP runtime control on
- *               ports advertising DOLBY_MS12_2_6 in supportedAQProcessors.
+ *           In addition to property reads/writes, ports expose a factory
+ *           method to obtain a feature-specific sub-interface:
  *             - getAudioCapture(listener) for shared-memory ring-buffer
  *               capture on ports advertising supportsAudioCapture = true.
+ *
+ *           Dolby MS12 v2.6 DAP runtime control is exposed via the port
+ *           controller, not the read-side handle — see
+ *           IAudioOutputPortController.getDolbyMs12_2_6_Dap(). This
+ *           gates DAP writes on the same exclusive-ownership boundary
+ *           used for property writes.
  */
 @VintfStability
 interface IAudioOutputPort {
@@ -178,19 +181,6 @@ interface IAudioOutputPort {
      * @see registerEventListener()
      */
     boolean unregisterEventListener(in IAudioOutputPortListener audioOutputPortEventListener);
-
-    /**
-     * @brief Creates a Dolby MS12 2.6 DAP command interface for this port.
-     * 
-     * If DOLBY_MS12_2_6 is reported as a supported AQProcessor in supportedAQProcessors then this function will return an interface to allow its control.
-     *
-     * @returns IDolbyMs12_2_6_Dap interface
-     * @exception binder::Status EX_UNSUPPORTED_OPERATION if Dolby MS12 v2.6 DAP is not supported.
-     *
-     * @see com.rdk.hal.audiomixer.OutputPortCapabilities.supportedAQProcessors
-     */
-    IDolbyMs12_2_6_Dap getDolbyMs12_2_6_Dap();
-
 
     /**
      * @brief Creates an audio capture interface for this port.

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
@@ -18,8 +18,6 @@
  */
 package com.rdk.hal.audiomixer;
 
-import com.rdk.hal.audiomixer.IAudioCapture;
-import com.rdk.hal.audiomixer.IAudioCaptureListener;
 import com.rdk.hal.audiomixer.IAudioOutputPortController;
 import com.rdk.hal.audiomixer.IAudioOutputPortControllerListener;
 import com.rdk.hal.audiomixer.IAudioOutputPortListener;
@@ -46,16 +44,12 @@ import com.rdk.hal.PropertyValue;
  *           state. Property writes are gated on holding the controller — see
  *           IAudioOutputPortController.setProperty().
  *
- *           In addition to property reads/writes, ports expose a factory
- *           method to obtain a feature-specific sub-interface:
- *             - getAudioCapture(listener) for shared-memory ring-buffer
- *               capture on ports advertising supportsAudioCapture = true.
- *
- *           Dolby MS12 v2.6 DAP runtime control is exposed via the port
- *           controller, not the read-side handle — see
- *           IAudioOutputPortController.getDolbyMs12_2_6_Dap(). This
- *           gates DAP writes on the same exclusive-ownership boundary
- *           used for property writes.
+ *           DAP and audio capture are exposed only via the port
+ *           controller (not the read-side handle): see
+ *           IAudioOutputPortController.getDolbyMs12_2_6_Dap() and
+ *           IAudioOutputPortController.getAudioCapture(). Write-capable
+ *           sub-interface acquisition is gated on the same exclusive-
+ *           ownership boundary used for property writes.
  */
 @VintfStability
 interface IAudioOutputPort {
@@ -182,18 +176,4 @@ interface IAudioOutputPort {
      */
     boolean unregisterEventListener(in IAudioOutputPortListener audioOutputPortEventListener);
 
-    /**
-     * @brief Creates an audio capture interface for this port.
-     * 
-     * @param[in] audioCaptureListener a Listener for capture callbacks.
-     * 
-     * If supportsAudioCapture is true then this function will return an interface to allow its control.
-     *
-     * @returns IAudioCapture interface
-     * @exception binder::Status EX_UNSUPPORTED_OPERATION if audio capture from this port is not supported.
-     * @exception binder::Status EX_NULL_POINTER if audioCaptureListener is null.
-     *
-     * @see com.rdk.hal.audiomixer.OutputPortCapabilities.supportsAudioCapture
-     */
-    IAudioCapture getAudioCapture(in IAudioCaptureListener audioCaptureListener );
 }

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
@@ -76,9 +76,11 @@ interface IAudioOutputPortController {
      *           for this port.
      *
      *           Acquiring the DAP interface requires holding this
-     *           IAudioOutputPortController. The exclusive-write boundary on
-     *           the port controller serves as the ownership boundary for DAP
-     *           writes too — no separate DAP-level open()/close() is needed.
+     *           IAudioOutputPortController. Because the interface itself
+     *           is acquired here, the port controller's ownership boundary
+     *           gates all DAP access — reads as well as writes — for the
+     *           lifetime of the controller. No separate DAP-level
+     *           open()/close() is needed.
      *
      *           Supported when the port's IAQProcessor reports
      *           AQProcessor.DOLBY_MS12_2_6 via getProcessorType().
@@ -97,13 +99,14 @@ interface IAudioOutputPortController {
      * @brief    Creates an audio capture interface for the controlled port.
      *
      *           Acquiring the audio capture interface requires holding this
-     *           IAudioOutputPortController. The exclusive-write boundary on
-     *           the port controller serves as the ownership boundary for
-     *           capture too — only the controller owner can capture from
-     *           this port.
+     *           IAudioOutputPortController. Capture acquisition is gated
+     *           by holding the port controller — the read-side
+     *           IAudioOutputPort handle does not expose getAudioCapture(),
+     *           so only the controller owner can capture from this port.
      *
      *           Supported when OutputPortCapabilities.supportsAudioCapture
-     *           is true for this port.
+     *           is true for this port (note: that field's own docblock
+     *           also references this controller-acquired path).
      *
      * @param[in] audioCaptureListener  Listener for capture callbacks.
      *

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
@@ -18,6 +18,8 @@
  */
 package com.rdk.hal.audiomixer;
 
+import com.rdk.hal.audiomixer.IAudioCapture;
+import com.rdk.hal.audiomixer.IAudioCaptureListener;
 import com.rdk.hal.audiomixer.IDolbyMs12_2_6_Dap;
 import com.rdk.hal.audiomixer.OutputPortProperty;
 import com.rdk.hal.PropertyValue;
@@ -28,8 +30,9 @@ import com.rdk.hal.PropertyValue;
  *           Exclusive write controller returned by IAudioOutputPort.open().
  *           Hosts mutating operations on the output port (property writes for
  *           volume, mute, output format, transcode format, AQ processor, etc.)
- *           and factory methods for write-capable sub-interfaces such as the
- *           Dolby MS12 v2.6 DAP runtime command surface.
+ *           and factory methods for write-capable sub-interfaces — the
+ *           Dolby MS12 v2.6 DAP runtime command surface and the audio
+ *           capture interface.
  *
  *           Only one client may hold the controller at a time. If the holding
  *           client crashes, the HAL detects the binder death and releases
@@ -89,4 +92,30 @@ interface IAudioOutputPortController {
      * @see IAQProcessor.getProcessorType()
      */
     IDolbyMs12_2_6_Dap getDolbyMs12_2_6_Dap();
+
+    /**
+     * @brief    Creates an audio capture interface for the controlled port.
+     *
+     *           Acquiring the audio capture interface requires holding this
+     *           IAudioOutputPortController. The exclusive-write boundary on
+     *           the port controller serves as the ownership boundary for
+     *           capture too — only the controller owner can capture from
+     *           this port.
+     *
+     *           Supported when OutputPortCapabilities.supportsAudioCapture
+     *           is true for this port.
+     *
+     * @param[in] audioCaptureListener  Listener for capture callbacks.
+     *
+     * @returns  IAudioCapture interface for the controlled port.
+     *
+     * @exception binder::Status EX_UNSUPPORTED_OPERATION if audio capture
+     *            from this port is not supported.
+     * @exception binder::Status EX_NULL_POINTER if @c audioCaptureListener
+     *            is null.
+     *
+     * @see IAudioOutputPort.open()
+     * @see com.rdk.hal.audiomixer.OutputPortCapabilities.supportsAudioCapture
+     */
+    IAudioCapture getAudioCapture(in IAudioCaptureListener audioCaptureListener);
 }

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
@@ -18,14 +18,18 @@
  */
 package com.rdk.hal.audiomixer;
 
+import com.rdk.hal.audiomixer.IDolbyMs12_2_6_Dap;
 import com.rdk.hal.audiomixer.OutputPortProperty;
 import com.rdk.hal.PropertyValue;
 
 /**
  * @brief    Audio Output Port Controller HAL interface.
- * @details  Exclusive write controller returned by IAudioOutputPort.open().
+ *
+ *           Exclusive write controller returned by IAudioOutputPort.open().
  *           Hosts mutating operations on the output port (property writes for
- *           volume, mute, output format, transcode format, AQ processor, etc.).
+ *           volume, mute, output format, transcode format, AQ processor, etc.)
+ *           and factory methods for write-capable sub-interfaces such as the
+ *           Dolby MS12 v2.6 DAP runtime command surface.
  *
  *           Only one client may hold the controller at a time. If the holding
  *           client crashes, the HAL detects the binder death and releases
@@ -53,7 +57,7 @@ interface IAudioOutputPortController {
      * @param[in] value     Property value; union field must match the property type.
      *
      * @returns  true on successful write, false if the property is not supported
-     *           by this port or the value is rejected.
+     *            by this port or the value is rejected.
      *
      * @exception binder::Status EX_ILLEGAL_ARGUMENT if property is unknown or
      *            value type does not match.
@@ -63,4 +67,26 @@ interface IAudioOutputPortController {
      * @see IAudioOutputPort.getProperty()
      */
     boolean setProperty(in OutputPortProperty property, in PropertyValue value);
+
+    /**
+     * @brief    Returns the Dolby MS12 v2.6 DAP runtime command interface
+     *           for this port.
+     *
+     *           Acquiring the DAP interface requires holding this
+     *           IAudioOutputPortController. The exclusive-write boundary on
+     *           the port controller serves as the ownership boundary for DAP
+     *           writes too — no separate DAP-level open()/close() is needed.
+     *
+     *           Supported when the port's IAQProcessor reports
+     *           AQProcessor.DOLBY_MS12_2_6 via getProcessorType().
+     *
+     * @returns  IDolbyMs12_2_6_Dap runtime command interface.
+     *
+     * @exception binder::Status EX_UNSUPPORTED_OPERATION if Dolby MS12 v2.6
+     *            DAP is not supported on this port.
+     *
+     * @see IAudioOutputPort.open()
+     * @see IAQProcessor.getProcessorType()
+     */
+    IDolbyMs12_2_6_Dap getDolbyMs12_2_6_Dap();
 }

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPortController.aidl
@@ -57,7 +57,7 @@ interface IAudioOutputPortController {
      * @param[in] value     Property value; union field must match the property type.
      *
      * @returns  true on successful write, false if the property is not supported
-     *            by this port or the value is rejected.
+     *           by this port or the value is rejected.
      *
      * @exception binder::Status EX_ILLEGAL_ARGUMENT if property is unknown or
      *            value type does not match.

--- a/audiomixer/current/com/rdk/hal/audiomixer/OutputPortCapabilities.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/OutputPortCapabilities.aidl
@@ -81,12 +81,20 @@ parcelable OutputPortCapabilities {
     @nullable String[] dolbyMs12AudioProfiles;
 
     /**
-     * Indicates whether this output port supports audio capture via getAudioCapture().
-     * If true, clients may call IAudioOutputPort.getAudioCapture(listener) to obtain
-     * an IAudioCapture interface for streaming audio from this port.
-     * If false, calling getAudioCapture() will throw binder::Status EX_UNSUPPORTED_OPERATION.
-     * 
-     * @see IAudioOutputPort.getAudioCapture()
+     * @brief   True when this port supports audio capture via
+     *          IAudioOutputPortController.getAudioCapture().
+     *
+     * @details If true, clients holding the port controller (acquired
+     *          via IAudioOutputPort.open()) may call
+     *          IAudioOutputPortController.getAudioCapture(listener) to
+     *          obtain an IAudioCapture interface for streaming audio
+     *          from this port. If false, calling @c getAudioCapture()
+     *          throws binder::Status EX_UNSUPPORTED_OPERATION. Capture
+     *          acquisition is gated by holding the port controller —
+     *          the read-side IAudioOutputPort handle does not expose
+     *          getAudioCapture().
+     *
+     * @see     IAudioOutputPortController.getAudioCapture()
      */
     boolean supportsAudioCapture;
 }

--- a/audiomixer/current/docs/audio_mixer.md
+++ b/audiomixer/current/docs/audio_mixer.md
@@ -173,7 +173,7 @@ flowchart TD
 * Mixer accepts input streams with declared `ContentType` and `Codec`.
 * Inputs are processed and mixed into one or more outputs.
 * Output formats can be negotiated and configured using `IAudioOutputPortController.setProperty(OUTPUT_FORMAT, ...)` (controller acquired via `IAudioOutputPort.open()`).
-* AQ processors are configured via typed sub-interfaces — for Dolby MS12 2.6 ports, `IAudioOutputPort.getDolbyMs12_2_6_Dap()` returns an `IDolbyMs12_2_6_Dap` for per-setting runtime control (bass enhancer, volume leveller, surround virtualizer, dialogue enhancer, EQ modes, DRC, Atmos lock, downmix, volume modeler, centre spreading, active downmix). Port-level MS12 audio profile selection is exposed via `OutputPortProperty.DOLBY_MS12_AUDIO_PROFILE` against the profiles enumerated in `OutputPortCapabilities.dolbyMs12AudioProfiles`.
+* For Dolby MS12 2.6 ports, `IAudioOutputPortController.getDolbyMs12_2_6_Dap()` returns the `IDolbyMs12_2_6_Dap` runtime command interface (bass enhancer, volume leveller, surround virtualizer, dialogue enhancer, EQ modes, DRC, Atmos lock, downmix, volume modeler, centre spreading, active downmix). DAP access requires holding the port controller — the same exclusive-ownership boundary used for property writes serves as the ownership boundary for DAP writes too. Port-level MS12 audio profile selection is exposed via `OutputPortProperty.DOLBY_MS12_AUDIO_PROFILE` against the profiles enumerated in `OutputPortCapabilities.dolbyMs12AudioProfiles`.
 * Where `OutputPortCapabilities.supportsAudioCapture` is true, capture is created from `IAudioOutputPort.getAudioCapture(listener)`.
 * Audio capture uses a shared-memory ring buffer returned by `getSharedMemory(out long[] sharedMemorySizeBytes)` (length-1 array carries the buffer size; AIDL primitives cannot be `out` parameters), with `releaseData()` acknowledgements after `onDataAvailable()` callbacks.
 * Output formats, including passthrough where supported, are dynamically switchable if capabilities permit.
@@ -437,7 +437,7 @@ Mixers can operate in secure and non-secure paths. Mixer properties such as `MIX
 
 ## Dolby MS12 Runtime Commands
 
-The `IDolbyMs12_2_6_Dap` interface exposes one method per MS12 IDK 2.6 runtime command and is created from `IAudioOutputPort.getDolbyMs12_2_6_Dap()`.
+The `IDolbyMs12_2_6_Dap` interface exposes one method per MS12 IDK 2.6 runtime command. It is obtained from `IAudioOutputPortController.getDolbyMs12_2_6_Dap()`, so DAP access is gated by holding the exclusive port controller acquired via `IAudioOutputPort.open()`. No separate DAP-level open()/close() is required — the port controller's ownership boundary covers DAP writes.
 
 Non-boolean argument constraints are declared per output port in `audiomixer/current/hfp-audiomixer.yaml` under `outputPorts[].supportedAQProcessors[].setFunctions`.
 

--- a/audiomixer/current/docs/audio_mixer.md
+++ b/audiomixer/current/docs/audio_mixer.md
@@ -431,7 +431,7 @@ For ports without hot-plug detection (`SPDIF`, `SPEAKERS`, `COMPOSITE`), the HFP
 
 ## Modes of Operation
 
-Mixers can operate in secure and non-secure paths. Mixer properties such as `MIXING_MODE`, `MUTE`, and `DEBUG_TAP_ENABLED` affect runtime behaviour via the controller property interface. Output-port properties such as `DOLBY_MS12_AUDIO_PROFILE` are configured via `IAudioOutputPort.setProperty()`.
+Mixers can operate in secure and non-secure paths. Mixer properties such as `MIXING_MODE`, `MUTE`, and `DEBUG_TAP_ENABLED` are written via `IAudioMixerController.setProperty()` (controller acquired via `IAudioMixer.open()`). Output-port properties such as `DOLBY_MS12_AUDIO_PROFILE` are written via `IAudioOutputPortController.setProperty()` (controller acquired via `IAudioOutputPort.open()`). Reads on both go through the read-side handle's `getProperty()`.
 
 ---
 

--- a/audiomixer/current/docs/audio_mixer.md
+++ b/audiomixer/current/docs/audio_mixer.md
@@ -173,7 +173,7 @@ flowchart TD
 * Mixer accepts input streams with declared `ContentType` and `Codec`.
 * Inputs are processed and mixed into one or more outputs.
 * Output formats can be negotiated and configured using `IAudioOutputPortController.setProperty(OUTPUT_FORMAT, ...)` (controller acquired via `IAudioOutputPort.open()`).
-* For Dolby MS12 2.6 ports, `IAudioOutputPortController.getDolbyMs12_2_6_Dap()` returns the `IDolbyMs12_2_6_Dap` runtime command interface (bass enhancer, volume leveller, surround virtualizer, dialogue enhancer, EQ modes, DRC, Atmos lock, downmix, volume modeler, centre spreading, active downmix). DAP access requires holding the port controller — the same exclusive-ownership boundary used for property writes serves as the ownership boundary for DAP writes too. Port-level MS12 audio profile selection is exposed via `OutputPortProperty.DOLBY_MS12_AUDIO_PROFILE` against the profiles enumerated in `OutputPortCapabilities.dolbyMs12AudioProfiles`.
+* For Dolby MS12 2.6 ports, `IAudioOutputPortController.getDolbyMs12_2_6_Dap()` returns the `IDolbyMs12_2_6_Dap` runtime command interface (bass enhancer, volume leveller, surround virtualizer, dialogue enhancer, EQ modes, DRC, Atmos lock, downmix, volume modeler, centre spreading, active downmix). Because the interface is acquired from the port controller, the port controller's ownership boundary gates all DAP access — reads as well as writes — for the lifetime of the controller. Port-level MS12 audio profile selection is exposed via `OutputPortProperty.DOLBY_MS12_AUDIO_PROFILE` against the profiles enumerated in `OutputPortCapabilities.dolbyMs12AudioProfiles`.
 * Where `OutputPortCapabilities.supportsAudioCapture` is true, capture is created from `IAudioOutputPortController.getAudioCapture(listener)` — like DAP runtime control, capture acquisition is gated by holding the port controller acquired via `IAudioOutputPort.open()`.
 * Audio capture uses a shared-memory ring buffer returned by `getSharedMemory(out long[] sharedMemorySizeBytes)` (length-1 array carries the buffer size; AIDL primitives cannot be `out` parameters), with `releaseData()` acknowledgements after `onDataAvailable()` callbacks.
 * Output formats, including passthrough where supported, are dynamically switchable if capabilities permit.
@@ -437,7 +437,7 @@ Mixers can operate in secure and non-secure paths. Mixer properties such as `MIX
 
 ## Dolby MS12 Runtime Commands
 
-The `IDolbyMs12_2_6_Dap` interface exposes one method per MS12 IDK 2.6 runtime command. It is obtained from `IAudioOutputPortController.getDolbyMs12_2_6_Dap()`, so DAP access is gated by holding the exclusive port controller acquired via `IAudioOutputPort.open()`. No separate DAP-level open()/close() is required — the port controller's ownership boundary covers DAP writes.
+The `IDolbyMs12_2_6_Dap` interface exposes one method per MS12 IDK 2.6 runtime command. It is obtained from `IAudioOutputPortController.getDolbyMs12_2_6_Dap()`, so DAP access is gated by holding the exclusive port controller acquired via `IAudioOutputPort.open()`. Because the interface is acquired from the controller, the ownership boundary applies to all DAP access — reads as well as writes — for the controller's lifetime. No separate DAP-level open()/close() is required.
 
 Non-boolean argument constraints are declared per output port in `audiomixer/current/hfp-audiomixer.yaml` under `outputPorts[].supportedAQProcessors[].setFunctions`.
 

--- a/audiomixer/current/docs/audio_mixer.md
+++ b/audiomixer/current/docs/audio_mixer.md
@@ -174,7 +174,7 @@ flowchart TD
 * Inputs are processed and mixed into one or more outputs.
 * Output formats can be negotiated and configured using `IAudioOutputPortController.setProperty(OUTPUT_FORMAT, ...)` (controller acquired via `IAudioOutputPort.open()`).
 * For Dolby MS12 2.6 ports, `IAudioOutputPortController.getDolbyMs12_2_6_Dap()` returns the `IDolbyMs12_2_6_Dap` runtime command interface (bass enhancer, volume leveller, surround virtualizer, dialogue enhancer, EQ modes, DRC, Atmos lock, downmix, volume modeler, centre spreading, active downmix). DAP access requires holding the port controller — the same exclusive-ownership boundary used for property writes serves as the ownership boundary for DAP writes too. Port-level MS12 audio profile selection is exposed via `OutputPortProperty.DOLBY_MS12_AUDIO_PROFILE` against the profiles enumerated in `OutputPortCapabilities.dolbyMs12AudioProfiles`.
-* Where `OutputPortCapabilities.supportsAudioCapture` is true, capture is created from `IAudioOutputPort.getAudioCapture(listener)`.
+* Where `OutputPortCapabilities.supportsAudioCapture` is true, capture is created from `IAudioOutputPortController.getAudioCapture(listener)` — like DAP runtime control, capture acquisition is gated by holding the port controller acquired via `IAudioOutputPort.open()`.
 * Audio capture uses a shared-memory ring buffer returned by `getSharedMemory(out long[] sharedMemorySizeBytes)` (length-1 array carries the buffer size; AIDL primitives cannot be `out` parameters), with `releaseData()` acknowledgements after `onDataAvailable()` callbacks.
 * Output formats, including passthrough where supported, are dynamically switchable if capabilities permit.
 


### PR DESCRIPTION
Closes #593.

## Summary

Follows @hari22yuva's proposal in discussion #591 — relocate `getDolbyMs12_2_6_Dap()` from `IAudioOutputPort` (read handle) to `IAudioOutputPortController` (exclusive write controller). DAP runtime command access is now gated by holding the port controller; the same ownership boundary used for `OutputPortProperty` writes serves as the ownership boundary for DAP writes too.

## Changes

Three files, ~37 lines added / ~23 removed:

- **`IAudioOutputPort.aidl`** — removed `getDolbyMs12_2_6_Dap()` declaration; updated class-level docblock to point callers at the port controller for DAP access; dropped the `IDolbyMs12_2_6_Dap` import.
- **`IAudioOutputPortController.aidl`** — added `IDolbyMs12_2_6_Dap getDolbyMs12_2_6_Dap()` with full docblock (gating semantics, capability check, exception). Updated class-level docblock to mention the new factory method.
- **`docs/audio_mixer.md`** — updated the Operation and Data Flow bullet and the Dolby MS12 Runtime Commands section to reflect controller-gated DAP access.

The `IDolbyMs12_2_6_Dap` interface itself is **unchanged** — all 15 setters and 14 getters keep their current signatures.

## Ownership semantics

```
IAudioOutputPort.open(listener) → IAudioOutputPortController       (acquire write exclusivity)
    IAudioOutputPortController.setProperty(...)                    (port property writes)
    IAudioOutputPortController.getDolbyMs12_2_6_Dap()              (acquire DAP runtime command interface)
        IDolbyMs12_2_6_Dap.set*(...)                               (DAP writes — gated by controller ownership)
        IDolbyMs12_2_6_Dap.get*()                                  (DAP reads — same gate; see follow-up below)
IAudioOutputPort.close(controller)                                 (release write exclusivity)
```

A second client that wants to read DAP state without write ownership cannot do so today. If a concrete consumer surfaces (settings UI / certification suite / diagnostics), a follow-up PR can add an observer surface — but the present change scopes only what was explicitly asked in #591.

## What changed from the previous version of this PR

Previous attempts split `IDolbyMs12_2_6_Dap` into three interfaces (read-handle + DapController + DapListener) with separate open/close ownership. @hari22yuva flagged that as different from the proposal in #591 (["this PR has different changes not what we discussed"](https://github.com/rdkcentral/rdk-halif-aidl/pull/594)). This force-push reverts to the simpler relocation.

Dropped from the previous version:
- `IDolbyMs12_2_6_DapController.aidl` (new file — deleted)
- `IDolbyMs12_2_6_DapListener.aidl` (new file — deleted)
- `IDolbyMs12_2_6_Dap.aidl` rewrite into a read-only handle with open()/close() — reverted to develop state
- Audiomixer version bump — no longer needed; PR #573 still owns the `0.3.0.0` generation

## Coordination with PR #573

This PR remains stacked on `feature/411-audiomixer-aq-parameter-api`. PR #573's `0.3.0.0` generation absorbs the small change here; no separate bump in `audiomixer/metadata.yaml`.

## Build verification

```
./build_modules.sh audiomixer       # exit 0, 41 libs built; generated bindings clean
```

## References

- Discussion #591 — @hari22yuva original proposal.
- Issue #593 — tracker.
- PR #573 — IAQProcessor / IAQProcessorController, parallel pattern for AQ parameter tuning.