### PR TITLE
feat(audiomixer)!: rename register/unregisterListener → *EventListener + boolean return, drop state guards (#597)

### DIFF
--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl
@@ -67,10 +67,21 @@ interface IAudioMixer {
     /**
     * @brief Gets an audio output port interface by ID.
     *
-    * Returns null if the port is not supported on this mixer instance.
+    * The ID must be one of the values returned by `getAudioOutputPortIds()`.
+    * Out-of-range or negative identifiers raise `EX_ILLEGAL_ARGUMENT`. An
+    * identifier within range but not currently mounted on this mixer
+    * instance returns `null` — callers should enumerate via
+    * `getAudioOutputPortIds()` rather than probe-by-ID.
     *
-    * @param id Output port identifier (as int).
-    * @returns IAudioOutputPort interface or null.
+    * @param[in] id Output port identifier (as int).
+    * @returns      IAudioOutputPort interface, or null if no port with the
+    *               given ID is mounted on this mixer instance.
+    *
+    * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c id is negative or
+    *            outside the range of supported port identifiers for this
+    *            platform.
+    *
+    * @see getAudioOutputPortIds()
     */
     @nullable IAudioOutputPort getAudioOutputPort(in int id);
 
@@ -130,13 +141,34 @@ interface IAudioMixer {
 
     /**
     * @brief Registers a listener to receive events from this mixer instance.
-    * @param[in] listener Instance of IAudioMixerEventListener to receive callbacks.
+    *
+    * Multiple listeners may be registered. Registration does not require
+    * ownership of the mixer controller — observers can attach without
+    * holding the IAudioMixerController. Re-registering the same listener
+    * instance is a no-op and does not raise an exception.
+    *
+    * @param[in] listener Instance of IAudioMixerEventListener to receive
+    *                     callbacks.
+    *
+    * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+    *
+    * @see unregisterListener()
+    * @see IAudioMixerEventListener
     */
     void registerListener(in IAudioMixerEventListener listener);
 
     /**
      * @brief     Un-registers a previously registered mixer event listener.
-     * @param[in] listener   Instance of IAudioMixerEventListener to remove.
+     *
+     *            Unregistering a listener that was never registered (or
+     *            already unregistered) is a no-op and does not raise an
+     *            exception.
+     *
+     * @param[in] listener  Instance of IAudioMixerEventListener to remove.
+     *
+     * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+     *
+     * @see registerListener()
      */
     void unregisterListener(in IAudioMixerEventListener listener);
 
@@ -148,18 +180,40 @@ interface IAudioMixer {
     *
     * The length and order of the returned array correspond to the current active
     * mixer inputs; each entry matches the input at the same index as returned
-    * by capability or enumeration APIs.
+    * by capability or enumeration APIs. Inactive inputs report
+    * `Codec.UNDEFINED`.
     *
-    * @returns List of codecs for active sources.
+    * Requires the mixer to be open (state at or after READY). When the
+    * mixer is in CLOSED or OPENING, the call raises EX_ILLEGAL_STATE.
+    *
+    * @returns List of codecs for active sources; empty when no inputs
+    *          are currently routed.
+    *
+    * @exception binder::Status EX_ILLEGAL_STATE if the mixer is in CLOSED
+    *            or OPENING state.
+    *
+    * @see IAudioMixer.open()
+    * @see Codec
     */
     Codec[] getCurrentSourceCodecs();
 
     /**
      * @brief     Gets the current audio source routing for all mixer inputs.
-     * Returns an array with one element for each mixer input (as declared in Capabilities.inputs).
-     *            If a mixer input has no source connected, `AudioSourceType.NONE` is indicated.
      *
-     * @returns   Array of audio source to mixer tree input routing configurations.
+     *            Returns an array with one element for each mixer input (as
+     *            declared in `Capabilities.inputs`). If a mixer input has no
+     *            source connected, `AudioSourceType.NONE` is indicated.
+     *
+     *            Requires the mixer to be open (state at or after READY).
+     *            When the mixer is in CLOSED or OPENING, the call raises
+     *            EX_ILLEGAL_STATE.
+     *
+     * @returns   Array of audio source to mixer tree input routing
+     *            configurations.
+     *
+     * @exception binder::Status EX_ILLEGAL_STATE if the mixer is in CLOSED
+     *            or OPENING state.
+     *
      * @see       IAudioMixerController.setInputRouting()
      */
     InputRouting[] getInputRouting();

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl
@@ -67,19 +67,18 @@ interface IAudioMixer {
     /**
     * @brief Gets an audio output port interface by ID.
     *
-    * The ID must be one of the values returned by `getAudioOutputPortIds()`.
-    * Out-of-range or negative identifiers raise `EX_ILLEGAL_ARGUMENT`. An
-    * identifier within range but not currently mounted on this mixer
-    * instance returns `null` — callers should enumerate via
-    * `getAudioOutputPortIds()` rather than probe-by-ID.
+    * Callers should discover valid port identifiers via
+    * `getAudioOutputPortIds()` rather than probe-by-ID. Negative or
+    * otherwise structurally invalid identifiers raise
+    * `EX_ILLEGAL_ARGUMENT`; an identifier that is plausible but not
+    * currently mounted on this mixer instance returns `null`.
     *
     * @param[in] id Output port identifier (as int).
     * @returns      IAudioOutputPort interface, or null if no port with the
     *               given ID is mounted on this mixer instance.
     *
     * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c id is negative or
-    *            outside the range of supported port identifiers for this
-    *            platform.
+    *            structurally invalid for this platform.
     *
     * @see getAudioOutputPortIds()
     */
@@ -178,16 +177,14 @@ interface IAudioMixer {
     * Useful for clients to discover what input formats are currently processed
     * by the mixer for debugging, display, or selection logic.
     *
-    * The length and order of the returned array correspond to the current active
-    * mixer inputs; each entry matches the input at the same index as returned
-    * by capability or enumeration APIs. Inactive inputs report
-    * `Codec.UNDEFINED`.
+    * The length and order of the returned array correspond to the current
+    * active mixer inputs; each entry matches the input at the same index
+    * as returned by capability or enumeration APIs.
     *
     * Requires the mixer to be open (state at or after READY). When the
     * mixer is in CLOSED or OPENING, the call raises EX_ILLEGAL_STATE.
     *
-    * @returns List of codecs for active sources; empty when no inputs
-    *          are currently routed.
+    * @returns List of codecs for active sources.
     *
     * @exception binder::Status EX_ILLEGAL_STATE if the mixer is in CLOSED
     *            or OPENING state.

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl
@@ -139,37 +139,42 @@ interface IAudioMixer {
     boolean close(in IAudioMixerController audioMixerController);
 
     /**
-    * @brief Registers a listener to receive events from this mixer instance.
-    *
-    * Multiple listeners may be registered. Registration does not require
-    * ownership of the mixer controller — observers can attach without
-    * holding the IAudioMixerController. Re-registering the same listener
-    * instance is a no-op and does not raise an exception.
-    *
-    * @param[in] listener Instance of IAudioMixerEventListener to receive
-    *                     callbacks.
-    *
-    * @exception binder::Status EX_NULL_POINTER if @c listener is null.
-    *
-    * @see unregisterListener()
-    * @see IAudioMixerEventListener
-    */
-    void registerListener(in IAudioMixerEventListener listener);
+     * Registers an audio mixer event listener.
+     *
+     * An `IAudioMixerEventListener` can only be registered once and will
+     * fail on subsequent registration attempts with the same instance.
+     * Registration does not require ownership of the mixer controller —
+     * observers can attach without holding the IAudioMixerController.
+     *
+     * @param[in] audioMixerEventListener Listener object for callbacks.
+     *
+     * @returns boolean
+     * @retval true  The event listener was registered.
+     * @retval false The event listener is already registered.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_NULL_POINTER for Null object.
+     *
+     * @see unregisterEventListener()
+     * @see IAudioMixerEventListener
+     */
+    boolean registerEventListener(in IAudioMixerEventListener audioMixerEventListener);
 
     /**
-     * @brief     Un-registers a previously registered mixer event listener.
+     * Unregisters an audio mixer event listener.
      *
-     *            Unregistering a listener that was never registered (or
-     *            already unregistered) is a no-op and does not raise an
-     *            exception.
+     * @param[in] audioMixerEventListener Listener object for callbacks.
      *
-     * @param[in] listener  Instance of IAudioMixerEventListener to remove.
+     * @returns boolean
+     * @retval true  The event listener was unregistered.
+     * @retval false The event listener was not found registered.
      *
-     * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_NULL_POINTER for Null object.
      *
-     * @see registerListener()
+     * @see registerEventListener()
      */
-    void unregisterListener(in IAudioMixerEventListener listener);
+    boolean unregisterEventListener(in IAudioMixerEventListener audioMixerEventListener);
 
     /**
     * @brief Gets the list of currently active source codecs being mixed.
@@ -181,15 +186,15 @@ interface IAudioMixer {
     * active mixer inputs; each entry matches the input at the same index
     * as returned by capability or enumeration APIs.
     *
-    * Requires the mixer to be open (state at or after READY). When the
-    * mixer is in CLOSED or OPENING, the call raises EX_ILLEGAL_STATE.
+    * Callable independent of open()/close(), like `getCapabilities()` —
+    * does not require holding the IAudioMixerController and does not gate
+    * on the mixer lifecycle state.
     *
     * @returns List of codecs for active sources.
     *
-    * @exception binder::Status EX_ILLEGAL_STATE if the mixer is in CLOSED
-    *            or OPENING state.
+    * @exception binder::Status::Exception::EX_NONE for success.
     *
-    * @see IAudioMixer.open()
+    * @see IAudioMixer.getCapabilities()
     * @see Codec
     */
     Codec[] getCurrentSourceCodecs();
@@ -201,16 +206,17 @@ interface IAudioMixer {
      *            declared in `Capabilities.inputs`). If a mixer input has no
      *            source connected, `AudioSourceType.NONE` is indicated.
      *
-     *            Requires the mixer to be open (state at or after READY).
-     *            When the mixer is in CLOSED or OPENING, the call raises
-     *            EX_ILLEGAL_STATE.
+     *            Callable independent of open()/close(), like
+     *            `getCapabilities()` — does not require holding the
+     *            IAudioMixerController and does not gate on the mixer
+     *            lifecycle state.
      *
      * @returns   Array of audio source to mixer tree input routing
      *            configurations.
      *
-     * @exception binder::Status EX_ILLEGAL_STATE if the mixer is in CLOSED
-     *            or OPENING state.
+     * @exception binder::Status::Exception::EX_NONE for success.
      *
+     * @see       IAudioMixer.getCapabilities()
      * @see       IAudioMixerController.setInputRouting()
      */
     InputRouting[] getInputRouting();

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerController.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerController.aidl
@@ -86,10 +86,31 @@ interface IAudioMixerController {
 
     /**
      * @brief     Sets a property on the controlled mixer instance.
+     *
+     *            The property must be writable in the current mixer state.
+     *            Property writability is documented per-key in Property.aidl.
+     *
      * @param[in] property      The property key (from Property enum).
-     * @param[in] propertyValue The value to set (PropertyValue union).
-     * @returns   true if successfully set, false otherwise.
+     * @param[in] propertyValue The value to set (PropertyValue union; active
+     *                          union field must match the property type).
+     *
+     * @returns   true on successful write; false if the property is not
+     *            supported on this mixer or the value is rejected (e.g.
+     *            out of range for the property).
+     *
+     * @retval    true   The property was written and is now in effect.
+     * @retval    false  The property is unsupported on this mixer instance
+     *                   or the value was rejected; mixer state is unchanged.
+     *
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c property is unknown
+     *            or the PropertyValue union's active field does not match
+     *            the property's declared type.
+     * @exception binder::Status EX_ILLEGAL_STATE if the mixer is not in a
+     *            state that permits writing this property.
+     *
      * @see       IAudioMixer.getProperty()
+     * @see       Property
+     * @see       PropertyValue
      */
     boolean setProperty(in Property property, in PropertyValue propertyValue);
 

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl
@@ -47,8 +47,22 @@ interface IAudioMixerManager {
     /**
      * @brief Acquires a specific audio mixer interface by ID.
      *
-     * @param id Mixer resource identifier.
-     * @returns IAudioMixer interface for controlling the mixer, or null if unavailable.
+     * The ID must be one of the values returned by `getAudioMixerIds()`.
+     * Identifiers outside the declared `IAudioMixer.Id` enum raise
+     * EX_ILLEGAL_ARGUMENT. A valid declared ID that is not currently
+     * present on the platform returns `null`.
+     *
+     * @param[in] id  Mixer resource identifier.
+     *
+     * @returns       IAudioMixer interface for controlling the mixer, or
+     *                `null` if the ID is declared by the enum but no mixer
+     *                with that ID is mounted on this platform.
+     *
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c id is outside the
+     *            range of the IAudioMixer.Id enum.
+     *
+     * @see getAudioMixerIds()
+     * @see IAudioMixer
      */
     @nullable IAudioMixer getAudioMixer(in IAudioMixer.Id id);
 }

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl
@@ -41,6 +41,8 @@ interface IAudioMixerManager {
      * be stable for the lifetime of the process.
      *
      * @returns Array of IAudioMixer.Id values representing available mixers.
+     *
+     * @exception binder::Status::Exception::EX_NONE for success.
      */
     IAudioMixer.Id[] getAudioMixerIds();
 
@@ -59,8 +61,9 @@ interface IAudioMixerManager {
      *                `null` if @c id is a defined enum value but no mixer
      *                with that ID is mounted on this platform.
      *
-     * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c id is not a
-     *            defined value of `IAudioMixer.Id`.
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if @c id
+     *            is not a defined value of `IAudioMixer.Id`.
      *
      * @see getAudioMixerIds()
      * @see IAudioMixer

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl
@@ -47,19 +47,20 @@ interface IAudioMixerManager {
     /**
      * @brief Acquires a specific audio mixer interface by ID.
      *
-     * The ID must be one of the values returned by `getAudioMixerIds()`.
-     * Identifiers outside the declared `IAudioMixer.Id` enum raise
-     * EX_ILLEGAL_ARGUMENT. A valid declared ID that is not currently
-     * present on the platform returns `null`.
+     * Callers should discover mounted mixer identifiers via
+     * `getAudioMixerIds()` rather than probe-by-ID. Identifiers that are
+     * not a defined value of `IAudioMixer.Id` raise EX_ILLEGAL_ARGUMENT;
+     * a defined enum value for which no mixer is currently mounted on
+     * this platform returns `null`.
      *
      * @param[in] id  Mixer resource identifier.
      *
      * @returns       IAudioMixer interface for controlling the mixer, or
-     *                `null` if the ID is declared by the enum but no mixer
+     *                `null` if @c id is a defined enum value but no mixer
      *                with that ID is mounted on this platform.
      *
-     * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c id is outside the
-     *            range of the IAudioMixer.Id enum.
+     * @exception binder::Status EX_ILLEGAL_ARGUMENT if @c id is not a
+     *            defined value of `IAudioMixer.Id`.
      *
      * @see getAudioMixerIds()
      * @see IAudioMixer

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
@@ -145,14 +145,32 @@ interface IAudioOutputPort {
      * @brief    Registers a listener for port property change events.
      *
      *           Multiple listeners may be registered. Listener registration
-     *           does not require ownership of the controller.
+     *           does not require ownership of the controller — observers
+     *           can attach without holding the IAudioOutputPortController.
+     *           Re-registering the same listener instance is a no-op and
+     *           does not raise an exception.
      *
      * @param[in] listener  Listener for property change notifications.
+     *
+     * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+     *
+     * @see unregisterListener()
+     * @see IAudioOutputPortListener
      */
     void registerListener(in IAudioOutputPortListener listener);
 
     /**
      * @brief    Un-registers a previously registered listener.
+     *
+     *           Unregistering a listener that was never registered (or
+     *           already unregistered) is a no-op and does not raise an
+     *           exception.
+     *
+     * @param[in] listener  Listener previously passed to registerListener().
+     *
+     * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+     *
+     * @see registerListener()
      */
     void unregisterListener(in IAudioOutputPortListener listener);
 

--- a/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
+++ b/audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl
@@ -142,37 +142,42 @@ interface IAudioOutputPort {
     boolean close(in IAudioOutputPortController controller);
 
     /**
-     * @brief    Registers a listener for port property change events.
+     * Registers an audio output port event listener.
      *
-     *           Multiple listeners may be registered. Listener registration
-     *           does not require ownership of the controller — observers
-     *           can attach without holding the IAudioOutputPortController.
-     *           Re-registering the same listener instance is a no-op and
-     *           does not raise an exception.
+     * An `IAudioOutputPortListener` can only be registered once and will
+     * fail on subsequent registration attempts with the same instance.
+     * Listener registration does not require ownership of the controller —
+     * observers can attach without holding the IAudioOutputPortController.
      *
-     * @param[in] listener  Listener for property change notifications.
+     * @param[in] audioOutputPortEventListener Listener object for callbacks.
      *
-     * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+     * @returns boolean
+     * @retval true  The event listener was registered.
+     * @retval false The event listener is already registered.
      *
-     * @see unregisterListener()
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_NULL_POINTER for Null object.
+     *
+     * @see unregisterEventListener()
      * @see IAudioOutputPortListener
      */
-    void registerListener(in IAudioOutputPortListener listener);
+    boolean registerEventListener(in IAudioOutputPortListener audioOutputPortEventListener);
 
     /**
-     * @brief    Un-registers a previously registered listener.
+     * Unregisters an audio output port event listener.
      *
-     *           Unregistering a listener that was never registered (or
-     *           already unregistered) is a no-op and does not raise an
-     *           exception.
+     * @param[in] audioOutputPortEventListener Listener object for callbacks.
      *
-     * @param[in] listener  Listener previously passed to registerListener().
+     * @returns boolean
+     * @retval true  The event listener was unregistered.
+     * @retval false The event listener was not found registered.
      *
-     * @exception binder::Status EX_NULL_POINTER if @c listener is null.
+     * @exception binder::Status::Exception::EX_NONE for success.
+     * @exception binder::Status::Exception::EX_NULL_POINTER for Null object.
      *
-     * @see registerListener()
+     * @see registerEventListener()
      */
-    void unregisterListener(in IAudioOutputPortListener listener);
+    boolean unregisterEventListener(in IAudioOutputPortListener audioOutputPortEventListener);
 
     /**
      * @brief Creates a Dolby MS12 2.6 DAP command interface for this port.

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiomixer
-version: 0.2.0.0
+version: 0.3.0.0
 status: AMBER
 description: "Audio mixing and routing for multi-stream output"
 type: SOC


### PR DESCRIPTION
Closes #597 (raised by @hari22yuva).

Force-push 38071bb4 — scope expanded per @hari22yuva [PR #599 review](https://github.com/rdkcentral/rdk-halif-aidl/pull/599#pullrequestreview-4465819657) from docs-only to a **BREAKING audiomixer interface change** for cross-module harmonisation with the audiodecoder convention.

## Summary

audiomixer was the outlier with `void registerListener` / `void unregisterListener` and `listener` parameter names. This PR aligns it with the audiodecoder pattern: `boolean registerEventListener` / `boolean unregisterEventListener` returning `true` on success / `false` on duplicate-register or unknown-unregister, with `@retval` lines, `@exception EX_NONE` / `EX_NULL_POINTER` documented, and method/parameter names harmonised.

Plus the state-guard correction hari called out on `getCurrentSourceCodecs()` / `getInputRouting()`.

## Changes

### [IAudioMixer.aidl](audiomixer/current/com/rdk/hal/audiomixer/IAudioMixer.aidl)

| Method | Change |
|---|---|
| `void registerListener(IAudioMixerEventListener listener)` | → `boolean registerEventListener(in IAudioMixerEventListener audioMixerEventListener)` with `@retval true/false`, `@exception EX_NONE`/`EX_NULL_POINTER`. |
| `void unregisterListener(IAudioMixerEventListener listener)` | → `boolean unregisterEventListener(in IAudioMixerEventListener audioMixerEventListener)` with `@retval true/false`, `@exception EX_NONE`/`EX_NULL_POINTER`. |
| `getCurrentSourceCodecs()` | Dropped `EX_ILLEGAL_STATE` for CLOSED/OPENING — callable independent of open()/close(), like `getCapabilities()`. `@exception EX_NONE` added. |
| `getInputRouting()` | Same drop of `EX_ILLEGAL_STATE`; `@exception EX_NONE` added. |

### [IAudioOutputPort.aidl](audiomixer/current/com/rdk/hal/audiomixer/IAudioOutputPort.aidl)

| Method | Change |
|---|---|
| `void registerListener(IAudioOutputPortListener listener)` | → `boolean registerEventListener(in IAudioOutputPortListener audioOutputPortEventListener)`. |
| `void unregisterListener(IAudioOutputPortListener listener)` | → `boolean unregisterEventListener(in IAudioOutputPortListener audioOutputPortEventListener)`. |

### [IAudioMixerManager.aidl](audiomixer/current/com/rdk/hal/audiomixer/IAudioMixerManager.aidl)

| Method | Change |
|---|---|
| `getAudioMixerIds()` | `@exception EX_NONE` added. |
| `getAudioMixer(IAudioMixer.Id)` | `@exception EX_NONE` added alongside the existing `EX_ILLEGAL_ARGUMENT`. |

### Version

`audiomixer/metadata.yaml`: `0.2.0.0` → **`0.3.0.0`** (breaking — method renames + return-type change).

## Out of scope

The same `void register/unregisterListener` pattern still exists on:

- `IAQProcessor.aidl` (in PR #573, currently in 0.22.0 milestone)
- `IDolbyMs12_2_6_Dap.aidl` (PR #594)
- `IAudioCapture.aidl`

@hari22yuva's review explicitly called out only IAudioMixer + IAudioOutputPort, so this PR scopes there. Full audiomixer-wide harmonisation can be a follow-up if reviewers want it.

## Cherry-pick plan

After merge to `develop`, cherry-pick onto `release/0.21.0` preserves the `0.3.0.0` breaking-generation bump and re-snapshots `audiomixer/0.2.0.0/` → `audiomixer/0.3.0.0/`. `versions_released.yaml` + `mkdocs.yml` updated.

## Build verification

```
./build_modules.sh audiomixer       # exit 0, generated bindings clean
```

## Test plan

- [ ] @hari22yuva approval that the rename + signature changes match the requested template
- [ ] Confirm caller-side updates are tracked (any internal consumers of the old `registerListener` need the rename)
- [ ] CI: Signature / Fossid / blackduck / copyright pass