### PR TITLE
docs(audiodecoder): spec mid-stream sample-rate / channel-count changes (#600)

### DIFF
--- a/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl
@@ -163,11 +163,16 @@ interface IAudioDecoderController {
 	void flush(in boolean reset);
 
     /**
-	 * Signals a discontinuity in the audio stream.
+	 * Signals a PTS discontinuity in the audio stream.
      *
      * The audio decoder must be in a state of `STARTED`.
      * Buffers that follow this call passed in `decodeBufferWithMetadata()` shall be
      * regarded as PTS discontinuous to any audio frames previously passed.
+     *
+     * This call covers PTS gaps only. It does NOT signal a sample-rate or
+     * channel-count change — for those, call `setAudioFormat()` with the
+     * new parameters while staying in STARTED. See "Mid-Stream Format
+     * Changes" in audio_decoder.md.
      *
      * This method remains the authoritative path for signalling discontinuity in
      * v1. The `InputBufferMetadata.discontinuity` field is reserved and MUST be
@@ -177,6 +182,8 @@ interface IAudioDecoderController {
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE
      *
      * @pre The resource must be in State::STARTED.
+     *
+     * @see setAudioFormat()
      */
     void signalDiscontinuity();
 
@@ -252,7 +259,7 @@ interface IAudioDecoderController {
     boolean parseCodecSpecificData(in CSDAudioFormat csdAudioFormat, in byte[] codecData);
 
     /**
-     * Sets the audio stream format hint before decoding begins.
+     * Sets the audio stream format hint.
      *
      * Provides the channel count and sample rate sourced from container
      * or demuxer metadata (e.g. GStreamer caps). Required for codecs
@@ -265,6 +272,19 @@ interface IAudioDecoderController {
      * decoder will use the CSD values. If both are provided, the CSD
      * values take precedence.
      *
+     * Valid in both State::READY (initial setup before start()) and
+     * State::STARTED (mid-stream format change). When called in STARTED,
+     * the decoder applies the new format to all subsequently submitted
+     * input buffers; buffers already queued complete decoding under the
+     * old format. No lifecycle transition is triggered, no flush() is
+     * required, and signalDiscontinuity() is NOT used for this case —
+     * it covers PTS gaps only. See "Mid-Stream Format Changes" in
+     * audio_decoder.md.
+     *
+     * Codec changes (e.g. AAC -> AC-3) are out of scope; those still
+     * require stop() -> setAudioFormat() -> start() because the decoder
+     * backend itself must be reconfigured.
+     *
      * @param[in] channels    Number of audio channels.
      *                        Common values: 1 (mono), 2 (stereo),
      *                        6 (5.1 surround), 8 (7.1 surround).
@@ -273,12 +293,15 @@ interface IAudioDecoderController {
      *                        44100, 48000, 96000, 192000.
      *
      * @exception binder::Status::Exception::EX_NONE for success.
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the resource is not in the READY state.
-     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if channels or sampleRate is <= 0.
+     * @exception binder::Status::Exception::EX_ILLEGAL_STATE if the
+     *            resource is not in State::READY or State::STARTED.
+     * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if
+     *            channels or sampleRate is <= 0.
      *
-     * @pre The resource must be in State::READY.
+     * @pre The resource must be in State::READY or State::STARTED.
      *
      * @see PCMMetadata.numChannels, PCMMetadata.sampleRate
+     * @see signalDiscontinuity()
      */
     void setAudioFormat(in int channels, in int sampleRate);
 }

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/PCMMetadata.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/PCMMetadata.aidl
@@ -20,8 +20,18 @@ package com.rdk.hal.audiodecoder;
 import com.rdk.hal.audiodecoder.ChannelType;
 import com.rdk.hal.audiodecoder.PCMFormat;
 
-/** 
+/**
  *  @brief     PCM Audio frame metadata.
+ *
+ *  Every field on this parcelable describes the format of the frame
+ *  it accompanies. When a mid-stream format change occurs (see
+ *  "Mid-Stream Format Changes" in audio_decoder.md), the first
+ *  FrameMetadata produced under the new format carries the updated
+ *  numChannels / channelTypes / sampleRate values; subsequent frames
+ *  carry the new values until the next change. No out-of-band
+ *  format-change notification is required — the change is visible at
+ *  the sink on the first frame post-transition.
+ *
  *  @author    Luc Kennedy-Lamb
  *  @author    Peter Stieglitz
  *  @author    Douglas Adler
@@ -31,18 +41,29 @@ import com.rdk.hal.audiodecoder.PCMFormat;
 parcelable PCMMetadata {
 
     /**
-     * Number of audio channels.
+     * Number of audio channels in this frame.
+     *
+     * Reflects the format of THIS frame; on a mid-stream format change
+     * this value updates on the first frame produced under the new
+     * format. See IAudioDecoderController.setAudioFormat().
      */
     int numChannels;
 
     /**
-     * Array of ChannelType enum values.
+     * Array of ChannelType enum values for this frame.
      * The array size should match the number of channels.
+     *
+     * Reflects the format of THIS frame; updates on the first frame
+     * produced after a mid-stream channel-layout change.
      */
     ChannelType[] channelTypes;
 
     /**
-     * Sample rate in samples/second.
+     * Sample rate in samples/second for this frame.
+     *
+     * Reflects the format of THIS frame; on a mid-stream format change
+     * this value updates on the first frame produced under the new
+     * format. See IAudioDecoderController.setAudioFormat().
      */
     int sampleRate;
 

--- a/audiodecoder/current/docs/audio_decoder.md
+++ b/audiodecoder/current/docs/audio_decoder.md
@@ -332,12 +332,12 @@ sequenceDiagram
     App->>Dec: setAudioFormat(channels=2, sampleRate=44100) (in READY)
     App->>Dec: start()
     App->>Dec: decodeBufferWithMetadata(buf_a1, …)
-    Dec->>Lst: onFrameOutput(frame_a1, PCMMetadata{numChannels=2, sampleRate=44100})
+    Dec->>Lst: onFrameOutput(nsPresentationTime=t_a1, frameAVBufferHandle=h_a1, metadata=FrameMetadata{pcm: PCMMetadata{numChannels=2, sampleRate=44100, …}})
     Note over App,Dec: Stream switches to 48 kHz 5.1 mid-flight
     App->>Dec: setAudioFormat(channels=6, sampleRate=48000) (in STARTED — mid-stream change)
     App->>Dec: decodeBufferWithMetadata(buf_b1, …)
-    Dec->>Lst: onFrameOutput(frame_b1, PCMMetadata{numChannels=6, sampleRate=48000})
-    Note right of Lst: Sink sees the new format on the first frame post-transition.
+    Dec->>Lst: onFrameOutput(nsPresentationTime=t_b1, frameAVBufferHandle=h_b1, metadata=FrameMetadata{pcm: PCMMetadata{numChannels=6, sampleRate=48000, …}})
+    Note right of Lst: Sink sees the new format on the first frame post-transition.<br/>FrameMetadata may be null on subsequent unchanged frames<br/>(per-frame metadata is only re-emitted on change — see Frame Metadata section).
 ```
 
 ## End of Stream Signalling

--- a/audiodecoder/current/docs/audio_decoder.md
+++ b/audiodecoder/current/docs/audio_decoder.md
@@ -311,6 +311,35 @@ Where the client has knowledge of PTS discontinuities in the audio stream, it sh
 
 For the first input [AV Buffer](../avbuffer/av_buffer.md) audio frame passed in for decode after the discontinuity, it shall indicate the discontinuity in its next output `FrameMetadata`.
 
+`signalDiscontinuity()` covers PTS gaps only — it does NOT signal a change of audio format. Mid-stream sample-rate or channel-count changes follow a separate contract, defined in the next section.
+
+## Mid-Stream Format Changes
+
+Live broadcast, adaptive streaming, and SSAI insertions can change the sample rate or channel configuration of a decoded audio stream without changing the codec — e.g. `44100 Hz → 48000 Hz` or `stereo → 5.1` while still AAC. The HAL contract for this case is:
+
+1. **No `stop()` / `start()` cycle is required.** The audio decoder MUST absorb an in-codec sample-rate or channel-count change while remaining in `State::STARTED`. The lifecycle does not transition back to `READY`.
+2. **`signalDiscontinuity()` is NOT the signal for a format change.** It is reserved for PTS discontinuities. Calling it on a format boundary does not by itself reconfigure the decoder.
+3. **The client signals the format change by re-calling `IAudioDecoderController.setAudioFormat(channels, sampleRate)` with the new values.** This call is valid in both `State::READY` (initial setup) and `State::STARTED` (mid-stream change). The decoder applies the new format to all subsequently submitted input buffers; previously queued buffers complete decoding under the old format.
+4. **`PCMMetadata` always reflects the format of the frame it accompanies.** When a format change crosses the decoder, the first output `FrameMetadata` produced under the new format carries the updated `PCMMetadata.sampleRate` / `PCMMetadata.numChannels` / `PCMMetadata.channelTypes`. No out-of-band notification is required; the change is visible at the sink on the first frame post-transition.
+5. **Codec changes are out of scope.** A change of `Codec` (e.g. AAC → AC-3) still requires `stop()` → `setAudioFormat()` → `start()` because the decoder backend itself must be reconfigured. This section covers in-codec parameter changes only.
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Dec as IAudioDecoderController
+    participant Lst as IAudioDecoderControllerListener
+    Note over App,Dec: Stream A: AAC 44.1 kHz stereo
+    App->>Dec: setAudioFormat(channels=2, sampleRate=44100) (in READY)
+    App->>Dec: start()
+    App->>Dec: decodeBufferWithMetadata(buf_a1, …)
+    Dec->>Lst: onFrameOutput(frame_a1, PCMMetadata{numChannels=2, sampleRate=44100})
+    Note over App,Dec: Stream switches to 48 kHz 5.1 mid-flight
+    App->>Dec: setAudioFormat(channels=6, sampleRate=48000) (in STARTED — mid-stream change)
+    App->>Dec: decodeBufferWithMetadata(buf_b1, …)
+    Dec->>Lst: onFrameOutput(frame_b1, PCMMetadata{numChannels=6, sampleRate=48000})
+    Note right of Lst: Sink sees the new format on the first frame post-transition.
+```
+
 ## End of Stream Signalling
 
 EOS rides entirely on the framework metadata parcelables on both sides of the interface. There is no separate signal method. Audio EOS is always application-driven - no supported audio elementary stream (MP3, AAC, AC-3/E-AC-3, Opus, Vorbis) carries an in-bitstream EOS marker.


### PR DESCRIPTION
Closes #600. Addresses [discussion #592](https://github.com/rdkcentral/rdk-halif-aidl/discussions/592) (raised by @hari22yuva).

## Summary

Documentation-only change. No AIDL surface change; no binder wire-format change; no `audiodecoder/metadata.yaml` bump on develop (cherry-pick onto `release/0.21.0` will carry the `0.2.0.0` → `0.2.0.1` patch). Pins down the HAL contract for **mid-stream in-codec format changes** — the case where the sample rate or channel count changes (e.g. AAC `44100 Hz` → `48000 Hz`, stereo → 5.1) without a codec change.

The methods that handle this case (`setAudioFormat()`, `signalDiscontinuity()`) already exist on the AIDL. The spec just needs to pin down which one covers what.

## Contract

1. **No `stop()` / `start()` cycle** for in-codec changes. Decoder absorbs the change while remaining in `State::STARTED`.
2. **`signalDiscontinuity()` is PTS-only**, NOT a format-change signal.
3. **Client re-calls `IAudioDecoderController.setAudioFormat(channels, sampleRate)`** with the new values. `@pre` relaxed from `State::READY`-only to `State::READY OR State::STARTED`.
4. **`PCMMetadata` always describes THIS frame** — `numChannels` / `channelTypes` / `sampleRate` update on the first frame post-transition. No out-of-band notification needed.
5. **Codec changes** (e.g. AAC → AC-3) are out of scope. Those still require `stop()` → `setAudioFormat()` → `start()`.

## What's documented

### [audio_decoder.md](audiodecoder/current/docs/audio_decoder.md)

New "Mid-Stream Format Changes" section between "Audio Stream Discontinuities" and "End of Stream Signalling". Includes a mermaid sequence diagram showing the AAC 44.1 kHz stereo → 48 kHz 5.1 transition end-to-end. The adjacent "Audio Stream Discontinuities" section gets a one-line note that `signalDiscontinuity()` covers PTS gaps only.

### [IAudioDecoderController.aidl](audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl)

- `setAudioFormat(channels, sampleRate)` — `@pre` extended to `State::READY OR State::STARTED`. STARTED-call semantics spelled out: applied to subsequently submitted buffers, in-flight buffers complete decoding under the old format. Codec change disclaimer.
- `signalDiscontinuity()` — clarified as PTS-only; explicit "NOT for format changes; use setAudioFormat() with new params" disclaimer; `@see setAudioFormat()`.

### [PCMMetadata.aidl](audiodecoder/current/com/rdk/hal/audiodecoder/PCMMetadata.aidl)

Parcelable-level docblock explains the per-frame guarantee. Per-field docs on `numChannels` / `channelTypes` / `sampleRate` note that values reflect THIS frame and update on the first frame produced under a new format.

## Out of scope

A per-buffer override path parallel to videodecoder PR #543 / issue #539 (`InputBufferMetadata.sampleRateOverride` / `channelsOverride`) — would carry container-derived format hints per-buffer instead of via a separate `setAudioFormat()` call. Not needed for the use case in #592; can be opened later if a concrete consumer surfaces.

## Cherry-pick plan

After merge to `develop`, this commit will be cherry-picked onto `release/0.21.0` with:
- `audiodecoder/metadata.yaml` patch bump `0.2.0.0` → `0.2.0.1`.
- `audiodecoder/0.2.0.0/` snapshot regenerated as `audiodecoder/0.2.0.1/`.
- `versions_released.yaml` and `mkdocs.yml` updated.

So the spec answer ships with 0.21.0.

## Build verification

```
./build_modules.sh audiodecoder       # exit 0; generated bindings clean
```

## Test plan

- [ ] @hari22yuva approval — answers to the four questions in #592 match expectations
- [ ] Vendor confirmation: do existing implementations absorb `setAudioFormat()` in STARTED today, or will some throw `EX_ILLEGAL_STATE`? (Implementation gap, separate from this spec PR.)
- [ ] `mkdocs build` renders the new section and sequence diagram correctly
- [ ] CI passes (Signature, Fossid, blackduck, copyright)

## References

- Discussion #592 — the original four questions
- Issue #600 — tracker
- PR #543 / Issue #539 — video-decoder parallel for per-buffer overrides (out of scope here)