### PR TITLE
fix(build): auto-resolve snapshot dependency closure (#638)

### DIFF
--- a/build_modules.sh
+++ b/build_modules.sh
@@ -568,6 +568,27 @@ fi
 # No toolchain involvement, no code generation.
 #######################################################################
 
+# Stage a snapshot's committed include/ tree into out/build/include so that
+# dependents resolve their ${HALIF_INCLUDE_DIR}/<comp>/<ver>/include refs.
+# Pure copy — snapshot include/ trees are committed pre-generated C++.
+stage_snapshot_headers() {
+    local comp="$1" ver="$2"
+    local src_inc="$ROOT_DIR/$comp/$ver/include"
+    [[ -d "$src_inc" ]] || return 0
+    local dst_inc="$ROOT_DIR/out/build/include/$comp/$ver/include"
+    mkdir -p "$dst_inc"
+    cp -RT "$src_inc" "$dst_inc"
+}
+
+# Extract the "<comp> <ver>" dependency pairs a snapshot declares via its
+# ${HALIF_INCLUDE_DIR}/<comp>/<ver>/include references in CMakeLists.txt.
+snapshot_deps() {
+    local cmake_file="$1"
+    grep -oE 'HALIF_INCLUDE_DIR\}/[a-z][a-z0-9_]*/[0-9][0-9.]*/include' "$cmake_file" 2>/dev/null \
+        | sed -E 's#HALIF_INCLUDE_DIR\}/([^/]+)/([^/]+)/include#\1 \2#' \
+        | sort -u
+}
+
 if [[ "$VERSION" != "current" ]]; then
     if [[ "$MODULE" == "all" ]]; then
         echo "❌ ERROR: --version $VERSION cannot be combined with 'all'."
@@ -593,6 +614,27 @@ if [[ "$VERSION" != "current" ]]; then
     echo "📸 Snapshot build: $MODULE/$VERSION"
     echo "    source: $SNAPSHOT_DIR"
     echo "    build:  $SNAPSHOT_BUILD_DIR"
+    echo ""
+
+    # Resolve and build this snapshot's dependency closure first, so its
+    # dependency headers (out/build/include) and libraries
+    # (out/target/lib/halif) are present before we configure. Each dependency
+    # is itself a snapshot build, so transitive deps resolve recursively, and
+    # an already-built dependency is skipped. Without this, a standalone
+    # snapshot build on a fresh checkout fails to find a dependency header
+    # such as com/rdk/hal/PropertyValue.h (#638).
+    while read -r dep dep_ver; do
+        [[ -n "$dep" ]] || continue
+        dep_so="$ROOT_DIR/out/target/lib/halif/lib${dep}-v${dep_ver}-cpp.so"
+        dep_inc="$ROOT_DIR/out/build/include/$dep/$dep_ver/include"
+        if [[ -f "$dep_so" && -d "$dep_inc" ]]; then
+            echo "   ✓ dependency ${dep}/${dep_ver} already built"
+            continue
+        fi
+        echo "   ↳ building dependency ${dep}/${dep_ver} ..."
+        "$0" "$dep" --version "$dep_ver" --jobs "$JOBS" --sdk-dir "$SDK_DIR" || {
+            echo "❌ Failed to build dependency ${dep}/${dep_ver} for $MODULE/$VERSION"; exit 1; }
+    done < <(snapshot_deps "$SNAPSHOT_DIR/CMakeLists.txt")
     echo ""
 
     # The local dev layout splits binder headers (out/build/include/binder_sdk)
@@ -621,6 +663,9 @@ if [[ "$VERSION" != "current" ]]; then
     else
         echo "❌ Snapshot library not found at $SO_PATH"; exit 1
     fi
+
+    # Stage this snapshot's headers so a later dependent build resolves them.
+    stage_snapshot_headers "$MODULE" "$VERSION"
     exit 0
 fi
 

--- a/build_modules.sh
+++ b/build_modules.sh
@@ -576,15 +576,19 @@ stage_snapshot_headers() {
     local src_inc="$ROOT_DIR/$comp/$ver/include"
     [[ -d "$src_inc" ]] || return 0
     local dst_inc="$ROOT_DIR/out/build/include/$comp/$ver/include"
-    mkdir -p "$dst_inc"
-    cp -RT "$src_inc" "$dst_inc"
+    mkdir -p "$dst_inc" || return 1
+    # Fail fast: a silent cp failure leaves dependents to fail later with
+    # missing headers, obscuring the root cause.
+    cp -RT "$src_inc" "$dst_inc" || return 1
 }
 
 # Extract the "<comp> <ver>" dependency pairs a snapshot declares via its
 # ${HALIF_INCLUDE_DIR}/<comp>/<ver>/include references in CMakeLists.txt.
 snapshot_deps() {
     local cmake_file="$1"
-    grep -oE 'HALIF_INCLUDE_DIR\}/[a-z][a-z0-9_]*/[0-9][0-9.]*/include' "$cmake_file" 2>/dev/null \
+    # `|| true`: grep exits 1 when a snapshot declares no HAL deps — that is a
+    # normal "empty list", not an error, so don't let it trip `set -o pipefail`.
+    { grep -oE 'HALIF_INCLUDE_DIR\}/[a-z][a-z0-9_]*/[0-9][0-9.]*/include' "$cmake_file" 2>/dev/null || true; } \
         | sed -E 's#HALIF_INCLUDE_DIR\}/([^/]+)/([^/]+)/include#\1 \2#' \
         | sort -u
 }
@@ -665,7 +669,8 @@ if [[ "$VERSION" != "current" ]]; then
     fi
 
     # Stage this snapshot's headers so a later dependent build resolves them.
-    stage_snapshot_headers "$MODULE" "$VERSION"
+    stage_snapshot_headers "$MODULE" "$VERSION" \
+        || { echo "❌ Failed to stage snapshot headers for $MODULE/$VERSION"; exit 1; }
     exit 0
 fi
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,18 +5,20 @@ is wired into CI — run it by hand.
 
 ## `smoke_test.sh`
 
-Exercises the three build paths the module-local restructure added and asserts
+Exercises the build paths the module-local restructure added and asserts
 the produced HAL libraries:
 
 ```bash
 ./tests/smoke_test.sh
 ```
 
-| Step | Command | Assertion |
-| ---- | ------- | --------- |
-| 1 | `./build_modules.sh all --clean` | one `lib<module>-vcurrent-cpp.so` per `*/current/` component |
-| 2 | `./build_modules.sh manifest` | same set, built from `versions.yaml` |
-| 3 | `./build_modules.sh <c> --version <v>` | `lib<c>-v<v>-cpp.so` for the first committed release snapshot |
+| Command | Assertion |
+| ------- | --------- |
+| `./build_modules.sh all --clean` | one `lib<module>-vcurrent-cpp.so` per `*/current/` component |
+| `./build_modules.sh manifest` | the released cohort from `versions_released.yaml` |
+| `./build_modules.sh manifest --file versions_current.yaml` | the dev cohort, every component at `current/` |
+| `./build_modules.sh <c> --version <v>` | `lib<c>-v<v>-cpp.so` for the first committed release snapshot |
+| `./build_modules.sh <c> --version <v>` with its dependency closure wiped first | the standalone snapshot build auto-resolves and rebuilds its dependencies' libraries + staged headers ([#638](https://github.com/rdkcentral/rdk-halif-aidl/issues/638)) |
 
 Exit status is `0` only if every check passes. The Binder SDK is staged
 automatically by `build_modules.sh` if missing.

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,13 +12,16 @@ the produced HAL libraries:
 ./tests/smoke_test.sh
 ```
 
+Where `<c>` is a component name (e.g. `videosink`) and `<v>` a released
+version (e.g. `0.2.0.0`):
+
 | Command | Assertion |
 | ------- | --------- |
 | `./build_modules.sh all --clean` | one `lib<module>-vcurrent-cpp.so` per `*/current/` component |
 | `./build_modules.sh manifest` | the released cohort from `versions_released.yaml` |
 | `./build_modules.sh manifest --file versions_current.yaml` | the dev cohort, every component at `current/` |
-| `./build_modules.sh <c> --version <v>` | `lib<c>-v<v>-cpp.so` for the first committed release snapshot |
-| `./build_modules.sh <c> --version <v>` with its dependency closure wiped first | the standalone snapshot build auto-resolves and rebuilds its dependencies' libraries + staged headers ([#638](https://github.com/rdkcentral/rdk-halif-aidl/issues/638)) |
+| `./build_modules.sh <c> --version <v>` | builds `lib<c>-v<v>-cpp.so` for the first committed release snapshot |
+| the same build, but with `<c>`'s dependency snapshots deleted first | the standalone snapshot build auto-resolves the dependency closure and rebuilds each dependency's library and staged headers ([#638](https://github.com/rdkcentral/rdk-halif-aidl/issues/638)) |
 
 Exit status is `0` only if every check passes. The Binder SDK is staged
 automatically by `build_modules.sh` if missing.

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -22,7 +22,7 @@
 #
 # smoke_test.sh - module-local build smoke test.
 #
-# Exercises the four build paths the module-local restructure (#493) +
+# Exercises the build paths the module-local restructure (#493) +
 # versioned-imports work (#538) added, and asserts the produced HAL
 # libraries:
 #
@@ -30,6 +30,7 @@
 #   2. ./build_modules.sh manifest                                     - build the released cohort (versions_released.yaml)
 #   3. ./build_modules.sh manifest --file versions_current.yaml        - build the dev cohort (every component at current/)
 #   4. ./build_modules.sh <c> --version <v>                            - build a single released snapshot
+#   5. ./build_modules.sh <c> --version <v> (deps wiped first)         - standalone snapshot build auto-resolves its dependency closure (#638)
 #
 # It is run on demand (no CI wiring). Exit status is 0 only if every check
 # passes.
@@ -44,7 +45,7 @@ REPO_ROOT="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.." && pwd)"
 cd "${REPO_ROOT}"
 
 if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
-    sed -n '23,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '23,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 0
 fi
 
@@ -76,7 +77,7 @@ echo ""
 # previous build don't inflate the lib counts. `--clean` clears the build
 # tree but not the staged output.
 rm -rf "${HALIF_LIB_DIR}"
-echo "[1/4] ./build_modules.sh all --clean"
+echo "[1/5] ./build_modules.sh all --clean"
 if ./build_modules.sh all --clean > /tmp/smoke_all.log 2>&1; then
     n=$(count_libs 'lib*-vcurrent-cpp.so')
     if [ "${n}" -eq "${EXPECTED_CURRENT}" ]; then
@@ -113,7 +114,7 @@ fi
 # with no snapshot yet) falls through and stays at `-vcurrent-cpp`.
 #######################################################################
 echo ""
-echo "[2/4] ./build_modules.sh manifest      (versions_released.yaml)"
+echo "[2/5] ./build_modules.sh manifest      (versions_released.yaml)"
 # Count via the *same* awk regex `build_modules.sh manifest` uses, so a
 # manifest-format regression that the parser silently drops (e.g.
 # aligned `name  : version` with spaces before the colon) shows up
@@ -158,7 +159,7 @@ fi
 # the in-development cohort devs work against day-to-day.
 #######################################################################
 echo ""
-echo "[3/4] ./build_modules.sh manifest --file versions_current.yaml  (dev)"
+echo "[3/5] ./build_modules.sh manifest --file versions_current.yaml  (dev)"
 if ./build_modules.sh manifest --file versions_current.yaml > /tmp/smoke_manifest_current.log 2>&1; then
     n=$(count_libs 'lib*-vcurrent-cpp.so')
     if [ "${n}" -eq "${EXPECTED_CURRENT}" ]; then
@@ -178,7 +179,7 @@ fi
 # it. (Released via ./release.sh; the snapshots are committed.)
 #######################################################################
 echo ""
-echo "[4/4] per-version snapshot build"
+echo "[4/5] per-version snapshot build"
 SNAP=""
 for d in */[0-9]*.[0-9]*.[0-9]*.[0-9]*/CMakeLists.txt; do
     [ -f "${d}" ] || continue
@@ -202,6 +203,69 @@ else
     else
         fail "snapshot: build_modules.sh exited non-zero (see /tmp/smoke_snapshot.log)"
         tail -15 /tmp/smoke_snapshot.log | sed 's/^/        /'
+    fi
+fi
+
+#######################################################################
+# 5. Standalone snapshot build with its dependency closure wiped (#638)
+#
+# Steps 1-4 leave out/build/include + out/target fully populated, so a
+# per-version snapshot build never proves it can stand up its own
+# dependencies. Here we pick a released snapshot that HAS dependencies,
+# wipe those dependencies' staged headers + libraries, then build ONLY
+# that snapshot and assert it auto-resolves and rebuilds the closure
+# (the exact failure mode of #638: missing com/rdk/hal/PropertyValue.h).
+#######################################################################
+echo ""
+echo "[5/5] standalone snapshot build resolves its dependency closure (#638)"
+# Find the first released snapshot whose CMakeLists declares HAL deps.
+DEPSNAP=""
+for d in */[0-9]*.[0-9]*.[0-9]*.[0-9]*/CMakeLists.txt; do
+    [ -f "${d}" ] || continue
+    grep -qE 'HALIF_INCLUDE_DIR\}/[a-z][a-z0-9_]*/[0-9][0-9.]*/include' "${d}" || continue
+    DEPSNAP="${d%/CMakeLists.txt}"
+    break
+done
+
+if [ -z "${DEPSNAP}" ]; then
+    pass "dep-closure: no released snapshot with dependencies found — nothing to exercise"
+else
+    dcomp="${DEPSNAP%%/*}"
+    dver="${DEPSNAP#*/}"
+    dcmake="${DEPSNAP}/CMakeLists.txt"
+    # Immediate dependencies declared by the snapshot's CMakeLists.
+    mapfile -t DEPS < <(grep -oE 'HALIF_INCLUDE_DIR\}/[a-z][a-z0-9_]*/[0-9][0-9.]*/include' "${dcmake}" \
+        | sed -E 's#HALIF_INCLUDE_DIR\}/([^/]+)/([^/]+)/include#\1 \2#' | sort -u)
+    echo "       target ${dcomp}/${dver}; wiping ${#DEPS[@]} dependency(ies): ${DEPS[*]}"
+
+    # Wipe the target + each dependency's staged headers, libraries and build
+    # dirs so the build genuinely starts from an unstaged state.
+    rm -rf "build/${dcomp}-${dver}" "build/${dcomp}/${dver}"
+    rm -f  "${HALIF_LIB_DIR}/lib${dcomp}-v${dver}-cpp.so"
+    rm -rf "${REPO_ROOT}/out/build/include/${dcomp}/${dver}"
+    for pair in "${DEPS[@]}"; do
+        set -- ${pair}; dep="$1"; depver="$2"
+        rm -f  "${HALIF_LIB_DIR}/lib${dep}-v${depver}-cpp.so"
+        rm -rf "${REPO_ROOT}/out/build/include/${dep}/${depver}"
+        rm -rf "build/${dep}-${depver}" "build/${dep}/${depver}"
+    done
+
+    if ./build_modules.sh "${dcomp}" --version "${dver}" > /tmp/smoke_depclosure.log 2>&1; then
+        missing=0
+        # The target and every wiped dependency lib must be back.
+        for pair in "${dcomp} ${dver}" "${DEPS[@]}"; do
+            set -- ${pair}; c="$1"; v="$2"
+            [ -f "${HALIF_LIB_DIR}/lib${c}-v${v}-cpp.so" ] || { fail "dep-closure: lib${c}-v${v}-cpp.so not rebuilt"; missing=1; }
+        done
+        # Each dependency's headers must have been re-staged (the #638 symptom).
+        for pair in "${DEPS[@]}"; do
+            set -- ${pair}; dep="$1"; depver="$2"
+            [ -d "${REPO_ROOT}/out/build/include/${dep}/${depver}/include" ] || { fail "dep-closure: ${dep}/${depver} headers not staged"; missing=1; }
+        done
+        [ "${missing}" -eq 0 ] && pass "dep-closure: ${dcomp}/${dver} auto-resolved and rebuilt ${#DEPS[@]} dependency(ies) from a wiped state"
+    else
+        fail "dep-closure: build_modules.sh exited non-zero (see /tmp/smoke_depclosure.log)"
+        tail -15 /tmp/smoke_depclosure.log | sed 's/^/        /'
     fi
 fi
 


### PR DESCRIPTION
Closes #638.

## Problem
`./build_modules.sh videosink --version 0.2.0.0` fails on a fresh checkout with `fatal error: com/rdk/hal/PropertyValue.h: No such file or directory`. The single-module snapshot path assumed its dependency **headers** were already staged in `out/build/include` and dependency **libraries** already installed in `out/target/lib/halif` — but only the `manifest` path arranged that. On a clean tree the compile fails (missing header), and even with headers the link would fail (missing `lib<dep>-v<ver>-cpp.so`). It "worked" only for anyone who had already run a full/manifest build.

## Fix
Resolve the dependency closure before building the requested snapshot:

- **`snapshot_deps()`** reads the `(comp, ver)` pairs the snapshot already declares via its `${HALIF_INCLUDE_DIR}/<comp>/<ver>/include` references in `CMakeLists.txt` — no new metadata.
- Each dependency is built through a **recursive** `build_modules.sh` invocation, so transitive deps resolve and an already-built dependency is **skipped** (the `common` diamond builds once).
- **`stage_snapshot_headers()`** copies each snapshot's committed `include/` tree into `out/build/include` after a successful build, so dependents resolve it.

## Test
From a wiped closure (removed staged headers + libs + build dirs for videosink/videodecoder/avclock/common 0.2.0.0):

```
$ ./build_modules.sh videosink --version 0.2.0.0
📸 Snapshot build: videosink/0.2.0.0
   ↳ building dependency avclock/0.2.0.0 ...
   ↳ building dependency common/0.2.0.0 ...   (leaf — compiles PropertyValue.cpp)
   ✓ dependency common/0.2.0.0 already built   (diamond reused)
   ↳ building dependency videodecoder/0.2.0.0 ...
```

Result: all four `lib*-v0.2.0.0-cpp.so` produced and all four header trees staged (incl. `common/.../PropertyValue.h`). `bash -n` clean.