### PR TITLE
fix(build): guard dev wrapper scripts against cross/OE env + document 3rd-party integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ single-component release would have been.
                              # branch + tag)
 ```
 
-### Production build (Yocto/BitBake)
+### Consuming the interfaces (build with CMake directly)
 
-Production and third-party build systems **invoke CMake directly** — the
-`build_*.sh` wrapper scripts are developer/architecture tools that require a
-native host toolchain and will refuse to run in a cross/OpenEmbedded
+Integrators and production build systems (Yocto/BitBake, buildroot, a CMake
+superbuild) **invoke CMake directly** and select what to build through `-D`
+switches. The `build_*.sh` wrapper scripts are developer/architecture-team tools
+that require a native host toolchain and refuse to run in a cross/OpenEmbedded
 environment. See [Third-Party Build Integration](docs/standards/build_integration.md)
-for the full integration contract, required variables, and recipe patterns.
+for the full contract and reference recipes.
 
 libbinder is built and staged by the separate **`linux-binder`** recipe
 (`DEPENDS = "linux-binder"`). The HAL libraries are then built **per component**
@@ -161,6 +162,10 @@ no AIDL compiler, and no linux_binder_idl source.
 A component absent from the manifest falls back to its `default:` entry.
 
 ## Scripts
+
+These are developer and architecture-team tools: they require a native host
+toolchain and refuse to run in a cross/OpenEmbedded environment. Integrators
+build with CMake directly — see [Consuming the interfaces](#consuming-the-interfaces-build-with-cmake-directly).
 
 | Script | Role |
 | ------ | ---- |
@@ -255,7 +260,9 @@ Used by `build_binder.sh` and `build_interfaces.sh` only:
 **Not used in production Yocto builds**.
 
 The full two-stage dev and production build workflows are covered in the
-[Quick Start](#quick-start) section above.
+[Quick Start](#quick-start) section above. See
+[Third-Party Build Integration](docs/standards/build_integration.md) for the
+full consumer/integrator build contract.
 
 ## Additional Documentation
 
@@ -265,6 +272,8 @@ The full two-stage dev and production build workflows are covered in the
   - Kernel configuration and runtime setup
   - Systemd service configuration
   - 32-bit userspace on 64-bit kernel support
+
+- **[docs/standards/build_integration.md](docs/standards/build_integration.md)** - Consumer/integrator build contract: direct-CMake switches, required variables, reference BitBake/Bob recipes
 
 - **[tests/README.md](tests/README.md)** - On-demand build verification
   - `tests/smoke_test.sh` - exercises the `all`, `manifest` and per-version build paths

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ single-component release would have been.
 
 ### Production build (Yocto/BitBake)
 
+Production and third-party build systems **invoke CMake directly** — the
+`build_*.sh` wrapper scripts are developer/architecture tools that require a
+native host toolchain and will refuse to run in a cross/OpenEmbedded
+environment. See [Third-Party Build Integration](docs/standards/build_integration.md)
+for the full integration contract, required variables, and recipe patterns.
+
 libbinder is built and staged by the separate **`linux-binder`** recipe
 (`DEPENDS = "linux-binder"`). The HAL libraries are then built **per component**
 from that staged SDK — each `<module>/<version>/` is self-contained (committed

--- a/build_binder.sh
+++ b/build_binder.sh
@@ -93,6 +93,13 @@ MY_PATH="$(realpath "${BASH_SOURCE[0]}")"
 MY_DIR="$(dirname "${MY_PATH}")"
 REPO_URL="https://github.com/rdkcentral/linux_binder_idl"
 
+# This is a developer/architecture wrapper — it needs a native host toolchain.
+# Yocto/cross builds must call CMake directly (see BUILD.md). Abort early in a
+# cross/OE environment rather than silently producing broken/empty output (#624).
+# Use 'return' when sourced so an interactive shell isn't killed.
+source "${MY_DIR}/dev_env_guard.sh"
+halif_guard_dev_host_env || return 1 2>/dev/null || exit 1
+
 # Pinned toolchain revision. The default is the first non-comment line of
 # binder_sdk.version (committed to the repo so the module-local generated C++
 # stays matched to the generator that produced it); override with the

--- a/build_binder.sh
+++ b/build_binder.sh
@@ -94,9 +94,14 @@ MY_DIR="$(dirname "${MY_PATH}")"
 REPO_URL="https://github.com/rdkcentral/linux_binder_idl"
 
 # This is a developer/architecture wrapper — it needs a native host toolchain.
-# Yocto/cross builds must call CMake directly (see BUILD.md). Abort early in a
-# cross/OE environment rather than silently producing broken/empty output (#624).
-# Use 'return' when sourced so an interactive shell isn't killed.
+# Yocto/cross builds must call CMake directly (see docs/standards/build_integration.md).
+# Abort early in a cross/OE environment rather than silently producing
+# broken/empty output (#624). Use 'return' when sourced so an interactive shell
+# isn't killed.
+#
+# Note: unlike build_modules.sh / build_interfaces.sh, the `clean` argument here
+# means "force rebuild" (it removes the SDK and rebuilds), so it is a build
+# operation and is intentionally NOT exempt from the guard.
 source "${MY_DIR}/dev_env_guard.sh"
 halif_guard_dev_host_env || return 1 2>/dev/null || exit 1
 

--- a/build_interfaces.sh
+++ b/build_interfaces.sh
@@ -42,6 +42,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 
+# Host-toolchain guard (#624): build / sdk operations need a native toolchain,
+# and Yocto/cross builds must call CMake directly (see BUILD.md). clean/help do
+# no toolchain work, so they stay usable in any environment.
+case "${1:-}" in
+    clean|cleanstable|cleanall|--help|-h|"") ;;
+    *) source "$SCRIPT_DIR/dev_env_guard.sh"; halif_guard_dev_host_env || exit 1 ;;
+esac
+
 # Show help if no arguments or help requested
 if [[ $# -eq 0 ]] || [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
     cat << EOF

--- a/build_interfaces.sh
+++ b/build_interfaces.sh
@@ -43,8 +43,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 
 # Host-toolchain guard (#624): build / sdk operations need a native toolchain,
-# and Yocto/cross builds must call CMake directly (see BUILD.md). clean/help do
-# no toolchain work, so they stay usable in any environment.
+# and Yocto/cross builds must call CMake directly (see
+# docs/standards/build_integration.md). clean/help do no toolchain work, so
+# they stay usable in any environment.
 case "${1:-}" in
     clean|cleanstable|cleanall|--help|-h|"") ;;
     *) source "$SCRIPT_DIR/dev_env_guard.sh"; halif_guard_dev_host_env || exit 1 ;;
@@ -92,7 +93,10 @@ Build Configuration:
   Use CC/CXX environment variables to control compiler and flags:
     CC=gcc CXX=g++ ./build_interfaces.sh <module>              # Release (default)
     CC="gcc -g" CXX="g++ -g" ./build_interfaces.sh <module>   # Debug build
-    CC=arm-linux-gnueabihf-gcc ./build_interfaces.sh <module>  # Cross-compile
+
+  Cross-compilation / Yocto: this wrapper is host-only and refuses to run in a
+  cross/OpenEmbedded environment. Production/cross builds invoke CMake directly
+  — see docs/standards/build_integration.md.
 
 Examples:
   # Building

--- a/build_modules.sh
+++ b/build_modules.sh
@@ -145,6 +145,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 
+# Host-toolchain guard (#624): build / sdk operations need a native toolchain,
+# and Yocto/cross builds must call CMake directly (see BUILD.md). clean/help do
+# no toolchain work, so they stay usable in any environment.
+case "${1:-}" in
+    clean|cleanall|--help|-h|--h|"") ;;
+    *) source "$SCRIPT_DIR/dev_env_guard.sh"; halif_guard_dev_host_env || exit 1 ;;
+esac
+
 # Suppress three classes of unfixable upstream noise so the verification
 # build output stays readable.
 #

--- a/build_modules.sh
+++ b/build_modules.sh
@@ -95,15 +95,11 @@ Build Configuration:
     # With custom flags
     CC=gcc CFLAGS="-O2 -g" CXXFLAGS="-O2 -g" ./build_modules.sh all
 
-    # Cross-compilation (Yocto pattern)
-    CC=arm-linux-gnueabihf-gcc \
-    CXX=arm-linux-gnueabihf-g++ \
-    CFLAGS="-march=armv7-a" \
-    CXXFLAGS="-march=armv7-a" \
-    LDFLAGS="-Wl,--hash-style=gnu" \
-    ./build_modules.sh all --sdk-dir /opt/sysroot/usr
-
   Supported variables: CC, CXX, CFLAGS, CXXFLAGS, LDFLAGS
+
+  Cross-compilation / Yocto: this wrapper is host-only and refuses to run in a
+  cross/OpenEmbedded environment. Production and cross builds invoke CMake
+  directly — see docs/standards/build_integration.md.
 
 Examples:
   # Basic usage
@@ -117,16 +113,14 @@ Examples:
   ./build_modules.sh cleanall                         # Remove out/ and build/
   ./build_modules.sh all --clean                      # Clean before build
 
-  # Custom SDK location (for Yocto/cross-compilation)
-  ./build_modules.sh all --sdk-dir /opt/sysroot/usr
+  # Custom SDK location (host dev with a non-default SDK prefix)
+  ./build_modules.sh all --sdk-dir /opt/sdk/usr
 
   # Parallel builds
   ./build_modules.sh all --jobs 8                     # 8 parallel jobs
 
-  # Yocto/BitBake integration
-  CC="${CC}" CXX="${CXX}" \
-  CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" \
-  ./build_modules.sh all --sdk-dir ${STAGING_DIR}${prefix}
+  # Yocto / cross builds do NOT use this script — invoke CMake directly.
+  # See docs/standards/build_integration.md.
 
 Output:
   Libraries: out/target/lib/halif/lib<module>-vcurrent-cpp.so
@@ -146,8 +140,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR"
 
 # Host-toolchain guard (#624): build / sdk operations need a native toolchain,
-# and Yocto/cross builds must call CMake directly (see BUILD.md). clean/help do
-# no toolchain work, so they stay usable in any environment.
+# and Yocto/cross builds must call CMake directly (see
+# docs/standards/build_integration.md). clean/help do no toolchain work, so
+# they stay usable in any environment.
 case "${1:-}" in
     clean|cleanall|--help|-h|--h|"") ;;
     *) source "$SCRIPT_DIR/dev_env_guard.sh"; halif_guard_dev_host_env || exit 1 ;;

--- a/dev_env_guard.sh
+++ b/dev_env_guard.sh
@@ -53,10 +53,13 @@ halif_guard_dev_host_env() {
     # A cross CC set outside an OE shell: compare target triples. (Inside an OE
     # shell PATH may already point cc at the cross compiler, so this can match
     # the host triple — the OECORE check above is what catches that case.)
+    # Derive the host triple from a *fixed* /usr/bin compiler first, so a cross
+    # toolchain that prepends PATH can't mask the host triple; fall back to a
+    # PATH-resolved cc/gcc only when the fixed paths are absent.
     if [ -n "${CC:-}" ]; then
         local cc_machine host_machine
         cc_machine="$(${CC} -dumpmachine 2>/dev/null || true)"
-        host_machine="$(cc -dumpmachine 2>/dev/null || gcc -dumpmachine 2>/dev/null || true)"
+        host_machine="$(/usr/bin/gcc -dumpmachine 2>/dev/null || /usr/bin/cc -dumpmachine 2>/dev/null || cc -dumpmachine 2>/dev/null || gcc -dumpmachine 2>/dev/null || true)"
         if [ -n "$cc_machine" ] && [ -n "$host_machine" ] && [ "$cc_machine" != "$host_machine" ]; then
             reasons+=("cross-compiler detected (CC -> ${cc_machine}, host ${host_machine})")
         fi

--- a/dev_env_guard.sh
+++ b/dev_env_guard.sh
@@ -27,7 +27,7 @@
 # team to test interfaces and cut releases on a developer machine — they are NOT
 # part of the production build path. Production / cross builds (Yocto/BitBake)
 # MUST invoke CMake directly with the correct variables; see
-# build-tools/linux_binder_idl/BUILD.md ("Production Build (CMake Direct)").
+# docs/standards/build_integration.md (the third-party build contract).
 #
 # Run inside a sourced OpenEmbedded cross environment, a wrapper produces broken
 # or empty output: the host AIDL tool gets cross-compiled (and can't run on the
@@ -64,8 +64,11 @@ halif_guard_dev_host_env() {
 
     [ "${#reasons[@]}" -eq 0 ] && return 0
 
+    # Name the wrapper that sourced us. When a wrapper is *sourced*
+    # (e.g. `source ./build_binder.sh`), $0 is the interactive shell, so prefer
+    # the caller's BASH_SOURCE entry.
     local self
-    self="$(basename "${0:-this script}")"
+    self="$(basename "${BASH_SOURCE[1]:-${0:-this script}}")"
     {
         echo ""
         echo "ERROR: ${self} is a developer/architecture wrapper and requires a native host toolchain."
@@ -74,7 +77,7 @@ halif_guard_dev_host_env() {
         echo ""
         echo "   Production / cross (Yocto/BitBake) builds MUST call CMake directly — these"
         echo "   wrappers are not for production recipes. See:"
-        echo "     build-tools/linux_binder_idl/BUILD.md  (\"Production Build (CMake Direct)\")"
+        echo "     docs/standards/build_integration.md  (Third-Party Build Integration)"
         echo ""
         echo "   To proceed anyway (not recommended): BINDER_ALLOW_CROSS_ENV=1 ./${self} ..."
         echo ""

--- a/dev_env_guard.sh
+++ b/dev_env_guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+#
+# Shared environment guard for the developer / architecture-team wrapper scripts
+# (build_binder.sh, build_modules.sh, build_interfaces.sh).
+#
+# These wrappers assume a NATIVE host toolchain. They exist for the architecture
+# team to test interfaces and cut releases on a developer machine — they are NOT
+# part of the production build path. Production / cross builds (Yocto/BitBake)
+# MUST invoke CMake directly with the correct variables; see
+# build-tools/linux_binder_idl/BUILD.md ("Production Build (CMake Direct)").
+#
+# Run inside a sourced OpenEmbedded cross environment, a wrapper produces broken
+# or empty output: the host AIDL tool gets cross-compiled (and can't run on the
+# build host), and the binder CMake auto-enables BUILD_ENV_YOCTO from OECORE_*,
+# which disables every install() rule — so out/target is silently never staged.
+#
+# This guard fails fast with a clear pointer instead. Override (not recommended)
+# with BINDER_ALLOW_CROSS_ENV=1.
+
+# Returns non-zero (with an explanatory message) when the current environment is
+# a Yocto/cross environment unsuitable for these host wrappers.
+halif_guard_dev_host_env() {
+    [ "${BINDER_ALLOW_CROSS_ENV:-0}" = "1" ] && return 0
+
+    local reasons=()
+
+    # The reliable Yocto signal: an OE shell exports these sysroots, and they are
+    # exactly what the binder CMake keys BUILD_ENV_YOCTO off.
+    if [ -n "${OECORE_NATIVE_SYSROOT:-}" ] || [ -n "${OECORE_TARGET_SYSROOT:-}" ]; then
+        reasons+=("OpenEmbedded/Yocto environment detected (OECORE_*_SYSROOT set)")
+    fi
+
+    # A cross CC set outside an OE shell: compare target triples. (Inside an OE
+    # shell PATH may already point cc at the cross compiler, so this can match
+    # the host triple — the OECORE check above is what catches that case.)
+    if [ -n "${CC:-}" ]; then
+        local cc_machine host_machine
+        cc_machine="$(${CC} -dumpmachine 2>/dev/null || true)"
+        host_machine="$(cc -dumpmachine 2>/dev/null || gcc -dumpmachine 2>/dev/null || true)"
+        if [ -n "$cc_machine" ] && [ -n "$host_machine" ] && [ "$cc_machine" != "$host_machine" ]; then
+            reasons+=("cross-compiler detected (CC -> ${cc_machine}, host ${host_machine})")
+        fi
+    fi
+
+    [ "${#reasons[@]}" -eq 0 ] && return 0
+
+    local self
+    self="$(basename "${0:-this script}")"
+    {
+        echo ""
+        echo "ERROR: ${self} is a developer/architecture wrapper and requires a native host toolchain."
+        local r
+        for r in "${reasons[@]}"; do echo "   - ${r}"; done
+        echo ""
+        echo "   Production / cross (Yocto/BitBake) builds MUST call CMake directly — these"
+        echo "   wrappers are not for production recipes. See:"
+        echo "     build-tools/linux_binder_idl/BUILD.md  (\"Production Build (CMake Direct)\")"
+        echo ""
+        echo "   To proceed anyway (not recommended): BINDER_ALLOW_CROSS_ENV=1 ./${self} ..."
+        echo ""
+    } >&2
+    return 1
+}

--- a/docs/standards/build_integration.md
+++ b/docs/standards/build_integration.md
@@ -37,8 +37,12 @@ C++; they are **never required on a build host or target**.
 3. **HAL modules: point at the staged SDK.** Configure the top-level CMake with
    the staged Binder SDK location. A staged SDK is flat, so headers and libraries
    share one prefix — set both `BINDER_SDK_DIR` and `BINDER_SDK_INCLUDE_DIR` to it.
-4. **Pin the interface versions** to build via `versions_released.yaml` (or
-   `INTERFACE_TARGET`/`AIDL_SRC_VERSION` on the CMake command line).
+4. **Select the version on the CMake command line.** `INTERFACE_TARGET` picks
+   the module(s) and `AIDL_SRC_VERSION` picks the version (`current` or a
+   released `X.Y.Z.W`). The top-level CMake builds one target/version per
+   invocation. `versions_released.yaml` is a convenience manifest consumed by
+   `build_modules.sh` — **not** by CMake — so a build system that wants a whole
+   released cohort iterates the versions itself (one CMake invocation each).
 
 ### CMake variables (Stage 2 — HAL modules)
 
@@ -52,8 +56,8 @@ C++; they are **never required on a build host or target**.
 
 ## Recipe pattern (BitBake)
 
-**Stage 1 — Binder SDK** is delivered by the `linux-binder` recipe. See
-[the Binder SDK BUILD guide](https://github.com/rdkcentral/rdk-halif-aidl/blob/develop/build-tools/linux_binder_idl/BUILD.md)
+**Stage 1 — Binder SDK** is delivered by the `linux-binder` recipe. See the
+[linux_binder_idl BUILD guide](https://github.com/rdkcentral/linux_binder_idl/blob/develop/BUILD.md)
 for the full recipe, cross-compilation flags, and runtime/systemd setup. The
 essential line:
 
@@ -67,21 +71,17 @@ EXTRA_OECMAKE = "-DBUILD_HOST_AIDL=OFF"
 DEPENDS = "linux-binder"
 inherit cmake
 
-do_configure() {
-    cmake -S ${S} -B ${B} \
-          -DINTERFACE_TARGET=all \
-          -DBINDER_SDK_DIR=${STAGING_DIR}${prefix} \
-          -DBINDER_SDK_INCLUDE_DIR=${STAGING_DIR}${prefix}
-}
+# Let the cmake class run configure / compile / install — don't override the
+# tasks. Pass build options via EXTRA_OECMAKE. The CMake install() rules place
+# the libraries under <prefix>/lib/halif, so the class' install step
+# (cmake --install ${B} --prefix ${D}${prefix}) puts them in the right place.
+EXTRA_OECMAKE = " \
+    -DINTERFACE_TARGET=all \
+    -DBINDER_SDK_DIR=${STAGING_DIR}${prefix} \
+    -DBINDER_SDK_INCLUDE_DIR=${STAGING_DIR}${prefix} \
+"
 
-do_compile() {
-    cmake --build ${B} -j ${PARALLEL_MAKE}
-}
-
-do_install() {
-    install -d ${D}${libdir}
-    install -m 0755 ${B}/out/target/lib/halif/*.so ${D}${libdir}/
-}
+FILES:${PN} += "${libdir}/halif/*.so"
 ```
 
 ## Why not the wrapper scripts

--- a/docs/standards/build_integration.md
+++ b/docs/standards/build_integration.md
@@ -1,0 +1,99 @@
+# Third-Party Build Integration
+
+This guide defines how a production or third-party build system (Yocto/BitBake,
+buildroot, or a bespoke CMake superbuild) consumes **rdk-halif-aidl**.
+
+!!! warning "Build the artifacts with CMake directly"
+    The repository's wrapper scripts — `build_binder.sh`, `build_modules.sh`,
+    `build_interfaces.sh` — are developer and architecture-team convenience tools
+    that **require a native host toolchain**. Production and cross builds **must
+    invoke CMake directly** with the variables below. The scripts detect a
+    cross/OpenEmbedded environment and abort, because running them there silently
+    produces broken or empty output.
+
+## What an integrator builds
+
+The deliverable is two CMake builds, run in order:
+
+| Stage | Source | Produces | Toolchain |
+| ----- | ------ | -------- | --------- |
+| 1 — Binder SDK | `linux_binder_idl` (the `linux-binder` recipe) | `libbinder.so`, `libutils.so`, `servicemanager`, headers | Target cross-toolchain |
+| 2 — HAL interface libraries | each `<module>/<version>/` | `lib<module>-v<version>-cpp.so` | Target cross-toolchain |
+
+The HAL libraries are compiled from **committed, pre-generated C++**. The AIDL
+compiler and Python are used offline by the architecture team to regenerate that
+C++; they are **never required on a build host or target**.
+
+## Requirements
+
+1. **Toolchain via the environment.** Provide `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`,
+   and `LDFLAGS` through the cross environment. BitBake sets these automatically;
+   CMake consumes them.
+2. **Binder SDK: runtime only.** Configure the `linux_binder_idl` build with
+   `-DBUILD_HOST_AIDL=OFF`. The host AIDL tool runs on the build host and is not
+   part of a target image. The binder CMake also auto-enables its Yocto profile
+   (disabling host-only install rules) when `OECORE_*_SYSROOT` is present — this
+   is correct and requires no action.
+3. **HAL modules: point at the staged SDK.** Configure the top-level CMake with
+   the staged Binder SDK location. A staged SDK is flat, so headers and libraries
+   share one prefix — set both `BINDER_SDK_DIR` and `BINDER_SDK_INCLUDE_DIR` to it.
+4. **Pin the interface versions** to build via `versions_released.yaml` (or
+   `INTERFACE_TARGET`/`AIDL_SRC_VERSION` on the CMake command line).
+
+### CMake variables (Stage 2 — HAL modules)
+
+| Variable                 | Purpose                                                      | Required |
+| ------------------------ | ------------------------------------------------------------ | -------- |
+| `INTERFACE_TARGET`       | Module(s) to build; `all` or a name (default `all`)          | No       |
+| `AIDL_SRC_VERSION`       | Version to build; `current` or `X.Y.Z.W` (default `current`) | No       |
+| `BINDER_SDK_DIR`         | Staged Binder SDK libraries prefix                           | Yes      |
+| `BINDER_SDK_INCLUDE_DIR` | Staged Binder SDK headers prefix                             | Yes      |
+| `OUT_DIR`                | Output directory (default `out`)                             | No       |
+
+## Recipe pattern (BitBake)
+
+**Stage 1 — Binder SDK** is delivered by the `linux-binder` recipe. See
+[the Binder SDK BUILD guide](https://github.com/rdkcentral/rdk-halif-aidl/blob/develop/build-tools/linux_binder_idl/BUILD.md)
+for the full recipe, cross-compilation flags, and runtime/systemd setup. The
+essential line:
+
+```bitbake
+EXTRA_OECMAKE = "-DBUILD_HOST_AIDL=OFF"
+```
+
+**Stage 2 — HAL interface libraries** depend on the staged SDK:
+
+```bitbake
+DEPENDS = "linux-binder"
+inherit cmake
+
+do_configure() {
+    cmake -S ${S} -B ${B} \
+          -DINTERFACE_TARGET=all \
+          -DBINDER_SDK_DIR=${STAGING_DIR}${prefix} \
+          -DBINDER_SDK_INCLUDE_DIR=${STAGING_DIR}${prefix}
+}
+
+do_compile() {
+    cmake --build ${B} -j ${PARALLEL_MAKE}
+}
+
+do_install() {
+    install -d ${D}${libdir}
+    install -m 0755 ${B}/out/target/lib/halif/*.so ${D}${libdir}/
+}
+```
+
+## Why not the wrapper scripts
+
+The scripts assume a developer's native host:
+
+- They build the host AIDL compiler. Under a cross `CC` that tool is compiled for
+  the target and cannot execute on the build host, failing configuration.
+- The binder CMake auto-enables its Yocto profile from `OECORE_*_SYSROOT`, which
+  disables the host-only install rules the scripts rely on — so a script run
+  inside an OpenEmbedded shell appears to succeed but stages nothing.
+
+Both are correct behaviours for a production build invoked **directly through
+CMake**, and both are wrong for the developer scripts — which is why the scripts
+refuse to run in a cross/OE environment. An integrator never needs them.

--- a/docs/standards/build_integration.md
+++ b/docs/standards/build_integration.md
@@ -54,6 +54,19 @@ C++; they are **never required on a build host or target**.
 | `BINDER_SDK_INCLUDE_DIR` | Staged Binder SDK headers prefix                             | Yes      |
 | `OUT_DIR`                | Output directory (default `out`)                             | No       |
 
+## Reference recipes
+
+Copy-me starting templates (not consumed by this repo) live under `examples/`:
+
+- [`rdk-halif-aidl.bb`](examples/rdk-halif-aidl.bb) — BitBake recipe.
+- [`rdk-halif-aidl.yaml`](examples/rdk-halif-aidl.yaml) — [Bob Build Tool](https://bobbuildtool.dev/) recipe.
+
+Both are thin wrappers over the same direct-CMake invocation, so the build is
+build-system-agnostic — porting to another build system means calling the same
+CMake with the same variables. The recipes are reference material and are not
+CI-verified here; pin them to a released tag and adapt the toolchain/sysroot to
+your project.
+
 ## Recipe pattern (BitBake)
 
 **Stage 1 — Binder SDK** is delivered by the `linux-binder` recipe. See the

--- a/docs/standards/examples/rdk-halif-aidl.bb
+++ b/docs/standards/examples/rdk-halif-aidl.bb
@@ -1,0 +1,57 @@
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# REFERENCE BitBake recipe for the RDK HAL AIDL interface libraries.
+#
+# This is a copy-me template, NOT a recipe consumed by this repository. Drop it
+# into your meta-layer, pin SRCREV/branch to a released tag, and adjust as
+# needed. It builds the committed, pre-generated C++ via direct CMake — no AIDL
+# compiler or Python is required on the build host (see
+# docs/standards/build_integration.md for the full contract).
+
+SUMMARY = "RDK HAL AIDL interface libraries (Polaris HAL)"
+HOMEPAGE = "https://github.com/rdkcentral/rdk-halif-aidl"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRC_URI = "git://github.com/rdkcentral/rdk-halif-aidl.git;protocol=https;branch=develop"
+# Pin to a released tag for reproducible builds, e.g.:
+#   SRCREV = "0.21.0"
+SRCREV = "${AUTOREV}"
+PV = "1.0+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+# The Binder SDK (libbinder/libutils + headers) is provided by the linux-binder
+# recipe and staged into the recipe sysroot.
+DEPENDS = "linux-binder"
+
+inherit cmake
+
+# Let the cmake class run configure / compile / install — do not override the
+# tasks. The install() rules place the libraries under <prefix>/lib/halif, so
+# the class' install step puts them in the right place.
+#
+# A staged SDK is flat, so headers and libraries share one prefix — point both
+# BINDER_SDK_DIR and BINDER_SDK_INCLUDE_DIR at it.
+EXTRA_OECMAKE = " \
+    -DINTERFACE_TARGET=all \
+    -DBINDER_SDK_DIR=${STAGING_DIR}${prefix} \
+    -DBINDER_SDK_INCLUDE_DIR=${STAGING_DIR}${prefix} \
+"
+
+FILES:${PN} += "${libdir}/halif/*.so"

--- a/docs/standards/examples/rdk-halif-aidl.bb
+++ b/docs/standards/examples/rdk-halif-aidl.bb
@@ -12,8 +12,11 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "git://github.com/rdkcentral/rdk-halif-aidl.git;protocol=https;branch=develop"
-# Pin to a released tag for reproducible builds, e.g.:
-#   SRCREV = "0.21.0"
+# For reproducible builds, pin to a released tag. SRCREV must be a git commit
+# SHA (a tag *name* is not a valid SRCREV) — reference the tag in SRC_URI and
+# set SRCREV to that tag's commit, e.g.:
+#   SRC_URI = "git://github.com/rdkcentral/rdk-halif-aidl.git;protocol=https;tag=0.21.0"
+#   SRCREV  = "<commit-sha-of-tag-0.21.0>"
 SRCREV = "${AUTOREV}"
 PV = "1.0+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/docs/standards/examples/rdk-halif-aidl.bb
+++ b/docs/standards/examples/rdk-halif-aidl.bb
@@ -1,21 +1,3 @@
-#/**
-# * Copyright 2026 RDK Management
-# *
-# * Licensed under the Apache License, Version 2.0 (the "License");
-# * you may not use this file except in compliance with the License.
-# * You may obtain a copy of the License at
-# *
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * Unless required by applicable law or agreed to in writing, software
-# * distributed under the License is distributed on an "AS IS" BASIS,
-# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# * See the License for the specific language governing permissions and
-# * limitations under the License.
-# *
-# * SPDX-License-Identifier: Apache-2.0
-# */
-#
 # REFERENCE BitBake recipe for the RDK HAL AIDL interface libraries.
 #
 # This is a copy-me template, NOT a recipe consumed by this repository. Drop it

--- a/docs/standards/examples/rdk-halif-aidl.yaml
+++ b/docs/standards/examples/rdk-halif-aidl.yaml
@@ -1,0 +1,55 @@
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# REFERENCE Bob Build Tool recipe for the RDK HAL AIDL interface libraries.
+#
+# This is a copy-me template, NOT a recipe consumed by this repository. Drop it
+# into your Bob project's recipes/ (the package name is the filename without
+# `.yaml`) and adapt the toolchain, the linux-binder dependency name, and the
+# SDK sysroot layout to your project. See docs/standards/build_integration.md
+# for the full contract.
+#
+# Like the BitBake recipe, this builds the committed, pre-generated C++ via
+# direct CMake — no AIDL compiler or Python is needed on the build host.
+
+checkoutSCM:
+    scm: git
+    url: https://github.com/rdkcentral/rdk-halif-aidl.git
+    branch: develop      # pin to a released tag for reproducible builds
+
+depends:
+    - linux-binder       # provides the Binder SDK (libbinder/libutils + headers)
+
+buildTools: [target-toolchain, cmake]
+buildVars: [CC, CXX, CFLAGS, CXXFLAGS, LDFLAGS]
+buildScript: |
+    # $1 = rdk-halif-aidl checkout (source); $2 = linux-binder package result.
+    # Adjust "$2/usr" to wherever the dependency stages its prefix.
+    cmake -S "$1" -B "$PWD/build" \
+        -DCMAKE_INSTALL_PREFIX="$PWD/install/usr" \
+        -DINTERFACE_TARGET=all \
+        -DBINDER_SDK_DIR="$2/usr" \
+        -DBINDER_SDK_INCLUDE_DIR="$2/usr"
+    cmake --build "$PWD/build" -j$(nproc)
+    cmake --install "$PWD/build"
+
+packageScript: |
+    # $1 = build result. Copy the staged install tree into the package.
+    # (Projects on the BobBuildTool "basement" layer can instead
+    #  `inherit: [install]` and use `installPackageDev "$1/install/"`.)
+    cp -a "$1/install/." .

--- a/docs/standards/examples/rdk-halif-aidl.yaml
+++ b/docs/standards/examples/rdk-halif-aidl.yaml
@@ -1,21 +1,3 @@
-#/**
-# * Copyright 2026 RDK Management
-# *
-# * Licensed under the Apache License, Version 2.0 (the "License");
-# * you may not use this file except in compliance with the License.
-# * You may obtain a copy of the License at
-# *
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * Unless required by applicable law or agreed to in writing, software
-# * distributed under the License is distributed on an "AS IS" BASIS,
-# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# * See the License for the specific language governing permissions and
-# * limitations under the License.
-# *
-# * SPDX-License-Identifier: Apache-2.0
-# */
-#
 # REFERENCE Bob Build Tool recipe for the RDK HAL AIDL interface libraries.
 #
 # This is a copy-me template, NOT a recipe consumed by this repository. Drop it

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - Fork-Based Contribution Guide: standards/forked_based_branching.md
       - Git Flow Branching Strategy: standards/git_flow_branching_strategy.md
       - Semantic Versioning: standards/semantic_versioning.md
+      - Third-Party Build Integration: standards/build_integration.md
   - Vendor HAL Interfaces (VHI):
     - Overview: key_concepts/hal/hal_interfaces.md
     - Interface Generation: introduction/interface_generation.md


### PR DESCRIPTION
Refs #624

## Background

#624 reports `build_binder.sh` failing in an OpenEmbedded ARM cross environment two ways: the host AIDL tool gets cross-compiled (can't run on the build host), and `OECORE_*_SYSROOT` makes the binder CMake set `BUILD_ENV_YOCTO=ON`, which disables every `install()` rule so `out/target` ends up empty.

**Both behaviours are correct for a production build invoked directly through CMake.** The actual problem is that the `build_*.sh` wrapper scripts — which are documented as developer/architecture-only tools ([BUILD.md](build-tools/linux_binder_idl/BUILD.md): *"Yocto/BitBake recipes must NOT use these wrapper scripts"*) — were run in an environment they were never meant for. The HAL libraries build from committed generated C++, so the AIDL **host** tool is never needed on a target at all.

So this is not a code adaptation bug — the fix is to **enforce and document the boundary**.

## Changes

- **`dev_env_guard.sh`** (new) — shared guard sourced by `build_binder.sh`, `build_modules.sh`, `build_interfaces.sh`. If it detects a cross `CC` (target triple ≠ host) or `OECORE_*_SYSROOT`, it aborts with a clear message pointing to the direct-CMake recipe. `clean`/help paths bypass it so they stay usable anywhere; `BINDER_ALLOW_CROSS_ENV=1` overrides.
- **`docs/standards/build_integration.md`** (new, wired into the nav) — the integration contract for third-party/Yocto build systems: two-stage build via direct CMake, required variables, BitBake recipe pattern, and why the wrapper scripts are not used.
- **README** — production-build section now states the contract and links the new doc.

## Testing

- `bash -n` on all four scripts — clean.
- Guard unit checks: native (no `CC`/`OECORE`) → allowed; `OECORE_*` set → blocked; cross `CC` → blocked; `BINDER_ALLOW_CROSS_ENV=1` → allowed.
- Wrapper smoke tests: `build_modules.sh --help` bypasses the guard (exit 0); `build_modules.sh <module>` and `build_interfaces.sh sdk` in a simulated OE env abort before doing any work with the pointer message.

---
### Update: reference recipes added
Folded in copy-me integration recipes so the guide ships **instructions + examples**:
- `docs/standards/examples/rdk-halif-aidl.bb` — BitBake reference recipe.
- `docs/standards/examples/rdk-halif-aidl.yaml` — Bob Build Tool reference recipe.

Both are thin wrappers over the same direct-CMake invocation, demonstrating the build is build-system-agnostic. Linked from `build_integration.md`; marked as reference templates (pin to a release tag, adapt toolchain/sysroot), not CI-verified — I have no Yocto/Bob environment to execute-test them.