### PR TITLE
docs(logging): journald native sd_journal_send() as HALIF/VL transport (#645)

### DIFF
--- a/vsi/filesystem/current/docs/logging_system.md
+++ b/vsi/filesystem/current/docs/logging_system.md
@@ -38,17 +38,17 @@ HALIF_LOG_* → sd_journal_send() → journald → syslog-ng → files
 
 Using the journald native API gives the most direct path to the primary collector and avoids the cyclic-loop risk that arises when logs are submitted via `/dev/log` while `journald` is configured to forward to `syslog-ng`. `syslog-ng` sources from journald (`source(s_journald)`) and remains the single downstream transport for filtering, routing, rotation, and file output.
 
-The framework is a thin set of compile-time macros over `sd_journal_send()`; it introduces no runtime logging backend, no RDK Logger dependency, and no log4c dependency, keeping the vendor layer independent of middleware logging.
+The framework is a thin set of compile-time macros over `sd_journal_send()`. Its only runtime dependency is `libsystemd` (already present on the platform); it introduces no logging backend framework, no runtime backend selection, no RDK Logger dependency, and no log4c dependency, keeping the vendor layer independent of middleware logging.
 
 !!! note "Integration with vendor implementations"
     In many environments, **vendors already implement their own logging systems** or frameworks within their deliveries.
     The purpose of this logging design is **not to replace or redefine vendor logging systems**, but rather to:
 
     - Provide a **consistent logging mechanism** for the *wrapper and interface layers* that sit between the RDK HAL Interface (HAL IF) and the vendor implementation.
-    - Ensure messages from these wrapper layers conform to common RDK syslog-ng formatting and severity conventions.
-    - Allow smooth coexistence with existing vendor logging — for example, a HAL wrapper may log both via syslog-ng (for system-wide visibility) and via the vendor’s internal mechanism (for component diagnostics).
+    - Ensure messages from these wrapper layers conform to common RDK formatting and severity conventions in the journald → syslog-ng pipeline.
+    - Allow smooth coexistence with existing vendor logging — for example, a HAL wrapper may log both via journald (for system-wide visibility) and via the vendor’s internal mechanism (for component diagnostics).
 
-    Vendors are **not required to adopt** the syslog-ng based logging macros within their proprietary HAL implementations. Instead, they may continue to use their preferred internal frameworks, provided that the **interface layers exposed to RDK** follow this standardized logging structure.
+    Vendors are **not required to adopt** the HALIF logging macros within their proprietary HAL implementations. Instead, they may continue to use their preferred internal frameworks, provided that the **interface layers exposed to RDK** follow this standardized logging structure.
 
 !!! note "**Governance**"
     - The logging interface, conventions, and requirements described here are managed at the system level, with governance and rules discussed and agreed globally across the RDK ecosystem. These are not per-vendor or per-component decisions, but are established as part of the platform-wide architecture.
@@ -74,7 +74,7 @@ Log levels are aligned with syslog-ng priority semantics. The table defines when
 | `LOG_CRIT`    | ✅ Always           | N/A                | Unrecoverable error; requires restart or recovery action.               |
 | `LOG_ERR`     | ✅ Always           | N/A                | Runtime failure; user-visible fault.                                    |
 | `LOG_WARNING` | ✅ Always           | N/A                | Recoverable condition; degraded operation.                              |
-| `LOG_NOTICE`  | ✅ Always           | N/A                | **System milestone** (e.g., initialization complete, start/stop event). |
+| `LOG_NOTICE`  | ✅ Always           | N/A                | **System milestone** (e.g., initialisation complete, start/stop event). |
 | `LOG_INFO`    | ⚙️ Optional        | `ENABLE_LOG_INFO`  | Routine operational information; enabled in debug builds only.          |
 | `LOG_DEBUG`   | ⚙️ Optional        | `ENABLE_LOG_DEBUG` | Detailed trace-level diagnostics; for engineering builds.               |
 
@@ -95,6 +95,9 @@ System-wide logging will be capped by file size and data throughput. The detaile
 ## Example Logging Macros for Module Inclusion
 
 The following is provided as a **conceptual example** for engineers. It illustrates how you can use macros to control logging output in your module. Messages are submitted to `journald` via `sd_journal_send()`, tagging each entry with `PRIORITY=` (the syslog severity) and a `SYSLOG_IDENTIFIER=` so that `syslog-ng` can filter and route by program name.
+
+!!! note "`fmt` must be a string literal"
+    These macros build the journald field with the string-literal concatenation `"MESSAGE=" fmt`, so `fmt` must be a compile-time string literal. To log a runtime `char*`, use `"MESSAGE=%s"` and pass the pointer as an argument (e.g. `LOGF(LOG_INFO, "%s", msg)`).
 
 ```c
 #include <syslog.h>          /* LOG_* severity constants */
@@ -221,7 +224,7 @@ This approach ensures that all critical, error, and diagnostic information from 
 
 int tuner_init(void)
 {
-    LOGF(LOG_NOTICE,  "Tuner HAL initialization complete");
+    LOGF(LOG_NOTICE,  "Tuner HAL initialisation complete");
     LOGF(LOG_WARNING, "Using fallback configuration");
 
     LOGF_INFO("DSP firmware version %s", dsp_version());
@@ -239,7 +242,7 @@ void tuner_deinit(void)
 ### Example Output (Production)
 
 ```syslog
-Oct 25 10:44:02 TUNER_HAL[1021]: Tuner HAL initialization complete
+Oct 25 10:44:02 TUNER_HAL[1021]: Tuner HAL initialisation complete
 Oct 25 10:44:02 TUNER_HAL[1021]: Using fallback configuration
 Oct 25 10:45:11 TUNER_HAL[1021]: Tuner HAL shutdown
 ```
@@ -271,4 +274,4 @@ log { source(s_journald); filter(f_tuner); filter(f_runtime); destination(d_tune
 ```
 
 !!! warning "Filtering / Routing Control"
-    Modules **do not modify syslog-ng** configuration; any routing or filtering changes are expected to controlled at a system level. Although these can be overridden during development and engineering builds.
+    Modules **do not modify syslog-ng** configuration; any routing or filtering changes are expected to be controlled at a system level. Although these can be overridden during development and engineering builds.

--- a/vsi/filesystem/current/docs/logging_system.md
+++ b/vsi/filesystem/current/docs/logging_system.md
@@ -5,12 +5,13 @@
 | Date        | Author             | Comments                                              |
 | ----------- | ------------------ | ----------------------------------------------------- |
 | 25 Sept 2025 | G. Weatherup | Upgraded to full syslog-ng concepts |
+| 29 June 2026 | G. Weatherup | Transport via journald native API (`sd_journal_send()`) |
 
 ---
 
-This document defines how modules should use the **syslog-ng** service provided by the vendor layer for all runtime logging. It establishes a **common logging framework**, build-time verbosity controls, and clear usage policy for log levels in production and debug environments.
+This document defines how modules emit runtime logs into the platform logging pipeline. It establishes a **common logging framework**, build-time verbosity controls, and clear usage policy for log levels in production and debug environments.
 
-The design removes the need for a custom logging subsystem — all modules interact with syslog-ng directly through the standard POSIX `syslog()` API.
+The design removes the need for a custom logging subsystem — modules write directly to **journald** through the native `sd_journal_send()` API. `journald` is the primary collector on the platform and forwards entries to **syslog-ng**, which filters, routes, and writes the log files.
 
 ---
 
@@ -19,13 +20,25 @@ The design removes the need for a custom logging subsystem — all modules inter
 
 ## Overview
 
-The logging system defines how RDK HAL interface layers and associated wrapper components use the **syslog-ng–based system logging infrastructure** provided by the platform.
+The logging system defines how RDK HAL interface layers and associated wrapper components emit logs into the platform's **journald + syslog-ng** logging infrastructure.
 
 This implementation provides a **common and consistent logging method** for HAL interface layers to:
 
 - Use standardized severity levels (`LOG_CRIT`, `LOG_ERR`, `LOG_WARNING`, etc.).
 - Maintain uniform formatting and verbosity control across all HAL and vendor integrations.
-- Ensure log output integrates seamlessly with the platform’s existing **syslog-ng** pipeline and vendor log management tools.
+- Ensure log output integrates seamlessly with the platform’s existing **journald → syslog-ng** pipeline and vendor log management tools.
+
+### Logging Pipeline
+
+HALIF / vendor-layer macros write directly to `journald` using the native `sd_journal_send()` API. `journald` is the primary collector and forwards entries to `syslog-ng`, which applies filtering/routing and writes the files:
+
+```text
+HALIF_LOG_* → sd_journal_send() → journald → syslog-ng → files
+```
+
+Using the journald native API gives the most direct path to the primary collector and avoids the cyclic-loop risk that arises when logs are submitted via `/dev/log` while `journald` is configured to forward to `syslog-ng`. `syslog-ng` sources from journald (`source(s_journald)`) and remains the single downstream transport for filtering, routing, rotation, and file output.
+
+The framework is a thin set of compile-time macros over `sd_journal_send()`; it introduces no runtime logging backend, no RDK Logger dependency, and no log4c dependency, keeping the vendor layer independent of middleware logging.
 
 !!! note "Integration with vendor implementations"
     In many environments, **vendors already implement their own logging systems** or frameworks within their deliveries.
@@ -44,9 +57,9 @@ This implementation provides a **common and consistent logging method** for HAL 
 
 | Category               | Description                                                                  |
 | ---------------------- | ---------------------------------------------------------------------------- |
-| **Interface**          | Modules call `syslog()` directly. No wrapper.                                |
+| **Interface**          | Modules call `sd_journal_send()` directly. No runtime backend.               |
 | **Control**            | Verbosity controlled by build flags (`ENABLE_LOG_INFO`, `ENABLE_LOG_DEBUG`). |
-| **Routing**            | Syslog-ng filters and routes based on `program()` and `level()`.             |
+| **Routing**            | Syslog-ng sources from journald; routes on identifier and `level()`.         |
 | **Production Policy**  | NOTICE and above are enabled; INFO and DEBUG are disabled.                   |
 | **Engineering Builds** | Enable INFO and DEBUG for diagnostics and component-level tracing.           |
 
@@ -81,20 +94,32 @@ System-wide logging will be capped by file size and data throughput. The detaile
 
 ## Example Logging Macros for Module Inclusion
 
-The following is provided as a **conceptual example** for engineers. It illustrates how you can use macros to control logging output in your module. Each module should still call `openlog()`/`closelog()` and may consider to adapt these macros as needed.
+The following is provided as a **conceptual example** for engineers. It illustrates how you can use macros to control logging output in your module. Messages are submitted to `journald` via `sd_journal_send()`, tagging each entry with `PRIORITY=` (the syslog severity) and a `SYSLOG_IDENTIFIER=` so that `syslog-ng` can filter and route by program name.
 
 ```c
-#include <syslog.h>
+#include <syslog.h>          /* LOG_* severity constants */
+#include <systemd/sd-journal.h>
+
+#define MODULE_TAG "TUNER_HAL"
+
+/* ---- Always-on severities ---- */
+#define LOGF(prio, fmt, ...) \
+    sd_journal_send("PRIORITY=%d", (prio), \
+                    "SYSLOG_IDENTIFIER=%s", MODULE_TAG, \
+                    "MESSAGE=" fmt, ##__VA_ARGS__, NULL)
 
 /* ---- Optional severities (build controlled) ---- */
 #ifdef ENABLE_LOG_INFO
-  #define LOGF_INFO(fmt, ...)   syslog(LOG_INFO, fmt, ##__VA_ARGS__)
+  #define LOGF_INFO(fmt, ...)   LOGF(LOG_INFO, fmt, ##__VA_ARGS__)
 #else
   #define LOGF_INFO(fmt, ...)   do {} while (0)
 #endif
 
 #ifdef ENABLE_LOG_DEBUG
-  #define LOGF_DEBUG(fmt, ...)  syslog(LOG_DEBUG, "[%s:%d] " fmt, __func__, __LINE__, ##__VA_ARGS__)
+  #define LOGF_DEBUG(fmt, ...)  sd_journal_send("PRIORITY=%d", LOG_DEBUG, \
+                                  "SYSLOG_IDENTIFIER=%s", MODULE_TAG, \
+                                  "CODE_FILE=%s", __FILE__, "CODE_LINE=%d", __LINE__, \
+                                  "MESSAGE=" fmt, ##__VA_ARGS__, NULL)
 #else
   #define LOGF_DEBUG(fmt, ...)  do {} while (0)
 #endif
@@ -168,38 +193,46 @@ This approach ensures that all critical, error, and diagnostic information from 
 ## Example Module Usage
 
 ```c
-#include <syslog.h>
+#include <syslog.h>          /* LOG_* severity constants */
+#include <systemd/sd-journal.h>
+
+#define MODULE_TAG "TUNER_HAL"
+
+#define LOGF(prio, fmt, ...) \
+    sd_journal_send("PRIORITY=%d", (prio), \
+                    "SYSLOG_IDENTIFIER=%s", MODULE_TAG, \
+                    "MESSAGE=" fmt, ##__VA_ARGS__, NULL)
 
 /* ---- Optional severities (build controlled) ---- */
 #ifdef ENABLE_LOG_INFO
-  #define LOGF_INFO(fmt, ...)   syslog(LOG_INFO, fmt, ##__VA_ARGS__)
+  #define LOGF_INFO(fmt, ...)   LOGF(LOG_INFO, fmt, ##__VA_ARGS__)
 #else
   #define LOGF_INFO(fmt, ...)   do {} while (0)
 #endif
 
 #ifdef ENABLE_LOG_DEBUG
-  #define LOGF_DEBUG(fmt, ...)  syslog(LOG_DEBUG, "[%s:%d] " fmt, __func__, __LINE__, ##__VA_ARGS__)
+  #define LOGF_DEBUG(fmt, ...)  sd_journal_send("PRIORITY=%d", LOG_DEBUG, \
+                                  "SYSLOG_IDENTIFIER=%s", MODULE_TAG, \
+                                  "CODE_FILE=%s", __FILE__, "CODE_LINE=%d", __LINE__, \
+                                  "MESSAGE=" fmt, ##__VA_ARGS__, NULL)
 #else
   #define LOGF_DEBUG(fmt, ...)  do {} while (0)
 #endif
 
 int tuner_init(void)
 {
-    openlog("TUNER_HAL", LOG_PID, LOG_USER);
-
-    syslog(LOG_NOTICE, "Tuner HAL initialization complete");
-    syslog(LOG_WARNING, "Using fallback configuration");
+    LOGF(LOG_NOTICE,  "Tuner HAL initialization complete");
+    LOGF(LOG_WARNING, "Using fallback configuration");
 
     LOGF_INFO("DSP firmware version %s", dsp_version());
     LOGF_DEBUG("PLL lock value=0x%x bias=%d", read_pll(), read_bias());
 
-    closelog();
     return 0;
 }
 
 void tuner_deinit(void)
 {
-    syslog(LOG_NOTICE, "Tuner HAL shutdown");
+    LOGF(LOG_NOTICE, "Tuner HAL shutdown");
 }
 ```
 
@@ -222,10 +255,10 @@ Oct 25 10:44:02 TUNER_HAL[1021]: [tuner_init:47] PLL lock value=0x32 bias=9
 
 ## Runtime Configuration (syslog-ng Filtering)
 
-The vendor’s syslog-ng configuration handles message routing based on `program()` and `level()`:
+The vendor’s syslog-ng configuration sources entries from journald and routes them based on identifier and `level()`. The `SYSLOG_IDENTIFIER=` set by `sd_journal_send()` is matched with `program()`:
 
 ```syslog
-source s_sys { system(); internal(); };
+source s_journald { systemd-journal(); };
 
 # Filter and routing example
 filter f_tuner { program("TUNER_HAL"); };
@@ -234,7 +267,7 @@ filter f_debug   { level(debug..emerg);  };  # debug/engineering
 
 destination d_tuner_file { file("/var/log/TUNER_HAL.log" create-dirs(yes)); };
 
-log { source(s_sys); filter(f_tuner); filter(f_runtime); destination(d_tuner_file); };
+log { source(s_journald); filter(f_tuner); filter(f_runtime); destination(d_tuner_file); };
 ```
 
 !!! warning "Filtering / Routing Control"


### PR DESCRIPTION
Fixes #645

## What

Updates the VSI **Logging System** spec (`vsi/filesystem/current/docs/logging_system.md`) so the HALIF / vendor-layer (VL) logging transport uses **journald's native `sd_journal_send()` API** instead of POSIX `syslog()`.

**Canonical path:**

```text
HALIF_LOG_* → sd_journal_send() → journald → syslog-ng → files
```

## Why

Outcome of the *Vendor layer logger* architecture thread (Jun 2026). On the current RDK-E image:

- `journald` is the **primary collector** and `syslog-ng` *sources from journald* (`source(s_journald)`), with `ForwardToSyslog=no` by default.
- A POSIX `syslog()` call therefore actually flows `component → syslog() → /dev/log → journald → syslog-ng → file` — indirect, and it risks a **cyclic log loop** if journald is also forwarding to syslog-ng.
- Calling the journald native API goes straight to the primary collector (`→ journald volatile RAM → syslog-ng → file`), removing the loop risk.

The change keeps the VL **independent of RDK Logger (middleware) and log4c (orphaned)**, and introduces **no runtime logging backend / dynamic library** — HALIF logging stays a thin set of compile-time macros over `sd_journal_send()`.

## Changes

- Intro + Overview: state journald (`sd_journal_send()`) as the transport; add a **Logging Pipeline** subsection with the canonical path.
- **Key Principles** table: Interface row → `sd_journal_send()`; Routing row → syslog-ng sources from journald.
- Macro and module-usage examples: `openlog()`/`syslog()` → `sd_journal_send()` with structured `PRIORITY=` / `SYSLOG_IDENTIFIER=` (and `CODE_FILE`/`CODE_LINE` for DEBUG), preserving the existing `ENABLE_LOG_INFO` / `ENABLE_LOG_DEBUG` build-time verbosity controls.
- Runtime configuration example: syslog-ng source switched to `systemd-journal()` (`s_journald`).

## Scope notes

- Targets `logging_system.md` only — the single surviving logging spec. The older `halif_logging_system_design.md` is being retired in #627; this PR does not touch it (no overlap / no conflict).
- The broad RDK CPE logging **policy & governance** / canonical-format work remains tracked in #301.
- Log rotation / size / throughput policy stays TBD per the existing spec.

## Testing

- Doc-only change; no code paths affected.
