### PR TITLE
fix(docs): nest multi-version components under one nav parent (versions as children)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,41 +58,61 @@ nav:
     - Overview: key_concepts/hal/hal_interfaces.md
     - Interface Generation: introduction/interface_generation.md
     - AV Subsystem:
-      - Audio Decoder: '!include audiodecoder/current/mkdocs.yml'
-      - Audio Decoder 0.2.0.0: '!include audiodecoder/0.2.0.0/mkdocs.yml'
-      - Audio Mixer: '!include audiomixer/current/mkdocs.yml'
-      - Audio Mixer 0.3.0.0: '!include audiomixer/0.3.0.0/mkdocs.yml'
-      - Audio Mixer 0.2.0.0: '!include audiomixer/0.2.0.0/mkdocs.yml'
-      - Audio Sink: '!include audiosink/current/mkdocs.yml'
-      - Audio Sink 0.2.0.0: '!include audiosink/0.2.0.0/mkdocs.yml'
-      - AV Buffer: '!include avbuffer/current/mkdocs.yml'
-      - AV Buffer 0.2.0.0: '!include avbuffer/0.2.0.0/mkdocs.yml'
-      - AV Clock: '!include avclock/current/mkdocs.yml'
-      - AV Clock 0.2.0.0: '!include avclock/0.2.0.0/mkdocs.yml'
-      - Video Decoder: '!include videodecoder/current/mkdocs.yml'
-      - Video Decoder 0.2.0.0: '!include videodecoder/0.2.0.0/mkdocs.yml'
-      - Video Sink: '!include videosink/current/mkdocs.yml'
-      - Video Sink 0.2.0.0: '!include videosink/0.2.0.0/mkdocs.yml'
-    - Boot Reason: '!include bootreason/current/mkdocs.yml'
-    - Boot Reason 0.1.0.0: '!include bootreason/0.1.0.0/mkdocs.yml'
+      - Audio Decoder:
+        - Current: '!include audiodecoder/current/mkdocs.yml'
+        - 0.2.0.0: '!include audiodecoder/0.2.0.0/mkdocs.yml'
+        - 0.1.0.0: '!include audiodecoder/0.1.0.0/mkdocs.yml'
+      - Audio Mixer:
+        - Current: '!include audiomixer/current/mkdocs.yml'
+        - 0.3.0.0: '!include audiomixer/0.3.0.0/mkdocs.yml'
+        - 0.2.0.0: '!include audiomixer/0.2.0.0/mkdocs.yml'
+        - 0.1.0.1: '!include audiomixer/0.1.0.1/mkdocs.yml'
+      - Audio Sink:
+        - Current: '!include audiosink/current/mkdocs.yml'
+        - 0.2.0.0: '!include audiosink/0.2.0.0/mkdocs.yml'
+        - 0.1.0.0: '!include audiosink/0.1.0.0/mkdocs.yml'
+      - AV Buffer:
+        - Current: '!include avbuffer/current/mkdocs.yml'
+        - 0.2.0.0: '!include avbuffer/0.2.0.0/mkdocs.yml'
+        - 0.1.0.0: '!include avbuffer/0.1.0.0/mkdocs.yml'
+      - AV Clock:
+        - Current: '!include avclock/current/mkdocs.yml'
+        - 0.2.0.0: '!include avclock/0.2.0.0/mkdocs.yml'
+        - 0.1.0.0: '!include avclock/0.1.0.0/mkdocs.yml'
+      - Video Decoder:
+        - Current: '!include videodecoder/current/mkdocs.yml'
+        - 0.2.0.0: '!include videodecoder/0.2.0.0/mkdocs.yml'
+        - 0.1.0.0: '!include videodecoder/0.1.0.0/mkdocs.yml'
+      - Video Sink:
+        - Current: '!include videosink/current/mkdocs.yml'
+        - 0.2.0.0: '!include videosink/0.2.0.0/mkdocs.yml'
+        - 0.1.0.0: '!include videosink/0.1.0.0/mkdocs.yml'
+    - Boot Reason:
+      - Current: '!include bootreason/current/mkdocs.yml'
+      - 0.1.0.0: '!include bootreason/0.1.0.0/mkdocs.yml'
     - Broadcast: '!include broadcast/current/mkdocs.yml'
     - DRM: '!include drm/current/mkdocs.yml'
     - HDMI:
       - HDMI CEC: '!include hdmicec/current/mkdocs.yml'
       - HDMI Input: '!include hdmiinput/current/mkdocs.yml'
       - HDMI Output: '!include hdmioutput/current/mkdocs.yml'
-    - Common: '!include common/current/mkdocs.yml'
-    - Common 0.2.0.0: '!include common/0.2.0.0/mkdocs.yml'
+    - Common:
+      - Current: '!include common/current/mkdocs.yml'
+      - 0.2.0.0: '!include common/0.2.0.0/mkdocs.yml'
+      - 0.1.0.0: '!include common/0.1.0.0/mkdocs.yml'
     - Composite Input: '!include compositeinput/current/mkdocs.yml'
     - Deep Sleep: '!include deepsleep/current/mkdocs.yml'
     - Device Info: '!include deviceinfo/current/mkdocs.yml'
-    - Firmware Update: '!include firmwareupdate/current/mkdocs.yml'
-    - Firmware Update 0.2.0.0: '!include firmwareupdate/0.2.0.0/mkdocs.yml'
+    - Firmware Update:
+      - Current: '!include firmwareupdate/current/mkdocs.yml'
+      - 0.2.0.0: '!include firmwareupdate/0.2.0.0/mkdocs.yml'
     - Indicator: '!include indicator/current/mkdocs.yml'
     - Panel: '!include panel/current/mkdocs.yml'
     - Plane Control: '!include planecontrol/current/mkdocs.yml'
-    - Sensor: '!include sensor/current/mkdocs.yml'
-    - Sensor 0.2.0.0: '!include sensor/0.2.0.0/mkdocs.yml'
+    - Sensor:
+      - Current: '!include sensor/current/mkdocs.yml'
+      - 0.2.0.0: '!include sensor/0.2.0.0/mkdocs.yml'
+      - 0.1.0.0: '!include sensor/0.1.0.0/mkdocs.yml'
   - Vendor System Interfaces (VSI):
     - File System: '!include vsi/filesystem/current/mkdocs.yml'
     - Bluetooth: '!include vsi/bluetooth/current/mkdocs.yml'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1812,49 +1812,64 @@ update_mkdocs_for_release() {
         return 0
     fi
 
-    # If a `current` !include exists for this component, append a sibling
-    # versioned entry immediately after it, preserving the existing human
-    # label (e.g. "Audio Decoder") rather than inventing a comp@version
-    # label. We extract the label from the matching current line and
-    # construct a "<label> X.Y.Z.W:" prefix for the new entry. Python
-    # for the edit so YAML indentation stays exact byte-for-byte.
+    # The nav groups each component as a parent with one child per version:
+    #
+    #   - Sensor:
+    #     - Current: '!include sensor/current/mkdocs.yml'
+    #     - 0.2.0.0: '!include sensor/0.2.0.0/mkdocs.yml'
+    #
+    # Add the new version as a child under the component's parent. Two cases:
+    #   * already nested (a "Current:" child exists) — insert the new version
+    #     child immediately after Current (newest first).
+    #   * still flat (single "<Label>: '!include <comp>/current/...'" line, the
+    #     state of a component getting its first release) — convert it in place
+    #     to the nested parent + Current + versioned children.
+    # Python does the edit so YAML indentation stays exact byte-for-byte.
     local current_entry="'!include ${comp}/current/mkdocs.yml'"
     if ! grep -qF "${current_entry}" "${mkdocs}"; then
         warn "  [${comp}] no current/ mkdocs entry found; manual mkdocs.yml edit required"
         return 1
     fi
 
-    if ! python3 - "${mkdocs}" "${comp}" "${version}" "${current_entry}" "${entry}" <<'PYEOF'; then
-import io, re, sys
-mkdocs_path, comp, version, current_entry, new_entry = sys.argv[1:6]
-with open(mkdocs_path) as f:
-    lines = f.readlines()
+    if ! python3 - "${mkdocs}" "${comp}" "${version}" <<'PYEOF'; then
+import re, sys
+mkdocs_path, comp, version = sys.argv[1:4]
+lines = open(mkdocs_path).read().splitlines(keepends=True)
 
-# Locate the line containing the current entry. Capture the leading
-# indent ("    - ") and the label preceding the `:` so we can reuse it
-# for the versioned sibling.
-target_idx = None
-indent = ""
-label = ""
-for i, line in enumerate(lines):
-    if current_entry in line:
-        target_idx = i
-        m = re.match(r"^(\s*-\s+)(.*?):\s*'!include", line)
-        if not m:
-            sys.stderr.write(f"could not parse mkdocs label for {comp}\n")
-            sys.exit(1)
-        indent = m.group(1)
-        label = m.group(2)
-        break
-
-if target_idx is None:
-    sys.stderr.write(f"current entry not found in mkdocs.yml: {current_entry}\n")
+inc_re = re.compile(rf"'!include\s+{re.escape(comp)}/([^/]+)/mkdocs\.yml'")
+idxs = [i for i, l in enumerate(lines) if inc_re.search(l)]
+cur_idx = next((i for i in idxs if f"{comp}/current/" in lines[i]), None)
+if cur_idx is None:
+    sys.stderr.write(f"current entry not found for {comp}\n")
     sys.exit(1)
+m = re.match(r"^(\s*)-\s+(.*?):\s*'!include", lines[cur_idx])
+if not m:
+    sys.stderr.write(f"could not parse mkdocs label for {comp}\n")
+    sys.exit(1)
+indent, label = m.group(1), m.group(2)
 
-new_line = f"{indent}{label} {version}: {new_entry}\n"
-lines.insert(target_idx + 1, new_line)
-with open(mkdocs_path, "w") as f:
-    f.writelines(lines)
+def vkey(v):
+    return tuple(int(x) for x in v.split("."))
+
+new_inc = f"!include {comp}/{version}/mkdocs.yml"
+if label == "Current":
+    # Already nested — insert the new version child right after Current.
+    lines.insert(cur_idx + 1, f"{indent}- {version}: '{new_inc}'\n")
+else:
+    # Flat — fold the current line (and any legacy flat versioned siblings)
+    # into a nested parent->version block.
+    span = sorted(idxs)
+    versions = {inc_re.search(lines[i]).group(1) for i in span}
+    versions.discard("current")
+    versions.add(version)
+    child = indent + "  "
+    block = [f"{indent}- {label}:\n",
+             f"{child}- Current: '!include {comp}/current/mkdocs.yml'\n"]
+    for v in sorted(versions, key=vkey, reverse=True):
+        block.append(f"{child}- {v}: '!include {comp}/{v}/mkdocs.yml'\n")
+    lines[span[0]:span[-1] + 1] = block
+
+open(mkdocs_path, "w").write("".join(lines))
 sys.exit(0)
 PYEOF
         warn "  [${comp}] python mkdocs edit failed; manual mkdocs.yml edit required"


### PR DESCRIPTION
Fixes #630

## Problem

In the docs left panel, a component with multiple versions rendered as several separate, separately-expandable top-level entries — e.g. Sensor:

```
Sensor          → Motion / Thermal / Sensor
Sensor 0.2.0.0  → Motion / Thermal / Sensor
```

Cluttered, and it doesn't mirror the on-disk `<module>/<version>/` structure.

## Change

The 11 multi-version components (Audio Decoder, Audio Mixer, Audio Sink, AV Buffer, AV Clock, Video Decoder, Video Sink, Boot Reason, Common, Firmware Update, Sensor) are now nested — **parent = component, children = versions** (`Current` first, then released newest-first):

```
Sensor
  Current   → Motion / Thermal / Sensor
  0.2.0.0   → Motion / Thermal / Sensor
  0.1.0.0   → Motion / Thermal / Sensor
```

This also surfaces on-disk released versions that were missing from the nav (Sensor 0.1.0.0, Audio Decoder 0.1.0.0, Audio Mixer 0.1.0.1, etc.). Single-version components (e.g. Broadcast) are unchanged.

`update_mkdocs_for_release()` is updated to match: on release it inserts the new version as a **child** under the component's parent, and converts a component's first release from a flat entry into the nested form (so the layout stays consistent automatically).

## Verification

- `mkdocs build` succeeds; all version pages render (`sensor`, `sensor-0.1.0.0`, `sensor-0.2.0.0`).
- YAML structure validated (nested children parse correctly under each component).
- Automation tested on a copy for both paths: nested-insert (sensor 0.3.0.0 → child) and flat→nested (broadcast first release → converted), with descending version order preserved.