### PR TITLE
fix(release): clean stale build state before first verification build (#649)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -245,11 +245,32 @@ deploy_versioned_docs() {
     return 0
 }
 
+# The first verification build of a release run starts from clean staging,
+# so the cohort is proven to compile from a clean checkout — not from
+# incrementally staged headers (out/build/include) or a stale build cache
+# that could mask a missing dependency (see #638). Runs once per invocation
+# (guarded); the Binder SDK in out/target is preserved, so there is no SDK
+# rebuild and the clean is fast.
+_VERIFY_CLEAN_DONE=0
+verification_clean_once() {
+    [[ "${_VERIFY_CLEAN_DONE}" -eq 1 ]] && return 0
+    _VERIFY_CLEAN_DONE=1
+    phase "Pre-verification clean (once): build/, out/build/include, build cache"
+    rm -rf "${REPO_ROOT}/build"
+    rm -rf "${REPO_ROOT}/out/build/include"
+    rm -f "${BUILD_CACHE_FILE}"
+    log "  Cleared build/, out/build/include and ${BUILD_CACHE_FILE#"${REPO_ROOT}/"} —"
+    log "  verification builds from clean staging (Binder SDK in out/target kept)."
+}
+
 run_verification_build() {
     local label="$1"          # "current cohort" / "released cohort"
     local log_file="$2"
     shift 2
     mkdir -p "$(dirname "${log_file}")"
+
+    # Force a from-scratch build for the first verification pass of this run.
+    verification_clean_once
 
     # Cache lookup — skip if these exact inputs already built successfully.
     local key="$*"


### PR DESCRIPTION
Closes #649.

## Problem
The release verification build (`run_verification_build` → `./build_modules.sh manifest`) can pass on a developer machine yet fail on a fresh clone:

- **Stale staged headers** — `out/build/include/<dep>/<ver>/include/` is populated incrementally by prior builds, so a missing dependency header (the #638 `PropertyValue.h` case) is invisible to anyone who has already done a full build.
- **Build cache** — `out/.build-cache` skips the verification build entirely when input AIDL hashes are unchanged, even if on-disk staged artefacts are stale.

Net effect: a release could be cut and tagged "having passed verification" without ever proving the cohort builds cleanly from scratch.

## Fix
`verification_clean_once()` runs before the **first** verification build of a release invocation (guarded to once per run) and performs a **targeted** clean:

- `rm -rf build/`
- `rm -rf out/build/include`
- `rm -f out/.build-cache`
- **keeps** `out/target/` (the Binder SDK) — no SDK rebuild, so the clean is fast

The verification build then re-stages all dependency headers from scratch, so release verification reflects a clean-checkout build. Both `build_modules.sh manifest` and `all` repopulate `out/build/include` themselves, so nothing downstream breaks.

## Test
- `bash -n scripts/release.sh` clean
- Guard + rm-target behaviour verified in isolation (runs once, removes the three targets, preserves `out/target`).