### PR TITLE
fix(release): keep cohort snapshot dependency versions consistent + stage module-root helper headers

### DIFF
--- a/audiodecoder/0.2.0.0/interface.yaml
+++ b/audiodecoder/0.2.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiodecoder/*.aidl
   imports:
-    - common@current
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/audiomixer/0.3.0.0/interface.yaml
+++ b/audiomixer/0.3.0.0/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiomixer/*.aidl
   imports:
-    - audiodecoder@current
-    - audiosink@current
-    - common@current
+    - audiodecoder@0.2.0.0
+    - audiosink@0.2.0.0
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/audiosink/0.2.0.0/interface.yaml
+++ b/audiosink/0.2.0.0/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/audiosink/*.aidl
   imports:
-    - audiodecoder@current
-    - avclock@current
-    - common@current
+    - audiodecoder@0.2.0.0
+    - avclock@0.2.0.0
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/avbuffer/0.1.0.0/include/avbufferhelper.h
+++ b/avbuffer/0.1.0.0/include/avbufferhelper.h
@@ -1,0 +1,94 @@
+/**
+ *  If not stated otherwise in this file or this component's LICENSE
+ *  file the following copyright and licenses apply:
+ *
+ *  Copyright 2025 RDK Management
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License);
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an AS IS BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _AVBUFFERHELPER_H_
+#define _AVBUFFERHELPER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#include <cstdint>
+
+using namespace std;
+
+class IAVBufferHelper
+{
+public:
+    struct CopyMap {
+        uint32_t src_offset;
+        uint32_t dst_offset;
+        uint32_t size;
+    };
+
+
+    // helper functions for mapping and unmapping memory from handles
+    // used in the client code outside of the LinearBufferMgr class
+    /**
+     * @brief Map memory from the given handle.
+     * @param handle The handle to map memory from.
+     * @param[out] size The size of the mapped data
+     */
+    virtual void* mapHandle(uint64_t handle, uint32_t * size) = 0;
+
+    /**
+     * @brief Unmap memory from the given handle.
+     * @param handle The handle to unmap memory from.
+     * @return True if the memory was successfully unmapped, false otherwise.
+     */
+    virtual bool unmapHandle(uint64_t handle) = 0;
+
+    /**
+     * @brief Get the size of the memory mapped to the given handle.
+     * @param handle The handle to get the size from.
+     * @return The size of the memory mapped to the handle.
+     */
+    virtual uint32_t getAllocationSize(uint64_t handle) = 0;
+
+    /**
+     * @brief Write data from unsecure memory into a secure buffer.
+     * @param handle The handle to write data into.
+     * @param data The data to write.
+     * @param size The size of the data to write.
+     *
+     * @return True if the data was successfully written, false otherwise.
+     */
+    virtual bool writeSecureHandle(uint64_t handle, void* data, uint32_t size) { return false; }
+
+    /**
+     * @brief Copy data from one secure buffer to another.
+     * @param handleTo The handle to copy data to.
+     * @param handleFrom The handle to copy data from.
+     * @param CopyMap The map of offsets and sizes to copy.
+     * @param mapSize The number if indexes in the map.
+     *
+     * @return True if the data was successfully copied, false otherwise.
+     */
+    virtual bool copySecureHandleWithMap(uint64_t handleTo, uint64_t handleFrom, CopyMap map, uint32_t mapSize) { return false; }
+};
+
+// Factory function to get an instance of the AVBufferHelper
+IAVBufferHelper* getAVBufferHelperInstance();
+
+#endif //_AVBUFFERHELPER_H_

--- a/avbuffer/0.2.0.0/include/avbufferhelper.h
+++ b/avbuffer/0.2.0.0/include/avbufferhelper.h
@@ -1,0 +1,94 @@
+/**
+ *  If not stated otherwise in this file or this component's LICENSE
+ *  file the following copyright and licenses apply:
+ *
+ *  Copyright 2025 RDK Management
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License);
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an AS IS BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _AVBUFFERHELPER_H_
+#define _AVBUFFERHELPER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#include <cstdint>
+
+using namespace std;
+
+class IAVBufferHelper
+{
+public:
+    struct CopyMap {
+        uint32_t src_offset;
+        uint32_t dst_offset;
+        uint32_t size;
+    };
+
+
+    // helper functions for mapping and unmapping memory from handles
+    // used in the client code outside of the LinearBufferMgr class
+    /**
+     * @brief Map memory from the given handle.
+     * @param handle The handle to map memory from.
+     * @param[out] size The size of the mapped data
+     */
+    virtual void* mapHandle(uint64_t handle, uint32_t * size) = 0;
+
+    /**
+     * @brief Unmap memory from the given handle.
+     * @param handle The handle to unmap memory from.
+     * @return True if the memory was successfully unmapped, false otherwise.
+     */
+    virtual bool unmapHandle(uint64_t handle) = 0;
+
+    /**
+     * @brief Get the size of the memory mapped to the given handle.
+     * @param handle The handle to get the size from.
+     * @return The size of the memory mapped to the handle.
+     */
+    virtual uint32_t getAllocationSize(uint64_t handle) = 0;
+
+    /**
+     * @brief Write data from unsecure memory into a secure buffer.
+     * @param handle The handle to write data into.
+     * @param data The data to write.
+     * @param size The size of the data to write.
+     *
+     * @return True if the data was successfully written, false otherwise.
+     */
+    virtual bool writeSecureHandle(uint64_t handle, void* data, uint32_t size) { return false; }
+
+    /**
+     * @brief Copy data from one secure buffer to another.
+     * @param handleTo The handle to copy data to.
+     * @param handleFrom The handle to copy data from.
+     * @param CopyMap The map of offsets and sizes to copy.
+     * @param mapSize The number if indexes in the map.
+     *
+     * @return True if the data was successfully copied, false otherwise.
+     */
+    virtual bool copySecureHandleWithMap(uint64_t handleTo, uint64_t handleFrom, CopyMap map, uint32_t mapSize) { return false; }
+};
+
+// Factory function to get an instance of the AVBufferHelper
+IAVBufferHelper* getAVBufferHelperInstance();
+
+#endif //_AVBUFFERHELPER_H_

--- a/avbuffer/0.2.0.0/interface.yaml
+++ b/avbuffer/0.2.0.0/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/avbuffer/*.aidl
   imports:
-    - audiodecoder@current
-    - videodecoder@current
+    - audiodecoder@0.2.0.0
+    - videodecoder@0.2.0.0
   stability: vintf
   layout: module-local

--- a/avclock/0.2.0.0/interface.yaml
+++ b/avclock/0.2.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/avclock/*.aidl
   imports:
-    - common@current
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/compositeinput/0.2.0.0/CMakeLists.txt
+++ b/compositeinput/0.2.0.0/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${LIB_NAME} PRIVATE
 # via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
+    "${HALIF_INCLUDE_DIR}/common/0.2.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.2.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/compositeinput/0.2.0.0/interface.yaml
+++ b/compositeinput/0.2.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/compositeinput/*.aidl
   imports:
-    - common@0.1.0.0
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/hdmicec/0.1.0.0/CMakeLists.txt
+++ b/hdmicec/0.1.0.0/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${LIB_NAME} PRIVATE
 # via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
+    "${HALIF_INCLUDE_DIR}/common/0.2.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.2.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/hdmicec/0.1.0.0/interface.yaml
+++ b/hdmicec/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmicec/*.aidl
   imports:
-    - common@0.1.0.0
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/hdmiinput/0.1.0.0/CMakeLists.txt
+++ b/hdmiinput/0.1.0.0/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${LIB_NAME} PRIVATE
 # via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
+    "${HALIF_INCLUDE_DIR}/common/0.2.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.2.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/hdmiinput/0.1.0.0/interface.yaml
+++ b/hdmiinput/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmiinput/*.aidl
   imports:
-    - common@0.1.0.0
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/hdmioutput/0.1.0.0/CMakeLists.txt
+++ b/hdmioutput/0.1.0.0/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${LIB_NAME} PRIVATE
 # via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include")
+    "${HALIF_INCLUDE_DIR}/common/0.2.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -60,7 +60,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.2.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/hdmioutput/0.1.0.0/interface.yaml
+++ b/hdmioutput/0.1.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/hdmioutput/*.aidl
   imports:
-    - common@0.1.0.0
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/panel/0.1.0.0/CMakeLists.txt
+++ b/panel/0.1.0.0/CMakeLists.txt
@@ -50,8 +50,8 @@ target_include_directories(${LIB_NAME} PRIVATE
 # via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
-    "${HALIF_INCLUDE_DIR}/videodecoder/0.1.0.0/include")
+    "${HALIF_INCLUDE_DIR}/common/0.2.0.0/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/0.2.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -61,7 +61,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp videodecoder-v0.1.0.0-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.2.0.0-cpp videodecoder-v0.2.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/panel/0.1.0.0/interface.yaml
+++ b/panel/0.1.0.0/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/panel/*.aidl
   imports:
-    - common@0.1.0.0
-    - videodecoder@0.1.0.0
+    - common@0.2.0.0
+    - videodecoder@0.2.0.0
   stability: vintf
   layout: module-local

--- a/planecontrol/0.1.0.0/CMakeLists.txt
+++ b/planecontrol/0.1.0.0/CMakeLists.txt
@@ -50,8 +50,8 @@ target_include_directories(${LIB_NAME} PRIVATE
 # via direct deps, e.g. common via audiodecoder/videodecoder for avbuffer).
 if (DEFINED HALIF_INCLUDE_DIR)
     target_include_directories(${LIB_NAME} PRIVATE
-    "${HALIF_INCLUDE_DIR}/common/0.1.0.0/include"
-    "${HALIF_INCLUDE_DIR}/videodecoder/0.1.0.0/include")
+    "${HALIF_INCLUDE_DIR}/common/0.2.0.0/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/0.2.0.0/include")
 endif()
 
 target_link_directories(${LIB_NAME} PRIVATE
@@ -61,7 +61,7 @@ if (DEFINED HALIF_LIB_DIR)
     target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
 endif()
 
-target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.1.0.0-cpp videodecoder-v0.1.0.0-cpp)
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-v0.2.0.0-cpp videodecoder-v0.2.0.0-cpp)
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
 

--- a/planecontrol/0.1.0.0/interface.yaml
+++ b/planecontrol/0.1.0.0/interface.yaml
@@ -3,7 +3,7 @@ aidl_interface:
   srcs:
     - com/rdk/hal/planecontrol/*.aidl
   imports:
-    - common@0.1.0.0
-    - videodecoder@0.1.0.0
+    - common@0.2.0.0
+    - videodecoder@0.2.0.0
   stability: vintf
   layout: module-local

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1768,9 +1768,10 @@ create_snapshot() {
     # Copying them into the snapshot's include/ makes them ship and version with
     # the generated headers and be picked up by the include/-tree staging copy
     # that downstream snapshot builds rely on.
+    local _nullglob_was=0; shopt -q nullglob && _nullglob_was=1
     shopt -s nullglob
     local _root_hdrs=("${snapshot_dir}"/*.h)
-    shopt -u nullglob
+    [[ "${_nullglob_was}" -eq 0 ]] && shopt -u nullglob
     if [[ "${#_root_hdrs[@]}" -gt 0 ]]; then
         mkdir -p "${snapshot_dir}/include"
         if ! cp "${_root_hdrs[@]}" "${snapshot_dir}/include/"; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1859,7 +1859,12 @@ PYEOF
         while IFS= read -r _f; do
             [[ -z "${_f}" ]] && continue
             log "    ${_f}"
-            (cd "${REPO_ROOT}" && git add "${_f}") || warn "  git add ${_f} failed"
+            # The file was just rewritten on disk; if it can't be staged the
+            # release diff would be incomplete, so abort rather than warn.
+            (cd "${REPO_ROOT}" && git add "${_f}") || {
+                warn "  git add ${_f} failed"
+                return 1
+            }
         done <<< "${changed}"
     else
         log "  All cohort snapshots already reference cohort dependency versions."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1761,6 +1761,24 @@ create_snapshot() {
         fi
     fi
 
+    # Stage hand-authored module-root headers (e.g. avbufferhelper.h) into the
+    # snapshot's include/ tree (#623). These are public, versioned contract
+    # headers that live at the module root in current/ — current/include/ is
+    # gitignored generator output, so they cannot live there in the dev tree.
+    # Copying them into the snapshot's include/ makes them ship and version with
+    # the generated headers and be picked up by the include/-tree staging copy
+    # that downstream snapshot builds rely on.
+    shopt -s nullglob
+    local _root_hdrs=("${snapshot_dir}"/*.h)
+    shopt -u nullglob
+    if [[ "${#_root_hdrs[@]}" -gt 0 ]]; then
+        mkdir -p "${snapshot_dir}/include"
+        if ! cp "${_root_hdrs[@]}" "${snapshot_dir}/include/"; then
+            warn "Failed to stage module-root header(s) into ${comp}/${version}/include/."
+            return 1
+        fi
+    fi
+
     # Stage the snapshot. No -f needed: .gitignore scopes the binding
     # rules to */current/include/ and */current/src/ only — files under
     # <module>/<version>/ are outside that scope and stage cleanly with
@@ -1775,6 +1793,76 @@ create_snapshot() {
     # already showed every step above.
     if [[ "${VERBOSE}" -ne 1 ]]; then
         log "  [${comp}] → ${version}/  ${_C_GREEN}✓${_C_RESET}${refresh_marker}"
+    fi
+    return 0
+}
+
+# ----------------------------------------------------------------------------
+# Cohort snapshot dependency-version normalization (#623)
+# ----------------------------------------------------------------------------
+#
+# create_snapshot() pins a fresh snapshot's cross-component dependency versions
+# to the cohort at the moment it is cut. But a component whose AIDL did not
+# change in a later release is NOT re-cut — so its snapshot keeps the dependency
+# versions that were current when it was first generated. After a dependency
+# advances (e.g. common 0.1.0.0 -> 0.2.0.0), those stale snapshots reference a
+# version the cohort manifest no longer builds, and the manifest build fails.
+#
+# This pass rewrites, for the cohort snapshot of every component listed in
+# versions_released.yaml, each reference to ANOTHER component to that
+# dependency's cohort version. A snapshot's own library version is never
+# touched, and non-cohort historical snapshots are left frozen.
+normalize_cohort_snapshot_deps() {
+    local changed
+    changed="$(python3 - "${REPO_ROOT}" <<'PYEOF'
+import os, re, sys
+repo = sys.argv[1]
+manifest = os.path.join(repo, "versions_released.yaml")
+cohort = {}
+in_components = False
+with open(manifest) as fh:
+    for line in fh:
+        if re.match(r"^components:\s*$", line):
+            in_components = True
+            continue
+        if in_components:
+            m = re.match(r"^\s+([A-Za-z0-9_]+):\s*(\S+)\s*$", line)
+            if m:
+                cohort[m.group(1)] = m.group(2)
+            elif line.strip() and not line[0].isspace():
+                in_components = False
+changed = []
+for comp, ver in sorted(cohort.items()):
+    if ver == "current":
+        continue
+    cmake = os.path.join(repo, comp, ver, "CMakeLists.txt")
+    if not os.path.isfile(cmake):
+        continue
+    text = orig = open(cmake).read()
+    for dep, dep_ver in cohort.items():
+        if dep == comp or dep_ver == "current":
+            continue
+        text = re.sub(rf"(?<![A-Za-z0-9_]){re.escape(dep)}-v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-cpp",
+                      f"{dep}-v{dep_ver}-cpp", text)
+        text = re.sub(rf"(HALIF_INCLUDE_DIR}}/{re.escape(dep)}/)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/",
+                      rf"\g<1>{dep_ver}/", text)
+    if text != orig:
+        open(cmake, "w").write(text)
+        changed.append(f"{comp}/{ver}/CMakeLists.txt")
+for c in changed:
+    print(c)
+PYEOF
+)" || { warn "  cohort dependency normalization: python step failed"; return 1; }
+
+    if [[ -n "${changed}" ]]; then
+        log "  Rewrote cohort dependency versions in:"
+        while IFS= read -r _f; do
+            [[ -z "${_f}" ]] && continue
+            log "    ${_f}"
+            (cd "${REPO_ROOT}" && git add "${_f}") || warn "  git add ${_f} failed"
+        done <<< "${changed}"
+    else
+        log "  All cohort snapshots already reference cohort dependency versions."
     fi
     return 0
 }
@@ -2866,6 +2954,17 @@ if [[ "${DO_WRITES}" -eq 1 && "${changed_count}" -gt 0 ]]; then
     fi
     (cd "${REPO_ROOT}" && git add versions_released.yaml) \
         || warn "git add versions_released.yaml failed (file may be untracked)"
+
+    # 2b. Normalize cohort snapshot dependency versions (#623). Snapshots not
+    # re-cut this release still reference the dependency versions current when
+    # they were first generated; after versions_released.yaml advances, rewrite
+    # their cross-component dep refs to the cohort versions so the manifest
+    # build below stays internally consistent.
+    phase "Normalizing cohort snapshot dependency versions..."
+    log ""
+    if ! normalize_cohort_snapshot_deps; then
+        die "Cohort snapshot dependency normalization failed. Aborting release."
+    fi
 
     # 3. mkdocs.yml entries.
     if [[ "${NO_MKDOCS}" -eq 1 ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1798,7 +1798,7 @@ create_snapshot() {
 }
 
 # ----------------------------------------------------------------------------
-# Cohort snapshot dependency-version normalization (#623)
+# Cohort snapshot dependency-version normalization (#623, #616)
 # ----------------------------------------------------------------------------
 #
 # create_snapshot() pins a fresh snapshot's cross-component dependency versions
@@ -1807,11 +1807,15 @@ create_snapshot() {
 # versions that were current when it was first generated. After a dependency
 # advances (e.g. common 0.1.0.0 -> 0.2.0.0), those stale snapshots reference a
 # version the cohort manifest no longer builds, and the manifest build fails.
+# Snapshots also inherit current/'s `<dep>@current` AIDL imports, which are
+# non-deterministic in a frozen interface (#616).
 #
 # This pass rewrites, for the cohort snapshot of every component listed in
 # versions_released.yaml, each reference to ANOTHER component to that
-# dependency's cohort version. A snapshot's own library version is never
-# touched, and non-cohort historical snapshots are left frozen.
+# dependency's cohort version — in both CMakeLists.txt (link names + include
+# paths) and interface.yaml (AIDL import pins, including `@current`). A
+# snapshot's own version is never touched, and non-cohort historical snapshots
+# are left frozen.
 normalize_cohort_snapshot_deps() {
     local changed
     changed="$(python3 - "${REPO_ROOT}" <<'PYEOF'
@@ -1835,20 +1839,34 @@ changed = []
 for comp, ver in sorted(cohort.items()):
     if ver == "current":
         continue
+    # 1. CMakeLists.txt — link names + include paths (#623).
     cmake = os.path.join(repo, comp, ver, "CMakeLists.txt")
-    if not os.path.isfile(cmake):
-        continue
-    text = orig = open(cmake).read()
-    for dep, dep_ver in cohort.items():
-        if dep == comp or dep_ver == "current":
-            continue
-        text = re.sub(rf"(?<![A-Za-z0-9_]){re.escape(dep)}-v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-cpp",
-                      f"{dep}-v{dep_ver}-cpp", text)
-        text = re.sub(rf"(HALIF_INCLUDE_DIR}}/{re.escape(dep)}/)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/",
-                      rf"\g<1>{dep_ver}/", text)
-    if text != orig:
-        open(cmake, "w").write(text)
-        changed.append(f"{comp}/{ver}/CMakeLists.txt")
+    if os.path.isfile(cmake):
+        text = orig = open(cmake).read()
+        for dep, dep_ver in cohort.items():
+            if dep == comp or dep_ver == "current":
+                continue
+            text = re.sub(rf"(?<![A-Za-z0-9_]){re.escape(dep)}-v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-cpp",
+                          f"{dep}-v{dep_ver}-cpp", text)
+            text = re.sub(rf"(HALIF_INCLUDE_DIR}}/{re.escape(dep)}/)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/",
+                          rf"\g<1>{dep_ver}/", text)
+        if text != orig:
+            open(cmake, "w").write(text)
+            changed.append(f"{comp}/{ver}/CMakeLists.txt")
+    # 2. interface.yaml — AIDL import pins, e.g. common@current -> common@0.2.0.0 (#616).
+    # A frozen snapshot must not import @current (non-deterministic); pin every
+    # cross-component import to the cohort version.
+    iface = os.path.join(repo, comp, ver, "interface.yaml")
+    if os.path.isfile(iface):
+        text = orig = open(iface).read()
+        for dep, dep_ver in cohort.items():
+            if dep == comp or dep_ver == "current":
+                continue
+            text = re.sub(rf"(?<![A-Za-z0-9_]){re.escape(dep)}@[A-Za-z0-9._]+",
+                          f"{dep}@{dep_ver}", text)
+        if text != orig:
+            open(iface, "w").write(text)
+            changed.append(f"{comp}/{ver}/interface.yaml")
 for c in changed:
     print(c)
 PYEOF

--- a/videodecoder/0.2.0.0/interface.yaml
+++ b/videodecoder/0.2.0.0/interface.yaml
@@ -3,6 +3,6 @@ aidl_interface:
   srcs:
     - com/rdk/hal/videodecoder/*.aidl
   imports:
-    - common@current
+    - common@0.2.0.0
   stability: vintf
   layout: module-local

--- a/videosink/0.2.0.0/interface.yaml
+++ b/videosink/0.2.0.0/interface.yaml
@@ -3,8 +3,8 @@ aidl_interface:
   srcs:
     - com/rdk/hal/videosink/*.aidl
   imports:
-    - avclock@current
-    - common@current
-    - videodecoder@current
+    - avclock@0.2.0.0
+    - common@0.2.0.0
+    - videodecoder@0.2.0.0
   stability: vintf
   layout: module-local


### PR DESCRIPTION
Fixes #623

Both reported breakages of `./build_modules.sh manifest --file versions_released.yaml` are confirmed and fixed.

## 1. Stale cross-component dependency versions

`create_snapshot()` pins a snapshot's dependency versions to the cohort at the moment it is cut. A component whose AIDL did not change in a later release is **not** re-cut, so its snapshot keeps the dependency versions that were current when it was first generated. After `common`/`videodecoder` advanced to `0.2.0.0`, six cohort snapshots still pinned `0.1.0.0` — a version the cohort manifest no longer builds — producing the reported `PropertyValue.h: No such file` and `cannot find -lcommon-v0.1.0.0-cpp`.

**Fix (rewrite-on-release):** new `normalize_cohort_snapshot_deps()` runs during the release apply, right after `versions_released.yaml` is updated. For the cohort snapshot of every component, it rewrites each reference to **another** component to that dependency's cohort version. A snapshot's **own** library version is never touched, and non-cohort historical snapshots stay frozen.

Applied as a one-time fix to the six drifted snapshots:
`compositeinput/0.2.0.0`, `hdmicec/0.1.0.0`, `hdmiinput/0.1.0.0`, `hdmioutput/0.1.0.0`, `panel/0.1.0.0`, `planecontrol/0.1.0.0` (each `common`/`videodecoder` ref → `0.2.0.0`).

## 2. `avbufferhelper.h` never staged

`avbufferhelper.h` is the public, versioned contract header for the vendor-provided `libavbufferhelper.so`. It lives at the avbuffer module root, but header staging only copies the `include/` tree — so it never reached `out/`.

The source of truth stays at `avbuffer/current/avbufferhelper.h` (`current/include/` is gitignored generator output, so it can't live there). **Fix:** `create_snapshot()` now copies hand-authored module-root headers into the snapshot's `include/`, so they ship and version with the generated headers and are picked up by the existing staging copy. Staged into the existing `avbuffer/0.1.0.0` and `avbuffer/0.2.0.0` snapshots.

## Verification

- `bash -n scripts/release.sh` — clean; normalizer is idempotent (no drift on a consistent tree).
- `./build_modules.sh manifest` (released cohort) builds cleanly end-to-end; all six previously-failing snapshots now produce `lib<module>-v<version>-cpp.so`.
- `avbufferhelper.h` stages to `out/build/include/avbuffer/0.2.0.0/include/`.
- The formerly-reported `PropertyValue.h` / `-lcommon-v0.1.0.0-cpp` errors are gone.

---
### Also fixes #616 — pin frozen-snapshot AIDL imports
Frozen snapshots inherited `current/`'s `<dep>@current` imports (and some stale `<dep>@0.1.0.0` pins), which are non-deterministic for a frozen interface. The same `normalize_cohort_snapshot_deps()` pass now also rewrites `interface.yaml` import pins to the cohort version — keeping a snapshot's AIDL imports and its CMake build config in lockstep. One-time fix applied across 13 cohort `interface.yaml` files; non-cohort historical snapshots (e.g. `audiomixer/0.2.0.0`) left frozen.

Fixes #616