### PR TITLE
build: nest snapshot build dir as build/<module>/<version> (#651)

### DIFF
--- a/build_modules.sh
+++ b/build_modules.sh
@@ -583,7 +583,7 @@ if [[ "$VERSION" != "current" ]]; then
         exit 1
     fi
 
-    SNAPSHOT_BUILD_DIR="$ROOT_DIR/build/$MODULE-$VERSION"
+    SNAPSHOT_BUILD_DIR="$ROOT_DIR/build/$MODULE/$VERSION"
     if [[ "$CLEAN" == true ]]; then
         echo "🧹 Cleaning snapshot build directory: $SNAPSHOT_BUILD_DIR"
         rm -rf "$SNAPSHOT_BUILD_DIR"


### PR DESCRIPTION
Closes #651.

Snapshot/manifest builds wrote their CMake build tree to a flat `build/<module>-<version>` (e.g. `build/audiodecoder-0.1.0.0`), which doesn't match the nested source layout `<module>/<version>/`.

This nests the build output to mirror the source tree:

`build/<module>-<version>`  →  `build/<module>/<version>`

e.g. `build/audiodecoder/0.1.0.0`, `build/audiodecoder/0.2.0.0`.

Single-line change to the `SNAPSHOT_BUILD_DIR` assignment in the snapshot-build path of `build_modules.sh`. Everything downstream (`cmake -B`, `--build`, `--install`, `--clean` rm) flows through that variable, so nothing else changes. `build/current` (whole-cohort) and `build/binder` keep their names.

`bash -n build_modules.sh` clean.