### PR TITLE
feat(planecontrol)!: drop EGL-display methods from IGraphicsFbProvider + transform guide (#603, #620)

### DIFF
--- a/docs/transformation/westeros_graphics_fb_transform.md
+++ b/docs/transformation/westeros_graphics_fb_transform.md
@@ -1,0 +1,458 @@
+# Transforming Westeros onto IGraphicsFbProvider
+
+## Purpose
+
+This document describes how the Westeros compositor (and its successor) is
+transformed to render through the Plane Control HAL's graphics frame buffer
+interface, `IGraphicsFbProvider`, replacing the per-vendor Westeros GL
+backends with a single, platform-agnostic implementation.
+
+The HAL contract is vendor-agnostic and complete: it covers EGL display
+setup, DMA-buf buffer allocation, and presentation. The compositor needs
+exactly those three things, so all SoC-specific graphics code moves below
+the HAL boundary and is implemented once per platform.
+
+Related interface: [`planecontrol/current`](../../planecontrol/current/docs/plane_control.md).
+Related issues: #603 (this work), #329 (PlaneControl controller audit),
+issue #33 (Graphics allocation / Gralloc review), #62 (VSI Graphics specification).
+
+---
+
+## 1. The interface the compositor consumes
+
+A graphics plane exposes a provider, obtained from `IPlaneControl`:
+
+```aidl
+@nullable IGraphicsFbProvider getGraphicsFbProvider(
+    in int planeResourceIndex,
+    in IGraphicsFbProviderListener graphicsFbProviderListener);
+```
+
+`IGraphicsFbProvider` gives the compositor all three things it needs:
+
+```aidl
+@VintfStability
+interface IGraphicsFbProvider {
+    // EGL setup — replaces vendor-specific native display initialisation
+    long getNativeDisplayHandle();
+    int  getEGLPlatformType();
+
+    // Buffer lifecycle — replaces GBM / Nexus allocation
+    GraphicsFbCapabilities getCapabilities();
+    ParcelFileDescriptor   createGraphicsFb(in int width, in int height, out GraphicsFbInfo outInfo);
+    void                   destroyGraphicsFb(in int graphicsFbId);
+
+    // Presentation — replaces drmModeSetPlane / NEXUS_SurfaceClient
+    boolean commitGraphicsFb(in int graphicsFbId);
+}
+
+@VintfStability
+oneway interface IGraphicsFbProviderListener {
+    void onGraphicsFbReleased(in int oldGraphicsFbId, in long elapsedRealtimeNanos);
+}
+```
+
+The buffer metadata is split deliberately: per-frame geometry travels in
+`GraphicsFbInfo`, while the pixel format and modifier — constant for a
+given provider — travel in `GraphicsFbCapabilities`.
+
+```aidl
+@VintfStability
+parcelable GraphicsFbInfo {
+    int graphicsFbId;   // identifies the buffer
+    int pixelWidth;     // EGL_WIDTH
+    int pixelHeight;    // EGL_HEIGHT
+    int stride;         // bytes per row  (EGL_DMA_BUF_PLANE0_PITCH_EXT)
+    int offset;         // bytes to pixel data (EGL_DMA_BUF_PLANE0_OFFSET_EXT)
+}
+
+@VintfStability
+parcelable GraphicsFbCapabilities {
+    int  maxGraphicsFrameBuffers;
+    int  maxGraphicsFbWidth;
+    int  maxGraphicsFbHeight;
+    int  format;        // opaque pass-through value, known to the client EGL implementation
+    long modifier;      // opaque pass-through value, known to the client EGL implementation
+}
+```
+
+Three properties of the contract drive the compositor code and are easy to
+get wrong:
+
+- **`format` and `modifier` are provider-level capabilities, not per-frame.**
+  Read them once from `getCapabilities()`, not from `GraphicsFbInfo`. They are
+  **opaque** values passed through the interface without interpretation by the
+  HAL — "known to the client EGL implementation." On DRM-class platforms they
+  are a DRM fourcc and a DRM modifier and map directly to the EGL import
+  attributes below; the interface does not mandate that encoding.
+- **The returned file descriptor may be shared across buffers.**
+  `createGraphicsFb()` "can be called multiple times… The returned file
+  descriptor can be the same for all created graphics frame buffers." Buffers
+  are distinguished by `offset`, so the EGL import must key on `GraphicsFbInfo.offset`
+  and must not assume one fd per buffer.
+- **`getGraphicsFbProvider()` is `@nullable`.** A plane that is not of type
+  `GRAPHICS` returns null; confirm the plane type via `IPlaneControl.getCapabilities()`
+  first.
+
+---
+
+## 2. What EGL actually needs to import a buffer
+
+The [`EGL_EXT_image_dma_buf_import`](https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import.txt)
+extension defines exactly the metadata required to import a DMA-buf into EGL
+on Linux. Every field maps to something the provider hands back:
+
+| EGL attribute | Source |
+|---|---|
+| `EGL_DMA_BUF_PLANE0_FD_EXT` | the `ParcelFileDescriptor` from `createGraphicsFb()` |
+| `EGL_WIDTH` / `EGL_HEIGHT` | `GraphicsFbInfo.pixelWidth` / `pixelHeight` |
+| `EGL_DMA_BUF_PLANE0_PITCH_EXT` | `GraphicsFbInfo.stride` |
+| `EGL_DMA_BUF_PLANE0_OFFSET_EXT` | `GraphicsFbInfo.offset` |
+| `EGL_LINUX_DRM_FOURCC_EXT` | `GraphicsFbCapabilities.format` |
+| `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT` | `GraphicsFbCapabilities.modifier` |
+
+None of these attributes are allocator-specific. They are DRM/EGL standards
+and apply regardless of how the buffer was allocated underneath the HAL.
+
+---
+
+## 3. The problem today: a GL backend per vendor
+
+Westeros currently requires a different GL backend per SoC family. Each one
+re-implements EGL display init, buffer allocation, and presentation:
+
+| Backend | Lines | Source |
+|---|---|---|
+| `westeros-gl-brcm` (Broadcom / Nexus) | 530+ | [rdkcentral/westeros-gl-brcm](https://github.com/rdkcentral/westeros-gl-brcm) |
+| `westeros-gl-drm` (generic DRM / GBM) | 8,384 | [rdkcentral/westeros-gl-drm](https://github.com/rdkcentral/westeros-gl-drm) |
+| `westeros-soc-mtk` (Mediatek) | 3,936 | [rdk-e/westeros-soc-mtk](https://github.com/rdk-e/westeros-soc-mtk) |
+| `westeros-sink-soc-realtek` | vendor-specific | [rdk-e/westeros-sink-soc-realtek](https://github.com/rdk-e/westeros-sink-soc-realtek) |
+
+Each backend handles the same three concerns differently:
+
+1. **EGL display initialisation** — vendor-specific native display type.
+2. **Buffer allocation** — GBM on DRM, Nexus on Broadcom.
+3. **Buffer presentation** — `drmModeSetPlane` on DRM, `NEXUS_SurfaceClient` on Broadcom.
+
+Every new SoC needs a new backend; every bug fix may need porting across all
+of them. The architecture does not scale.
+
+---
+
+## 4. The transformation: one platform-agnostic Westeros
+
+The provider supplies the EGL display, the renderable buffers, and the
+presentation lifecycle, so one implementation works on every vendor. The
+SoC differences (GBM vs Nexus allocation, DRM vs Nexus presentation) live
+entirely inside the vendor HAL.
+
+```cpp
+// ONE Westeros GL backend — works on every vendor
+void init(sp<IPlaneControl> planeControl, int planeIndex) {
+    provider = planeControl->getGraphicsFbProvider(planeIndex, listener);
+    // provider is @nullable: confirm the plane is GRAPHICS before calling.
+
+    // 1. EGL setup — platform-agnostic, no vendor native-display code path
+    EGLDisplay dpy = eglGetPlatformDisplay(
+        provider->getEGLPlatformType(),
+        (void*)provider->getNativeDisplayHandle(), nullptr);
+    eglInitialize(dpy, nullptr, nullptr);
+    EGLContext ctx = eglCreateContext(dpy, config, EGL_NO_CONTEXT, ctxAttrs);
+
+    // 2. Format/modifier are provider-level capabilities — read once.
+    GraphicsFbCapabilities caps = provider->getCapabilities();
+
+    // 3. Allocate frame buffers (triple-buffered)
+    for (int i = 0; i < 3; i++) {
+        GraphicsFbInfo info;
+        frames[i].pfd = provider->createGraphicsFb(1920, 1080, &info);
+        frames[i].id  = info.graphicsFbId;
+
+        // 4. Import into EGL — identical on every vendor. Note: fd may be shared
+        //    across buffers; geometry is per-buffer, so key on info.offset.
+        EGLAttrib attrs[] = {
+            EGL_WIDTH,                          info.pixelWidth,
+            EGL_HEIGHT,                         info.pixelHeight,
+            EGL_LINUX_DRM_FOURCC_EXT,           caps.format,
+            EGL_DMA_BUF_PLANE0_FD_EXT,          frames[i].pfd.get(),
+            EGL_DMA_BUF_PLANE0_OFFSET_EXT,      info.offset,
+            EGL_DMA_BUF_PLANE0_PITCH_EXT,       info.stride,
+            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, (uint32_t)(caps.modifier),
+            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, (uint32_t)(caps.modifier >> 32),
+            EGL_NONE
+        };
+        frames[i].image = eglCreateImageKHR(dpy, EGL_NO_CONTEXT,
+                                            EGL_LINUX_DMA_BUF_EXT, nullptr, attrs);
+
+        // Back an FBO with the imported EGLImage
+        glGenTextures(1, &frames[i].texture);
+        glBindTexture(GL_TEXTURE_2D, frames[i].texture);
+        glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, frames[i].image);
+        glGenFramebuffers(1, &frames[i].fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, frames[i].fbo);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_2D, frames[i].texture, 0);
+        frames[i].available = true;
+    }
+}
+
+void renderAndPresent() {
+    Frame& f = nextAvailableFrame();
+    glBindFramebuffer(GL_FRAMEBUFFER, f.fbo);
+    renderScene();
+    glFinish();
+    provider->commitGraphicsFb(f.id);   // non-blocking; returns false on unknown id
+    f.available = false;
+}
+
+// IGraphicsFbProviderListener callback
+void onGraphicsFbReleased(int oldGraphicsFbId, long elapsedRealtimeNanos) {
+    findFrame(oldGraphicsFbId).available = true;   // oldGraphicsFbId == -1 on first release
+}
+```
+
+This replaces ~13,000 lines of vendor-specific GL backend code with one
+implementation that talks only standard EGL/GL — no GBM, no Nexus, no
+vendor `#include`.
+
+---
+
+## 5. Why a DMA-buf FD is the universal transport
+
+A DMA-buf is a Linux kernel object (`struct dma_buf`) that wraps physical
+memory as a shareable, reference-counted file descriptor. It is the export
+wrapper, not the memory itself.
+
+```
+        Caller sees: DMA-buf file descriptor (standard Linux kernel object)
+                                  │
+                       Kernel: struct dma_buf
+                       - reference counted across processes
+                       - exportable as FD via Binder
+                       - importable by GPU, display, video HW
+                                  │ backed by
+                ┌─────────────────┼─────────────────┐
+            CMA pages          GEM heap        Nexus-managed
+            (RTK / AML)        (DRM)            (Broadcom)
+```
+
+The physical memory may be CMA, a GEM heap, vendor carveout, or Nexus-managed
+memory. Any kernel driver that manages physical memory can implement the
+exporter callbacks (`struct dma_buf_ops`). This is why the interface names no
+allocator: the DMA-buf FD is the universal transport, and the allocation
+behind it is vendor-specific and hidden by the kernel.
+
+### DRM platforms (Realtek, Amlogic, Mediatek)
+
+These use the standard Linux DRM/GBM stack. The vendor HAL wraps it:
+
+```c
+// DRM vendor HAL — wraps kernel GBM allocation
+ParcelFileDescriptor createGraphicsFb(int w, int h, GraphicsFbInfo* info) {
+    struct gbm_bo* bo = gbm_bo_create(gbm, w, h,
+        GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+    info->stride = gbm_bo_get_stride(bo);
+    info->offset = gbm_bo_get_offset(bo, 0);
+    // format/modifier are reported once via getCapabilities():
+    //   gbm_bo_get_format(bo), gbm_bo_get_modifier(bo)
+    return ParcelFileDescriptor(gbm_bo_get_fd(bo));
+}
+```
+
+### Broadcom (Nexus) — no GBM, same DMA-buf result
+
+Broadcom has no DRM/KMS or GBM. Allocation goes through the proprietary
+Nexus userspace API, then exports a kernel DMA-buf FD:
+
+```c
+// Broadcom vendor HAL — Nexus allocation + kernel DMA-buf export
+ParcelFileDescriptor createGraphicsFb(int w, int h, GraphicsFbInfo* info) {
+    NEXUS_SurfaceCreateSettings settings;
+    NEXUS_Surface_GetDefaultCreateSettings(&settings);
+    settings.width = w; settings.height = h;
+    settings.pixelFormat = NEXUS_PixelFormat_eA8_R8_G8_B8;
+    NEXUS_SurfaceHandle surface = NEXUS_Surface_Create(&settings);
+    int fd = nexus_surface_export_dmabuf(surface);   // kernel DMA-buf export
+    info->stride = settings.pitch;
+    info->offset = 0;
+    return ParcelFileDescriptor(fd);
+}
+```
+
+That this works on Broadcom is not speculative. Broadcom's own DME player
+framework already exports Nexus surfaces as DMA-buf FDs and imports them into
+EGL with exactly the metadata this interface carries
+(`BSEAV/lib/dme/player/texturing/TextureData.cpp`, Broadcom refsw
+`refsw_release_unified_URSR_26_*`):
+
+```c
+// TextureData.cpp — Broadcom already uses EGL_LINUX_DMA_BUF_EXT on Nexus surfaces
+uint32_t fourcc; uint64_t modifier;
+NexusToDrm(status.pixelFormat, &fourcc, &modifier);   // Nexus format → DRM fourcc/modifier
+int fd;
+NEXUS_Surface_CreateDescriptor_driver(surface, &fd);  // Nexus → DMA-buf FD export
+
+EGLint attr[] = {
+    EGL_WIDTH,                          (EGLint)status.width,
+    EGL_HEIGHT,                         (EGLint)status.height,
+    EGL_LINUX_DRM_FOURCC_EXT,           (EGLint)fourcc,
+    EGL_DMA_BUF_PLANE0_FD_EXT,          fd,
+    EGL_DMA_BUF_PLANE0_OFFSET_EXT,      (EGLint)properties.pixelMemoryOffset,
+    EGL_DMA_BUF_PLANE0_PITCH_EXT,       (EGLint)status.pitch,
+    EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, (EGLint)(modifier >> 32),
+    EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, (EGLint)(modifier & 0xffffffff),
+    EGL_NONE
+};
+eglImage = eglCreateImageKHR(eglGetCurrentDisplay(),
+    EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attr);
+```
+
+`NexusToDrm()` maps Nexus pixel formats to DRM fourcc codes and modifiers
+(including `DRM_FORMAT_MOD_BROADCOM_UIF` for tiled formats). The chain is pure
+Nexus → kernel DMA-buf → EGL, with no GBM anywhere. The Broadcom graphics HAL
+performs this same sequence internally and returns the FD as
+`ParcelFileDescriptor` and the geometry as `GraphicsFbInfo`.
+
+---
+
+## 6. Why the HAL allocates, not the client
+
+On DRM platforms the kernel already provides displayable buffer allocation
+via GBM and [DMA-buf heaps](https://docs.kernel.org/userspace-api/dma-buf-heaps.html):
+the driver knows which memory is scanout-capable and which formats/modifiers
+the display planes support. A "client allocates" model (as in
+[Wayland linux-dmabuf-v1](https://wayland.app/protocols/linux-dmabuf-v1))
+works there because the kernel interface is standard.
+
+It does not work on Broadcom: there is no standard DRM/KMS path, and allocation
+goes through Nexus. A client-allocates model would force the middleware to know
+about Nexus, breaking the abstraction. Allocating in the HAL keeps the vendor
+interface difference below the boundary: the compositor calls
+`createGraphicsFb()` and never learns which kernel path was used.
+
+---
+
+## 7. Android precedent
+
+This mirrors Android's proven graphics buffer model:
+
+| Android | RDK (this design) |
+|---|---|
+| `IAllocator` HAL (AIDL) | `IGraphicsFbProvider` (AIDL) |
+| `HardwareBuffer` (FD + metadata) | `ParcelFileDescriptor` + `GraphicsFbInfo` |
+| `eglGetNativeClientBufferANDROID()` → opaque import | `eglCreateImageKHR(EGL_LINUX_DMA_BUF_EXT)` → explicit metadata |
+| `IComposerClient.presentDisplay()` | `commitGraphicsFb()` |
+| `IComposerClient` display config | `getNativeDisplayHandle()` + `getEGLPlatformType()` |
+| Vendor gralloc implementation | Vendor HAL: GBM on DRM, Nexus on Broadcom |
+
+The architecture is identical — vendor-opaque allocation behind a standard
+HAL, with the compositor never touching vendor code. The only difference is
+the EGL import extension: Linux uses `EGL_EXT_image_dma_buf_import` with
+explicit DRM metadata where Android uses an opaque `HardwareBuffer`.
+
+---
+
+## 8. What the transformation eliminates
+
+| Component | Status | Replaced by |
+|---|---|---|
+| `westeros-gl-brcm` (530+ lines) | Eliminated | `IGraphicsFbProvider` vendor HAL |
+| `westeros-gl-drm` (8,384 lines) | Eliminated | `IGraphicsFbProvider` vendor HAL |
+| `westeros-soc-mtk` (3,936 lines) | Eliminated | `IGraphicsFbProvider` vendor HAL |
+| Essos EGL abstraction | Eliminated when retired | `getNativeDisplayHandle()` / `getEGLPlatformType()` |
+| Custom FD-transport header (`GraphicsDmaBufFrameFd.h`) | Eliminated | `ParcelFileDescriptor` (built-in AIDL) |
+| `getNativeGraphicsWindowHandle()` | Eliminated | `createGraphicsFb()` returns a DMA-buf FD |
+| `flipGraphicsBuffer()` | Eliminated | `commitGraphicsFb()` |
+
+The compositor becomes a single, portable, vendor-agnostic implementation
+that talks standard EGL/GL. All vendor complexity moves below the HAL,
+implemented once per SoC and validated through VTS.
+
+---
+
+## 9. Reference implementation: `plane-control-poc`
+
+The [`rdk-e/graphics-test-apps`](https://github.com/rdk-e/graphics-test-apps)
+repository contains a working proof of concept (`plane-control-poc/`) that is
+this design prototyped over a Unix socket instead of Binder. Its wire protocol
+is `IGraphicsFbProvider` in all but name:
+
+| `PlaneControllerProtocol.h` message | `IGraphicsFbProvider` |
+|---|---|
+| `CreateBufferRequest { width, height }` | `createGraphicsFb(width, height, outInfo)` |
+| `CreateBufferResponse { buffer_id, width, height, stride, offset, format, fd }` | `GraphicsFbInfo` + `ParcelFileDescriptor` |
+| `DestroyBufferRequest { buffer_id }` | `destroyGraphicsFb(graphicsFbId)` |
+| `CommitBufferRequest { buffer_id }` | `commitGraphicsFb(graphicsFbId)` |
+| `ReleaseBufferEvent { buffer_id }` | `onGraphicsFbReleased(oldGraphicsFbId, …)` |
+
+It was tested on Amlogic (`apache-4k-mtc`); Realtek (`xione`) is in progress;
+Broadcom is blocked pending URSR 25.3, which adds the EGL DMA-buf *target*
+support the import path needs.
+
+**What it validates.** The POC confirms the load-bearing parts of this design
+on real hardware:
+
+- **DMA-buf FD + metadata is a sufficient cross-process transport.** The server
+  passes the FD over the socket via `SCM_RIGHTS` alongside `stride`/`offset`/
+  `format`; under Binder this becomes `ParcelFileDescriptor` + `GraphicsFbInfo`.
+- **The server is a thin GBM wrapper.** `drm-backend.cpp` allocates with
+  `gbm_bo_create[_with_modifiers]()` and exports with `gbm_bo_get_fd()`,
+  reading `gbm_bo_get_stride/offset/modifier()` — exactly the DRM vendor-HAL
+  shape in §5, presenting through a DRM atomic commit (`notes.txt`).
+- **The client import is standard EGL.** `OpenGLClient.cpp` imports the FD with
+  `eglCreateImageKHR(EGL_LINUX_DMA_BUF_EXT)` using `EGL_LINUX_DRM_FOURCC_EXT` +
+  `EGL_DMA_BUF_PLANE0_FD/OFFSET/PITCH_EXT`, then binds it to a texture/FBO —
+  exactly §2 and §4.
+
+**What the POC has not yet done — the work this design adds.** Bringing it onto
+the merged interface means closing these gaps:
+
+- **EGL display setup is still vendor-coupled.** The client opens
+  `/dev/dri/card0`, calls `gbm_create_device()`, and hardcodes
+  `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm, …)`. That is the exact code
+  path `getNativeDisplayHandle()` + `getEGLPlatformType()` exist to remove. Per
+  this design the client must take both from the provider and never touch the
+  DRM node or GBM — this is also what lets Broadcom, which has no `card0`/GBM,
+  work through the same client.
+- **No modifier is carried.** The protocol transports `format` only and assumes
+  linear. The server already knows the modifier (`gbm_bo_get_modifier()`); it
+  must be surfaced through `GraphicsFbCapabilities.modifier` and fed to
+  `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT`, which tiled formats (Amlogic AFBC,
+  `DRM_FORMAT_MOD_BROADCOM_UIF`) require.
+- **`format` is per-buffer in the POC**, but is constant per provider — it
+  belongs in `GraphicsFbCapabilities`, read once.
+- **The transport is a raw socket**, to be replaced by the `IGraphicsFbProvider`
+  Binder service.
+
+The POC therefore de-risks the design and is the natural starting point for the
+Amlogic vendor HAL; the transformation is to retarget its client onto the Binder
+interface and drive EGL setup through the provider rather than the DRM node.
+
+---
+
+## Sources
+
+### EGL / DRM
+- [EGL_EXT_image_dma_buf_import](https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import.txt)
+- [EGL_EXT_image_dma_buf_import_modifiers](https://github.com/KhronosGroup/EGL-Registry/blob/main/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt)
+- [DRM format modifiers — Collabora](https://www.collabora.com/news-and-blog/blog/2017/02/09/notes-on-drm-format-modifiers/)
+
+### Linux kernel
+- [DMA-BUF driver API](https://docs.kernel.org/driver-api/dma-buf.html)
+- [DMA-BUF heaps](https://docs.kernel.org/userspace-api/dma-buf-heaps.html)
+
+### Broadcom refsw
+- `refsw_release_unified_URSR_26_20260331-bme.tgz` — `BSEAV/lib/dme/player/texturing/TextureData.cpp`:
+  `NEXUS_Surface_CreateDescriptor_driver()` DMA-buf export, `NexusToDrm()` format mapping,
+  `eglCreateImageKHR(EGL_LINUX_DMA_BUF_EXT)` import.
+
+### RDK vendor GL backends
+- [westeros-gl-brcm](https://github.com/rdkcentral/westeros-gl-brcm) — Broadcom Nexus GL backend (no GBM)
+- [westeros-gl-drm](https://github.com/rdkcentral/westeros-gl-drm) — DRM/GBM GL backend
+- [westeros-soc-mtk](https://github.com/rdk-e/westeros-soc-mtk) — Mediatek GL backend
+- [westeros](https://github.com/rdkcentral/westeros) — main compositor
+- [essos](https://github.com/rdkcentral/essos) — EGL/input abstraction (to be retired)
+
+### Android
+- [AIDL for Hardware Composer HAL](https://source.android.com/docs/core/graphics/aidl-hwc)
+- [BufferQueue and Gralloc](https://source.android.com/docs/core/graphics/arch-bq-gralloc)

--- a/docs/transformation/westeros_graphics_fb_transform.md
+++ b/docs/transformation/westeros_graphics_fb_transform.md
@@ -7,10 +7,12 @@ transformed to render through the Plane Control HAL's graphics frame buffer
 interface, `IGraphicsFbProvider`, replacing the per-vendor Westeros GL
 backends with a single, platform-agnostic implementation.
 
-The HAL contract is vendor-agnostic and complete: it covers EGL display
-setup, DMA-buf buffer allocation, and presentation. The compositor needs
-exactly those three things, so all SoC-specific graphics code moves below
-the HAL boundary and is implemented once per platform.
+The HAL contract covers DMA-buf buffer allocation and presentation — the two
+concerns that carry the bulk of the per-vendor backend code. The compositor
+renders offscreen to FBOs and presents via `commitGraphicsFb()`, so EGL
+display/context setup needs no native window and is done in the client's platform
+EGL layer. All vendor allocation and presentation code moves below the HAL
+boundary and is implemented once per platform.
 
 Related interface: [`planecontrol/current`](../../planecontrol/current/docs/plane_control.md).
 Related issues: #603 (this work), #329 (PlaneControl controller audit),
@@ -28,21 +30,18 @@ A graphics plane exposes a provider, obtained from `IPlaneControl`:
     in IGraphicsFbProviderListener graphicsFbProviderListener);
 ```
 
-`IGraphicsFbProvider` gives the compositor all three things it needs:
+`IGraphicsFbProvider` gives the compositor the two things that must cross the
+HAL boundary — renderable buffers and presentation:
 
 ```aidl
 @VintfStability
 interface IGraphicsFbProvider {
-    // EGL setup — replaces vendor-specific native display initialisation
-    long getNativeDisplayHandle();
-    int  getEGLPlatformType();
-
-    // Buffer lifecycle — replaces GBM / Nexus allocation
+    // Buffer lifecycle — vendor allocation behind a standard FD
     GraphicsFbCapabilities getCapabilities();
     ParcelFileDescriptor   createGraphicsFb(in int width, in int height, out GraphicsFbInfo outInfo);
     void                   destroyGraphicsFb(in int graphicsFbId);
 
-    // Presentation — replaces drmModeSetPlane / NEXUS_SurfaceClient
+    // Presentation
     boolean commitGraphicsFb(in int graphicsFbId);
 }
 
@@ -131,8 +130,8 @@ re-implements EGL display init, buffer allocation, and presentation:
 Each backend handles the same three concerns differently:
 
 1. **EGL display initialisation** — vendor-specific native display type.
-2. **Buffer allocation** — GBM on DRM, Nexus on Broadcom.
-3. **Buffer presentation** — `drmModeSetPlane` on DRM, `NEXUS_SurfaceClient` on Broadcom.
+2. **Buffer allocation** — GBM on DRM platforms, a vendor allocator otherwise.
+3. **Buffer presentation** — `drmModeSetPlane` on DRM, a vendor presentation API otherwise.
 
 Every new SoC needs a new backend; every bug fix may need porting across all
 of them. The architecture does not scale.
@@ -141,10 +140,13 @@ of them. The architecture does not scale.
 
 ## 4. The transformation: one platform-agnostic Westeros
 
-The provider supplies the EGL display, the renderable buffers, and the
-presentation lifecycle, so one implementation works on every vendor. The
-SoC differences (GBM vs Nexus allocation, DRM vs Nexus presentation) live
-entirely inside the vendor HAL.
+The provider supplies the renderable buffers and the presentation lifecycle, so
+one implementation works on every vendor. The vendor differences in allocation
+and presentation live entirely inside the vendor HAL. EGL display/context
+creation stays client-side: because the compositor renders offscreen to FBOs and
+presents via `commitGraphicsFb()` (never `eglSwapBuffers()` to a native window),
+it needs only an `EGLDisplay`, a context, and the DMA-buf import extension — no
+native window, so nothing about the display has to cross the HAL.
 
 ```cpp
 // ONE Westeros GL backend — works on every vendor
@@ -152,10 +154,10 @@ void init(sp<IPlaneControl> planeControl, int planeIndex) {
     provider = planeControl->getGraphicsFbProvider(planeIndex, listener);
     // provider is @nullable: confirm the plane is GRAPHICS before calling.
 
-    // 1. EGL setup — platform-agnostic, no vendor native-display code path
-    EGLDisplay dpy = eglGetPlatformDisplay(
-        provider->getEGLPlatformType(),
-        (void*)provider->getNativeDisplayHandle(), nullptr);
+    // 1. EGL setup — client-side, offscreen: the compositor renders to FBOs, so
+    //    it needs only an EGLDisplay + context from the platform's offscreen EGL
+    //    (e.g. EGL_MESA_platform_surfaceless / EGL_EXT_platform_device).
+    EGLDisplay dpy = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
     eglInitialize(dpy, nullptr, nullptr);
     EGLContext ctx = eglCreateContext(dpy, config, EGL_NO_CONTEXT, ctxAttrs);
 
@@ -211,9 +213,10 @@ void onGraphicsFbReleased(int oldGraphicsFbId, long elapsedRealtimeNanos) {
 }
 ```
 
-This replaces ~13,000 lines of vendor-specific GL backend code with one
-implementation that talks only standard EGL/GL — no GBM, no Nexus, no
-vendor `#include`.
+This replaces ~13,000 lines of vendor-specific GL backend code — buffer
+allocation and presentation, the bulk of each backend — with one implementation
+that talks only standard EGL/GL. Offscreen EGL-display creation stays in the
+client's platform EGL layer.
 
 ---
 
@@ -232,22 +235,21 @@ wrapper, not the memory itself.
                        - importable by GPU, display, video HW
                                   │ backed by
                 ┌─────────────────┼─────────────────┐
-            CMA pages          GEM heap        Nexus-managed
-            (RTK / AML)        (DRM)            (Broadcom)
+            CMA pages          GEM heap        Vendor carveout
 ```
 
-The physical memory may be CMA, a GEM heap, vendor carveout, or Nexus-managed
-memory. Any kernel driver that manages physical memory can implement the
-exporter callbacks (`struct dma_buf_ops`). This is why the interface names no
-allocator: the DMA-buf FD is the universal transport, and the allocation
-behind it is vendor-specific and hidden by the kernel.
+The physical memory may be CMA, a GEM heap, or vendor carveout. Any kernel
+driver that manages physical memory can implement the exporter callbacks
+(`struct dma_buf_ops`). This is why the interface names no allocator: the
+DMA-buf FD is the universal transport, and the allocation behind it is
+vendor-specific and hidden by the kernel.
 
-### DRM platforms (Realtek, Amlogic, Mediatek)
+### DRM/GBM platforms
 
 These use the standard Linux DRM/GBM stack. The vendor HAL wraps it:
 
 ```c
-// DRM vendor HAL — wraps kernel GBM allocation
+// DRM/GBM vendor HAL — wraps kernel GBM allocation
 ParcelFileDescriptor createGraphicsFb(int w, int h, GraphicsFbInfo* info) {
     struct gbm_bo* bo = gbm_bo_create(gbm, w, h,
         GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
@@ -259,59 +261,15 @@ ParcelFileDescriptor createGraphicsFb(int w, int h, GraphicsFbInfo* info) {
 }
 ```
 
-### Broadcom (Nexus) — no GBM, same DMA-buf result
+### Platforms without GBM
 
-Broadcom has no DRM/KMS or GBM. Allocation goes through the proprietary
-Nexus userspace API, then exports a kernel DMA-buf FD:
-
-```c
-// Broadcom vendor HAL — Nexus allocation + kernel DMA-buf export
-ParcelFileDescriptor createGraphicsFb(int w, int h, GraphicsFbInfo* info) {
-    NEXUS_SurfaceCreateSettings settings;
-    NEXUS_Surface_GetDefaultCreateSettings(&settings);
-    settings.width = w; settings.height = h;
-    settings.pixelFormat = NEXUS_PixelFormat_eA8_R8_G8_B8;
-    NEXUS_SurfaceHandle surface = NEXUS_Surface_Create(&settings);
-    int fd = nexus_surface_export_dmabuf(surface);   // kernel DMA-buf export
-    info->stride = settings.pitch;
-    info->offset = 0;
-    return ParcelFileDescriptor(fd);
-}
-```
-
-That this works on Broadcom is not speculative. Broadcom's own DME player
-framework already exports Nexus surfaces as DMA-buf FDs and imports them into
-EGL with exactly the metadata this interface carries
-(`BSEAV/lib/dme/player/texturing/TextureData.cpp`, Broadcom refsw
-`refsw_release_unified_URSR_26_*`):
-
-```c
-// TextureData.cpp — Broadcom already uses EGL_LINUX_DMA_BUF_EXT on Nexus surfaces
-uint32_t fourcc; uint64_t modifier;
-NexusToDrm(status.pixelFormat, &fourcc, &modifier);   // Nexus format → DRM fourcc/modifier
-int fd;
-NEXUS_Surface_CreateDescriptor_driver(surface, &fd);  // Nexus → DMA-buf FD export
-
-EGLint attr[] = {
-    EGL_WIDTH,                          (EGLint)status.width,
-    EGL_HEIGHT,                         (EGLint)status.height,
-    EGL_LINUX_DRM_FOURCC_EXT,           (EGLint)fourcc,
-    EGL_DMA_BUF_PLANE0_FD_EXT,          fd,
-    EGL_DMA_BUF_PLANE0_OFFSET_EXT,      (EGLint)properties.pixelMemoryOffset,
-    EGL_DMA_BUF_PLANE0_PITCH_EXT,       (EGLint)status.pitch,
-    EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, (EGLint)(modifier >> 32),
-    EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, (EGLint)(modifier & 0xffffffff),
-    EGL_NONE
-};
-eglImage = eglCreateImageKHR(eglGetCurrentDisplay(),
-    EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attr);
-```
-
-`NexusToDrm()` maps Nexus pixel formats to DRM fourcc codes and modifiers
-(including `DRM_FORMAT_MOD_BROADCOM_UIF` for tiled formats). The chain is pure
-Nexus → kernel DMA-buf → EGL, with no GBM anywhere. The Broadcom graphics HAL
-performs this same sequence internally and returns the FD as
-`ParcelFileDescriptor` and the geometry as `GraphicsFbInfo`.
+Platforms with no DRM/GBM stack allocate through their own userspace allocator
+and export the result as a kernel DMA-buf FD. From the compositor's side the
+chain is identical — allocate, export as a DMA-buf FD, import into EGL with
+`EGL_LINUX_DMA_BUF_EXT` — so the interface names no allocator. The vendor HAL
+performs the allocation internally and returns the FD as `ParcelFileDescriptor`
+with geometry in `GraphicsFbInfo`; tiled formats are conveyed through
+`GraphicsFbCapabilities.modifier`.
 
 ---
 
@@ -324,9 +282,9 @@ the display planes support. A "client allocates" model (as in
 [Wayland linux-dmabuf-v1](https://wayland.app/protocols/linux-dmabuf-v1))
 works there because the kernel interface is standard.
 
-It does not work on Broadcom: there is no standard DRM/KMS path, and allocation
-goes through Nexus. A client-allocates model would force the middleware to know
-about Nexus, breaking the abstraction. Allocating in the HAL keeps the vendor
+It does not generalise: on platforms with no standard DRM/KMS path, a
+client-allocates model would force the middleware to know the vendor allocator's
+details, breaking the abstraction. Allocating in the HAL keeps the vendor
 interface difference below the boundary: the compositor calls
 `createGraphicsFb()` and never learns which kernel path was used.
 
@@ -342,8 +300,8 @@ This mirrors Android's proven graphics buffer model:
 | `HardwareBuffer` (FD + metadata) | `ParcelFileDescriptor` + `GraphicsFbInfo` |
 | `eglGetNativeClientBufferANDROID()` → opaque import | `eglCreateImageKHR(EGL_LINUX_DMA_BUF_EXT)` → explicit metadata |
 | `IComposerClient.presentDisplay()` | `commitGraphicsFb()` |
-| `IComposerClient` display config | `getNativeDisplayHandle()` + `getEGLPlatformType()` |
-| Vendor gralloc implementation | Vendor HAL: GBM on DRM, Nexus on Broadcom |
+| `IComposerClient` display config | Client-side offscreen EGL (out of HAL scope) |
+| Vendor gralloc implementation | Vendor HAL: GBM on DRM, vendor allocator otherwise |
 
 The architecture is identical — vendor-opaque allocation behind a standard
 HAL, with the compositor never touching vendor code. The only difference is
@@ -359,7 +317,7 @@ explicit DRM metadata where Android uses an opaque `HardwareBuffer`.
 | `westeros-gl-brcm` (530+ lines) | Eliminated | `IGraphicsFbProvider` vendor HAL |
 | `westeros-gl-drm` (8,384 lines) | Eliminated | `IGraphicsFbProvider` vendor HAL |
 | `westeros-soc-mtk` (3,936 lines) | Eliminated | `IGraphicsFbProvider` vendor HAL |
-| Essos EGL abstraction | Eliminated when retired | `getNativeDisplayHandle()` / `getEGLPlatformType()` |
+| Essos EGL abstraction | Reduced to a thin client-side offscreen-EGL shim | Client-side EGL (out of HAL scope) |
 | Custom FD-transport header (`GraphicsDmaBufFrameFd.h`) | Eliminated | `ParcelFileDescriptor` (built-in AIDL) |
 | `getNativeGraphicsWindowHandle()` | Eliminated | `createGraphicsFb()` returns a DMA-buf FD |
 | `flipGraphicsBuffer()` | Eliminated | `commitGraphicsFb()` |
@@ -385,9 +343,10 @@ is `IGraphicsFbProvider` in all but name:
 | `CommitBufferRequest { buffer_id }` | `commitGraphicsFb(graphicsFbId)` |
 | `ReleaseBufferEvent { buffer_id }` | `onGraphicsFbReleased(oldGraphicsFbId, …)` |
 
-It was tested on Amlogic (`apache-4k-mtc`); Realtek (`xione`) is in progress;
-Broadcom is blocked pending URSR 25.3, which adds the EGL DMA-buf *target*
-support the import path needs.
+It has been validated on DRM/GBM hardware. Platforms without a DRM/GBM stack
+need a kernel DMA-buf export path present in their firmware before the vendor
+HAL can be implemented; where that is a per-vendor enablement dependency it is
+tracked separately.
 
 **What it validates.** The POC confirms the load-bearing parts of this design
 on real hardware:
@@ -407,26 +366,25 @@ on real hardware:
 **What the POC has not yet done — the work this design adds.** Bringing it onto
 the merged interface means closing these gaps:
 
-- **EGL display setup is still vendor-coupled.** The client opens
+- **EGL display setup is still vendor-coupled in the POC.** The client opens
   `/dev/dri/card0`, calls `gbm_create_device()`, and hardcodes
-  `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm, …)`. That is the exact code
-  path `getNativeDisplayHandle()` + `getEGLPlatformType()` exist to remove. Per
-  this design the client must take both from the provider and never touch the
-  DRM node or GBM — this is also what lets Broadcom, which has no `card0`/GBM,
-  work through the same client.
+  `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm, …)`. Per this design the
+  client instead creates an **offscreen** `EGLDisplay` (surfaceless/device EGL)
+  and never opens the DRM node — it only renders to FBOs and presents via
+  `commitGraphicsFb()`, which also lets platforms without `card0`/GBM run the
+  same client.
 - **No modifier is carried.** The protocol transports `format` only and assumes
   linear. The server already knows the modifier (`gbm_bo_get_modifier()`); it
   must be surfaced through `GraphicsFbCapabilities.modifier` and fed to
-  `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT`, which tiled formats (Amlogic AFBC,
-  `DRM_FORMAT_MOD_BROADCOM_UIF`) require.
+  `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT`, which tiled formats require.
 - **`format` is per-buffer in the POC**, but is constant per provider — it
   belongs in `GraphicsFbCapabilities`, read once.
 - **The transport is a raw socket**, to be replaced by the `IGraphicsFbProvider`
   Binder service.
 
 The POC therefore de-risks the design and is the natural starting point for the
-Amlogic vendor HAL; the transformation is to retarget its client onto the Binder
-interface and drive EGL setup through the provider rather than the DRM node.
+first vendor HAL; the transformation is to retarget its client onto the Binder
+interface and create the EGL display offscreen rather than from the DRM node.
 
 ---
 
@@ -440,11 +398,6 @@ interface and drive EGL setup through the provider rather than the DRM node.
 ### Linux kernel
 - [DMA-BUF driver API](https://docs.kernel.org/driver-api/dma-buf.html)
 - [DMA-BUF heaps](https://docs.kernel.org/userspace-api/dma-buf-heaps.html)
-
-### Broadcom refsw
-- `refsw_release_unified_URSR_26_20260331-bme.tgz` — `BSEAV/lib/dme/player/texturing/TextureData.cpp`:
-  `NEXUS_Surface_CreateDescriptor_driver()` DMA-buf export, `NexusToDrm()` format mapping,
-  `eglCreateImageKHR(EGL_LINUX_DMA_BUF_EXT)` import.
 
 ### RDK vendor GL backends
 - [westeros-gl-brcm](https://github.com/rdkcentral/westeros-gl-brcm) — Broadcom Nexus GL backend (no GBM)

--- a/docs/transformation/westeros_graphics_fb_transform.md
+++ b/docs/transformation/westeros_graphics_fb_transform.md
@@ -47,7 +47,7 @@ interface IGraphicsFbProvider {
 
 @VintfStability
 oneway interface IGraphicsFbProviderListener {
-    void onGraphicsFbReleased(in int oldGraphicsFbId, in long elapsedRealtimeNanos);
+    void onGraphicsFbReleased(in int oldGraphicsFbId, in long timestampNs);
 }
 ```
 
@@ -208,7 +208,7 @@ void renderAndPresent() {
 }
 
 // IGraphicsFbProviderListener callback
-void onGraphicsFbReleased(int oldGraphicsFbId, long elapsedRealtimeNanos) {
+void onGraphicsFbReleased(int oldGraphicsFbId, long timestampNs) {
     findFrame(oldGraphicsFbId).available = true;   // oldGraphicsFbId == -1 on first release
 }
 ```

--- a/docs/transformation/westeros_graphics_fb_transform.md
+++ b/docs/transformation/westeros_graphics_fb_transform.md
@@ -172,7 +172,8 @@ void init(sp<IPlaneControl> planeControl, int planeIndex) {
 
         // 4. Import into EGL — identical on every vendor. Note: fd may be shared
         //    across buffers; geometry is per-buffer, so key on info.offset.
-        EGLAttrib attrs[] = {
+        // eglCreateImageKHR takes a const EGLint* attribute list.
+        EGLint attrs[] = {
             EGL_WIDTH,                          info.pixelWidth,
             EGL_HEIGHT,                         info.pixelHeight,
             EGL_LINUX_DRM_FOURCC_EXT,           caps.format,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,8 @@ nav:
     - Systemd: vsi/systemd/current/systemd.md
     - Kernel: '!include vsi/kernel/current/mkdocs.yml'
     - Linux Input: '!include vsi/linuxinput/current/mkdocs.yml'
+  - Transformation Guides:
+    - Westeros onto IGraphicsFbProvider: transformation/westeros_graphics_fb_transform.md
   - Vendor Tests Suites (VTS):
     - Levels of Test: external_content/ut-core-wiki/3.-Standards:-Levels-of-Test-for-Vendor-Layer.md
     - Level 4:

--- a/planecontrol/current/com/rdk/hal/planecontrol/IGraphicsFbProvider.aidl
+++ b/planecontrol/current/com/rdk/hal/planecontrol/IGraphicsFbProvider.aidl
@@ -105,26 +105,4 @@ interface IGraphicsFbProvider
      * @see createGraphicsFb()
      */
     void destroyGraphicsFb(in int graphicsFbId);
-
-    /**
-     * Gets a native display handle
-     * 
-     * Used by the compositor with eglGetPlatformDisplay() so EGL display
-     * initialisation does not require vendor-specific code paths.
-     * 
-     * @returns the vendor-specific native display handle for EGL setup.
-     * 
-     */
-    long getNativeDisplayHandle();
-    
-    /**
-     * Gets the EGL Platform Type
-     * 
-     * The platform type is paired with getNativeDisplayHandle() for eglGetPlatformDisplay().
-     *
-     * @returns the EGL_PLATFORM_* constant (e.g. EGL_PLATFORM_GBM_KHR or a
-     * vendor-defined value) that pairs with getNativeDisplayHandle() for
-     * eglGetPlatformDisplay().
-     */
-    int getEGLPlatformType();
 }

--- a/planecontrol/current/com/rdk/hal/planecontrol/IGraphicsFbProviderListener.aidl
+++ b/planecontrol/current/com/rdk/hal/planecontrol/IGraphicsFbProviderListener.aidl
@@ -30,10 +30,14 @@ oneway interface IGraphicsFbProviderListener
 {
     /**
      * @brief     Called after a call to commitGraphicsFb() when the Graphics Frame Buffer has become current.
-     * @param[in] oldGraphicsFbId    The Frame Id of the old frame replaced by the newly committed frame.
-     * @param[in] elapsedRealtimeNanos  The CLOCK_MONOTONIC time when the old graphics frame was replaced by the new.
+     * @param[in] oldGraphicsFbId  The Frame Id of the old frame replaced by the newly committed frame.
+     * @param[in] timestampNs      The CLOCK_MONOTONIC time, in nanoseconds, at which the old frame was
+     *                             replaced by the new one. The client compares this against the
+     *                             CLOCK_MONOTONIC time of its commitGraphicsFb() call to measure
+     *                             commit-to-present latency; CLOCK_MONOTONIC is system-wide, so the two
+     *                             readings are directly comparable across processes.
      *
      * If no old frame exists (e.g. on the first invocation), this callback is invoked with oldGraphicsFbId set to -1.
      */
-    void onGraphicsFbReleased(in int oldGraphicsFbId, in long elapsedRealtimeNanos);
+    void onGraphicsFbReleased(in int oldGraphicsFbId, in long timestampNs);
 }

--- a/planecontrol/current/docs/plane_control.md
+++ b/planecontrol/current/docs/plane_control.md
@@ -217,7 +217,7 @@ Use the returned graphics buffer and metadata with the client graphics stack (fo
 Call `IGraphicsFbProvider.commitGraphicsFb(graphicsFbId)` to queue the frame for presentation.
 This call is non-blocking.
 6. Reuse released buffers:
-Wait for `IGraphicsFbProviderListener.onGraphicsFbReleased(oldGraphicsFbId, elapsedRealtimeNanos)` before reusing a previously displayed buffer.
+Wait for `IGraphicsFbProviderListener.onGraphicsFbReleased(oldGraphicsFbId, timestampNs)` before reusing a previously displayed buffer.
 7. Destroy buffers when no longer needed:
 Call `IGraphicsFbProvider.destroyGraphicsFb(graphicsFbId)` for each created buffer during shutdown or reconfiguration.
 
@@ -245,7 +245,7 @@ sequenceDiagram
     Provider->>Plane: Queue frame for display
 
     Plane-->>Provider: Previous frame released
-    Provider-->>Listener: onGraphicsFbReleased(oldGraphicsFbId, elapsedRealtimeNanos)
+    Provider-->>Listener: onGraphicsFbReleased(oldGraphicsFbId, timestampNs)
     Listener-->>Client: Buffer available for reuse
 
     Client->>Provider: destroyGraphicsFb(graphicsFbId)


### PR DESCRIPTION
## Summary

A single branch carrying the interface change and the transformation guide.

**Interface (`planecontrol/current/IGraphicsFbProvider.aidl`):** remove `getNativeDisplayHandle()` and `getEGLPlatformType()`. A native display is a process-local, vendor-specific object and cannot cross the Binder boundary. Because presentation is via `commitGraphicsFb()` (offscreen FBO render, not a window surface), the compositor needs no native display — EGL display/context setup stays client-side in the platform EGL layer. The interface carries only buffer allocation and presentation.

**Doc (`docs/transformation/westeros_graphics_fb_transform.md`):**
- Scope the HAL contract to **buffer allocation + presentation**.
- Rewrite the EGL-init narrative for offscreen, client-side setup.
- Keep it **vendor-neutral**: describe the universal DMA-buf mechanism (open DRM/GBM example, generic "platforms without GBM"), and reference only the public Westeros backends — no proprietary vendor API or firmware detail.

Resolves the docs + interface portion of #603.

## Notes for reviewers

- `current/` tracks AIDL source only (bindings are generated at build/freeze), so there are no generated files to regenerate here.
- This is a **breaking** removal on `current`. `IGraphicsFbProvider` is present in the `0.1.0.0` frozen snapshot but not `0.2.0.0`/`0.3.0.0`; freeze/compat handling is left to the release process.
- Background discussion: #620.
