### PR TITLE
docs(standards): binder runtime layering, bitness & kernel requirements (#662)

### DIFF
--- a/docs/standards/binder_runtime_and_bitness.md
+++ b/docs/standards/binder_runtime_and_bitness.md
@@ -18,47 +18,70 @@ graph LR
     K -->|ioctl /dev/binder| D
 ```
 
-## Each layer ships its own bitness-matched libbinder
+## Each layer ships its own libbinder
 
-- **MW** builds and delivers its own `libbinder`/`libutils`, **32-bit** (`TARGET_LIB32_VERSION=ON`).
-- **Vendor** builds and delivers its own `libbinder`/`libutils`, matched to the vendor's own bitness (e.g. 64-bit).
-- The two interoperate **over the kernel Binder driver (IPC)**, which marshals transactions across the 32/64 boundary. Neither layer links the other's libraries.
+- **MW** builds and delivers its own `libbinder`/`libutils`. MW is **32-bit** on current platforms.
+- **Vendor** builds and delivers its own `libbinder`/`libutils`, at the vendor's bitness — **platform-dependent** (32- or 64-bit).
+- They interoperate **over the kernel Binder driver (IPC)**; neither layer links the other's libraries.
 
-## Bitness rule
+## Bitness rule (in-process)
 
 A process is a single ELF class; every library loaded into it must match that bitness. The dynamic linker refuses to load a 64-bit `.so` into a 32-bit process (and vice versa).
 
-| Boundary | Same process? | Bitness rule |
-|----------|---------------|--------------|
-| Within one layer's process (in-process linking) | yes | all libraries share the process bitness |
+| Boundary | Same process? | Rule |
+| --- | --- | --- |
+| Within one layer's process | yes | all libraries share the process bitness |
 | MW ↔ vendor | no — separate processes | bitness may differ; the kernel Binder driver bridges it |
 
-A cross-bitness split (32-bit MW, 64-bit vendor) is therefore an **IPC** boundary, served by per-layer bitness-matched binders. Kernel bitness is independent: a 64-bit kernel serves 32-bit userspace.
+## Binder protocol version — the constraint that governs interop
+
+Compile bitness is **not** what must match across MW, vendor, and kernel — the **Binder protocol version** is. libbinder verifies it with a strict **equality** check when it opens the driver: the open *fails* if the kernel's protocol version is not exactly the userspace library's. The version is selected at build time by `BINDER_IPC_32BIT`:
+
+| Build | `BINDER_IPC_32BIT` | `binder_uintptr_t` | Protocol |
+| --- | --- | --- | --- |
+| legacy 32-bit | set | 32-bit | **7** |
+| modern (any process bitness) | unset | 64-bit | **8** |
+
+A 32-bit process can run protocol **8** (64-bit binder handles inside a 32-bit process) — that is how a 32-bit and a 64-bit process interoperate on one kernel. **MW, vendor, and kernel must all agree on the protocol version.**
+
+### Two supported platform configurations
+
+| Platform | MW | Vendor | Protocol | MW build | Kernel |
+| --- | --- | --- | --- | --- | --- |
+| All-32-bit userspace | 32-bit | 32-bit | 7 | `BINDER_IPC_32BIT=1` | `CONFIG_ANDROID_BINDER_IPC_32BIT=y` |
+| Mixed (32-bit MW + 64-bit vendor) | 32-bit | 64-bit | 8 | 32-bit compile, `BINDER_IPC_32BIT` unset | `CONFIG_ANDROID_BINDER_IPC_32BIT` unset |
+
+> **Build gap.** linux_binder_idl currently couples `TARGET_LIB32_VERSION=ON` to `-DBINDER_IPC_32BIT=1` (`CMakeLists.txt:702-707`), so it can only produce the **protocol-7** 32-bit build. The **mixed** configuration needs a 32-bit compile with **protocol 8** (`BINDER_IPC_32BIT` unset). Decoupling the compile bitness from the protocol flag is tracked in linux_binder_idl#35. Until then, a 32-bit MW cannot share a kernel with a 64-bit vendor.
 
 ## Kernel requirements
 
-The target kernel must enable the Binder driver and expose the device the runtime opens:
-
 ```text
 CONFIG_ANDROID_BINDER_IPC=y
-CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"   # static device nodes
-CONFIG_ANDROID_BINDERFS=y                                    # kernels >= 5.0 (binderfs)
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"
+# All-32-bit-userspace (protocol 7) platforms ONLY:
+CONFIG_ANDROID_BINDER_IPC_32BIT=y
+# Mixed 32/64 (protocol 8) platforms: leave CONFIG_ANDROID_BINDER_IPC_32BIT UNSET
+CONFIG_ANDROID_BINDERFS=y    # optional; kernels >= 5.0
 ```
 
-- **Device node.** The runtime opens `/dev/binder`. On kernels **≥ 5.0** this may be provided via **binderfs** (`mount -t binder binder /dev/binderfs`); on earlier kernels it is a **static device node** created from `CONFIG_ANDROID_BINDER_DEVICES`.
-- **32-bit userspace on a 64-bit kernel.** A 64-bit kernel serves 32-bit MW via the Binder `compat_ioctl` path. Build the MW runtime to match the **userspace** architecture (32-bit), independent of kernel bitness.
-- **Protocol version.** The Binder protocol version is stable across the supported range (8 on 64-bit, 7 on 32-bit), so core transactions are version-independent.
+- **Device node.** libbinder opens `/dev/binder` directly; **binderfs is not required** (it is consulted only for an optional feature probe, and its absence is handled cleanly). On kernels < 5.0 use the static node from `CONFIG_ANDROID_BINDER_DEVICES`; ≥ 5.0 may use binderfs.
+- **32-bit userspace on a 64-bit kernel.** Served by the Binder `compat_ioctl` path. On a mixed platform the kernel uses protocol 8 (no `BINDER_IPC_32BIT`) and the 32-bit MW must also be a protocol-8 build.
 
-### Minimum supported kernel
+## Supported kernel range
 
-<!-- Pinned from the libbinder feature audit (#662): the floor is the lowest
-     kernel whose Binder driver implements every ioctl the AOSP-13 libbinder
-     issues unconditionally. Matrix added on completion of that audit. -->
+**The supported floor is kernel 4.9**, through 5.16 and later.
 
-The supported floor is the lowest kernel whose Binder driver implements every feature the shipped `libbinder` uses unconditionally. Features such as binderfs (5.0), process-freeze ioctls (5.x), and extended-error reporting (5.x) are introduced at specific kernel versions; a target below a used feature's introduction either degrades (if the runtime guards it) or fails (if unconditional). The pinned floor and per-feature matrix are tracked in #662.
+The upstream AOSP `android-13.0.0_r74` libbinder runtime works across this range: nothing it uses unconditionally is newer than the range, and newer ioctls (process-freeze ~5.10, oneway-spam-detection ~5.11) are runtime-guarded, so on older kernels they degrade non-fatally — `BINDER_SET_CONTEXT_MGR_EXT` (~4.19) falls back to `BINDER_SET_CONTEXT_MGR`, freeze/node-info ioctls return errors only to explicit opt-in callers, and the binderfs probe returns false. The governing constraint is **protocol-version + struct-ABI match**, not individual ioctl availability — libbinder hard-fails the driver open if the kernel's `BINDER_VERSION` is not exactly its own.
+
+!!! warning "Port patch must honour the 4.9 floor"
+    `native.patch` currently disables the pre-5.16 fallback definitions in `binder_module.h` on a "require 5.16+" assumption, which **breaks builds against 4.9 kernel headers**. The fallback shims must be restored so the runtime builds against both old and new headers — tracked in linux_binder_idl#35.
+
+### Verification
+
+Binder is a kernel driver, so the kernel under test must actually run. **Docker shares the host kernel and cannot test other kernel versions** — use **QEMU/KVM VMs**, one per kernel (**4.9, 5.4, 5.10, 5.15, 5.16**) × protocol (7/8) × bitness. Each runs a binder smoke test: open `/dev/binder` (catches the `BINDER_VERSION` mismatch), start `servicemanager`, register/fetch a service, round-trip a transaction, and exercise the guarded ioctls to confirm graceful degradation.
 
 ## Build & delivery
 
-- **MW recipe** builds the 32-bit Binder SDK (`TARGET_LIB32_VERSION=ON`) plus the HAL interface libraries, and stages them under `/mw/lib` with the layer's `ld.so.conf.d` entry.
-- **Vendor recipe** builds its own Binder runtime and HAL implementation at the vendor's bitness, staged under `/vendor/lib` with the vendor `ld.so.conf.d` entry.
+- **MW recipe** builds its 32-bit Binder runtime + the HAL interface libraries and stages them under `/mw/lib` with the layer `ld.so.conf.d` entry. The binder **protocol** (7 or 8) is selected to match the platform's vendor and kernel.
+- **Vendor recipe** builds its own Binder runtime + HAL implementation at the vendor's bitness, staged under `/vendor/lib`.
 - **servicemanager** runs once for the system context both layers share.

--- a/docs/standards/binder_runtime_and_bitness.md
+++ b/docs/standards/binder_runtime_and_bitness.md
@@ -1,0 +1,64 @@
+# Binder Runtime: Layering, Bitness, and Kernel Requirements
+
+How the Binder userspace runtime (`libbinder`/`libutils`) is built and delivered across the **MW** and **vendor** layers, and what the target kernel must provide.
+
+## Layering
+
+The [layer-aggregation architecture](../../vsi/filesystem/current/docs/directory_and_dynamic_linking_specification.md) mounts `/mw` and `/vendor` as independent, read-only layers. The MW and vendor layers run as **separate processes** and communicate over the kernel Binder driver.
+
+```mermaid
+graph LR
+    subgraph "MW process (32-bit)"
+        A[MW client] --> B[libbinder 32-bit]
+    end
+    subgraph "Vendor process (64-bit)"
+        D[libbinder 64-bit] --> E[Vendor HAL impl]
+    end
+    B -->|ioctl /dev/binder| K[Kernel Binder driver]
+    K -->|ioctl /dev/binder| D
+```
+
+## Each layer ships its own bitness-matched libbinder
+
+- **MW** builds and delivers its own `libbinder`/`libutils`, **32-bit** (`TARGET_LIB32_VERSION=ON`).
+- **Vendor** builds and delivers its own `libbinder`/`libutils`, matched to the vendor's own bitness (e.g. 64-bit).
+- The two interoperate **over the kernel Binder driver (IPC)**, which marshals transactions across the 32/64 boundary. Neither layer links the other's libraries.
+
+## Bitness rule
+
+A process is a single ELF class; every library loaded into it must match that bitness. The dynamic linker refuses to load a 64-bit `.so` into a 32-bit process (and vice versa).
+
+| Boundary | Same process? | Bitness rule |
+|----------|---------------|--------------|
+| Within one layer's process (in-process linking) | yes | all libraries share the process bitness |
+| MW ↔ vendor | no — separate processes | bitness may differ; the kernel Binder driver bridges it |
+
+A cross-bitness split (32-bit MW, 64-bit vendor) is therefore an **IPC** boundary, served by per-layer bitness-matched binders. Kernel bitness is independent: a 64-bit kernel serves 32-bit userspace.
+
+## Kernel requirements
+
+The target kernel must enable the Binder driver and expose the device the runtime opens:
+
+```text
+CONFIG_ANDROID_BINDER_IPC=y
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"   # static device nodes
+CONFIG_ANDROID_BINDERFS=y                                    # kernels >= 5.0 (binderfs)
+```
+
+- **Device node.** The runtime opens `/dev/binder`. On kernels **≥ 5.0** this may be provided via **binderfs** (`mount -t binder binder /dev/binderfs`); on earlier kernels it is a **static device node** created from `CONFIG_ANDROID_BINDER_DEVICES`.
+- **32-bit userspace on a 64-bit kernel.** A 64-bit kernel serves 32-bit MW via the Binder `compat_ioctl` path. Build the MW runtime to match the **userspace** architecture (32-bit), independent of kernel bitness.
+- **Protocol version.** The Binder protocol version is stable across the supported range (8 on 64-bit, 7 on 32-bit), so core transactions are version-independent.
+
+### Minimum supported kernel
+
+<!-- Pinned from the libbinder feature audit (#662): the floor is the lowest
+     kernel whose Binder driver implements every ioctl the AOSP-13 libbinder
+     issues unconditionally. Matrix added on completion of that audit. -->
+
+The supported floor is the lowest kernel whose Binder driver implements every feature the shipped `libbinder` uses unconditionally. Features such as binderfs (5.0), process-freeze ioctls (5.x), and extended-error reporting (5.x) are introduced at specific kernel versions; a target below a used feature's introduction either degrades (if the runtime guards it) or fails (if unconditional). The pinned floor and per-feature matrix are tracked in #662.
+
+## Build & delivery
+
+- **MW recipe** builds the 32-bit Binder SDK (`TARGET_LIB32_VERSION=ON`) plus the HAL interface libraries, and stages them under `/mw/lib` with the layer's `ld.so.conf.d` entry.
+- **Vendor recipe** builds its own Binder runtime and HAL implementation at the vendor's bitness, staged under `/vendor/lib` with the vendor `ld.so.conf.d` entry.
+- **servicemanager** runs once for the system context both layers share.

--- a/docs/standards/binder_runtime_and_bitness.md
+++ b/docs/standards/binder_runtime_and_bitness.md
@@ -51,7 +51,7 @@ A 32-bit process can run protocol **8** (64-bit binder handles inside a 32-bit p
 | All-32-bit userspace | 32-bit | 32-bit | 7 | `BINDER_IPC_32BIT=1` | `CONFIG_ANDROID_BINDER_IPC_32BIT=y` |
 | Mixed (32-bit MW + 64-bit vendor) | 32-bit | 64-bit | 8 | 32-bit compile, `BINDER_IPC_32BIT` unset | `CONFIG_ANDROID_BINDER_IPC_32BIT` unset |
 
-> **Build gap.** linux_binder_idl currently couples `TARGET_LIB32_VERSION=ON` to `-DBINDER_IPC_32BIT=1` (`CMakeLists.txt:702-707`), so it can only produce the **protocol-7** 32-bit build. The **mixed** configuration needs a 32-bit compile with **protocol 8** (`BINDER_IPC_32BIT` unset). Decoupling the compile bitness from the protocol flag is tracked in linux_binder_idl#35. Until then, a 32-bit MW cannot share a kernel with a 64-bit vendor.
+> **Build gap.** The [linux_binder_idl](https://github.com/rdkcentral/linux_binder_idl) toolchain currently couples `TARGET_LIB32_VERSION=ON` to `-DBINDER_IPC_32BIT=1` (in its top-level `CMakeLists.txt`, ~lines 702-707), so it can only produce the **protocol-7** 32-bit build. The **mixed** configuration needs a 32-bit compile with **protocol 8** (`BINDER_IPC_32BIT` unset). Decoupling the compile bitness from the protocol flag is tracked in [linux_binder_idl#35](https://github.com/rdkcentral/linux_binder_idl/issues/35). Until then, a 32-bit MW cannot share a kernel with a 64-bit vendor.
 
 ## Kernel requirements
 
@@ -77,7 +77,7 @@ CONFIG_ANDROID_BINDER_IPC_32BIT=y    # all-32-bit-userspace (protocol 7) ONLY;
 The upstream AOSP `android-13.0.0_r74` libbinder runtime works across this range: nothing it uses unconditionally is newer than the range, and newer ioctls (process-freeze ~5.10, oneway-spam-detection ~5.11) are runtime-guarded, so on older kernels they degrade non-fatally — `BINDER_SET_CONTEXT_MGR_EXT` (~4.19) falls back to `BINDER_SET_CONTEXT_MGR`, freeze/node-info ioctls return errors only to explicit opt-in callers, and the binderfs probe returns false. The governing constraint is **protocol-version + struct-ABI match**, not individual ioctl availability — libbinder hard-fails the driver open if the kernel's `BINDER_VERSION` is not exactly its own.
 
 !!! warning "Port patch must honour the 4.9 floor"
-    `native.patch` currently disables the pre-5.16 fallback definitions in `binder_module.h` on a "require 5.16+" assumption, which **breaks builds against 4.9 kernel headers**. The fallback shims must be restored so the runtime builds against both old and new headers — tracked in linux_binder_idl#35.
+    [`native.patch`](https://github.com/rdkcentral/linux_binder_idl/blob/develop/patches/native.patch) — in the external [linux_binder_idl](https://github.com/rdkcentral/linux_binder_idl) repo, not this one — currently disables the pre-5.16 fallback definitions in `binder_module.h` on a "require 5.16+" assumption, which **breaks builds against 4.9 kernel headers**. The fallback shims must be restored so the runtime builds against both old and new headers — tracked in [linux_binder_idl#35](https://github.com/rdkcentral/linux_binder_idl/issues/35).
 
 ### Verification
 

--- a/docs/standards/binder_runtime_and_bitness.md
+++ b/docs/standards/binder_runtime_and_bitness.md
@@ -56,15 +56,18 @@ A 32-bit process can run protocol **8** (64-bit binder handles inside a 32-bit p
 ## Kernel requirements
 
 ```text
-CONFIG_ANDROID_BINDER_IPC=y
-CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"
-# All-32-bit-userspace (protocol 7) platforms ONLY:
-CONFIG_ANDROID_BINDER_IPC_32BIT=y
-# Mixed 32/64 (protocol 8) platforms: leave CONFIG_ANDROID_BINDER_IPC_32BIT UNSET
-CONFIG_ANDROID_BINDERFS=y    # optional; kernels >= 5.0
+CONFIG_ANDROID_BINDER_IPC=y          # required
+
+# Device-node provisioning — pick ONE (these are alternatives, not both):
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"   # static nodes (any kernel)
+CONFIG_ANDROID_BINDERFS=y                                   # OR binderfs (kernels >= 5.0)
+
+# Binder protocol — must match userspace:
+CONFIG_ANDROID_BINDER_IPC_32BIT=y    # all-32-bit-userspace (protocol 7) ONLY;
+                                     # leave UNSET for protocol 8 (mixed 32/64)
 ```
 
-- **Device node.** libbinder opens `/dev/binder` directly; **binderfs is not required** (it is consulted only for an optional feature probe, and its absence is handled cleanly). On kernels < 5.0 use the static node from `CONFIG_ANDROID_BINDER_DEVICES`; ≥ 5.0 may use binderfs.
+- **Device node.** libbinder opens `/dev/binder`. The two provisioning routes are alternatives: a **static node** from `CONFIG_ANDROID_BINDER_DEVICES` (works on any kernel, including < 5.0), or **binderfs** (≥ 5.0) — which creates the node under its mount (e.g. `/dev/binderfs/binder`), which the platform then symlinks/bind-mounts to `/dev/binder`. binderfs is **not required**; libbinder consults it only for an optional feature probe and handles its absence cleanly.
 - **32-bit userspace on a 64-bit kernel.** Served by the Binder `compat_ioctl` path. On a mixed platform the kernel uses protocol 8 (no `BINDER_IPC_32BIT`) and the 32-bit MW must also be a protocol-8 build.
 
 ## Supported kernel range

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - Fork-Based Contribution Guide: standards/forked_based_branching.md
       - Git Flow Branching Strategy: standards/git_flow_branching_strategy.md
       - Semantic Versioning: standards/semantic_versioning.md
+      - Binder Runtime & Bitness: standards/binder_runtime_and_bitness.md
   - Vendor HAL Interfaces (VHI):
     - Overview: key_concepts/hal/hal_interfaces.md
     - Interface Generation: introduction/interface_generation.md


### PR DESCRIPTION
Part of #662.

Adds `docs/standards/binder_runtime_and_bitness.md` documenting the MW/vendor binder architecture:

- **Each layer ships its own bitness-matched libbinder** — MW 32-bit (`TARGET_LIB32_VERSION=ON`), vendor at its own bitness — and they communicate **over the kernel binder driver (IPC)**, which bridges 32/64. In-process linking can't cross ELF bitness, so the cross-bitness split is necessarily an IPC boundary.
- **Bitness rule** table (in-process vs cross-layer) and the kernel-bitness-independence note.
- **Kernel requirements** — binder config, device node (binderfs ≥5.0 vs static), 32-bit-userspace-on-64-bit-kernel compat path, stable protocol version.
- A placeholder for the **minimum-kernel feature matrix**, to be pinned from the libbinder feature audit (in progress under #662).

Wired into the mkdocs nav under Standards.

Follow-up commit will fill the feature matrix once the AOSP-13 libbinder ioctl audit completes.