### PR TITLE
docs(rag): add GitHub Team links to Reviewer Team Coverage table (#653)

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -171,17 +171,17 @@
 
 > **Note:** Architecture and Product_Architecture are the same organisational group reviewing as separate stakeholders, with members drawn from various teams.
 
-| Team | Role |
-|------|------|
-| Architecture | All components |
-| Product_Architecture | All components |
-| AV_Architecture | Audio/Video pipeline components |
-| Broadcast_Team | Broadcast/tuner components |
-| Control_Manager_Architecture | Remote control & input management |
-| Graphics_Architecture | Graphics, display & composition |
-| Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity |
-| Kernel_Architecture | System, kernel, boot & platform |
-| Vendor_Layer_Team | Vendor HAL implementation review |
+| Team | Role | GitHub Team (add members here) |
+| ---- | ---- | ------------------------------ |
+| Architecture | All components | [hal-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-arch-reviewers) |
+| Product_Architecture | All components | [hal-product-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-product-arch-reviewers) |
+| AV_Architecture | Audio/Video pipeline components | [hal-av-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-av-arch-reviewers) |
+| Broadcast_Team | Broadcast/tuner components | [hal-broadcast-reviewers](https://github.com/orgs/rdkcentral/teams/hal-broadcast-reviewers) |
+| Control_Manager_Architecture | Remote control & input management | [hal-control-manager-reviewers](https://github.com/orgs/rdkcentral/teams/hal-control-manager-reviewers) |
+| Graphics_Architecture | Graphics, display & composition | [hal-graphics-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-graphics-arch-reviewers) |
+| Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity | [hal-connectivity-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-connectivity-arch-reviewers) |
+| Kernel_Architecture | System, kernel, boot & platform | [hal-kernel-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-kernel-arch-reviewers) |
+| Vendor_Layer_Team | Vendor HAL implementation review | [rdk-halif-aidl-pr-review-team](https://github.com/orgs/rdkcentral/teams/rdk-halif-aidl-pr-review-team) |
 
 ---
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -408,17 +408,17 @@ cat >> "$OUTPUT" << 'FOOTER'
 
 > **Note:** Architecture and Product_Architecture are the same organisational group reviewing as separate stakeholders, with members drawn from various teams.
 
-| Team | Role |
-|------|------|
-| Architecture | All components |
-| Product_Architecture | All components |
-| AV_Architecture | Audio/Video pipeline components |
-| Broadcast_Team | Broadcast/tuner components |
-| Control_Manager_Architecture | Remote control & input management |
-| Graphics_Architecture | Graphics, display & composition |
-| Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity |
-| Kernel_Architecture | System, kernel, boot & platform |
-| Vendor_Layer_Team | Vendor HAL implementation review |
+| Team | Role | GitHub Team (add members here) |
+| ---- | ---- | ------------------------------ |
+| Architecture | All components | [hal-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-arch-reviewers) |
+| Product_Architecture | All components | [hal-product-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-product-arch-reviewers) |
+| AV_Architecture | Audio/Video pipeline components | [hal-av-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-av-arch-reviewers) |
+| Broadcast_Team | Broadcast/tuner components | [hal-broadcast-reviewers](https://github.com/orgs/rdkcentral/teams/hal-broadcast-reviewers) |
+| Control_Manager_Architecture | Remote control & input management | [hal-control-manager-reviewers](https://github.com/orgs/rdkcentral/teams/hal-control-manager-reviewers) |
+| Graphics_Architecture | Graphics, display & composition | [hal-graphics-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-graphics-arch-reviewers) |
+| Connectivity_Architecture | Bluetooth, Wi-Fi & connectivity | [hal-connectivity-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-connectivity-arch-reviewers) |
+| Kernel_Architecture | System, kernel, boot & platform | [hal-kernel-arch-reviewers](https://github.com/orgs/rdkcentral/teams/hal-kernel-arch-reviewers) |
+| Vendor_Layer_Team | Vendor HAL implementation review | [rdk-halif-aidl-pr-review-team](https://github.com/orgs/rdkcentral/teams/rdk-halif-aidl-pr-review-team) |
 
 ---
 


### PR DESCRIPTION
Closes #653.

Adds a **GitHub Team (add members here)** column to the Reviewer Team Coverage table, linking each reviewer team to its `rdkcentral` org page so members can be added/managed straight from the report.

- Slugs come from `scripts/team_mapping.yaml` (all 9 verified to exist in the org).
- Changed in **`scripts/generate_rag_report.sh`** (the table is generated, so a manual edit to the output would be wiped on regen) and mirrored into the committed **`RAG_STATUS_REPORT.md`** — the two table blocks are byte-identical.

`bash -n scripts/generate_rag_report.sh` clean.