### PR TITLE
feat(datasource): conceptual data-source HAL module — common BufferDescriptor + IDataSource (#668)

### DIFF
--- a/datasource/current/CMakeLists.txt
+++ b/datasource/current/CMakeLists.txt
@@ -1,0 +1,118 @@
+#** *****************************************************************************
+# *
+# * If not stated otherwise in this file or this component's LICENSE file the
+# * following copyright and licenses apply:
+# *
+# * Copyright 2025 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+#** ******************************************************************************
+# Standalone direct-compile build for <component>/current/.
+#
+# Mirrors the shape of the snapshot CMakeLists written by release.sh into
+# <component>/<version>/, so a downstream consumer can build any single
+# component from its own directory:
+#
+#     cmake -S <component>/current -B build/<component> \
+#         -DBINDER_SDK_DIR=/path/to/out/target \
+#         -DBINDER_SDK_INCLUDE_DIR=/path/to/out/build \
+#         -DHALIF_LIB_DIR=/path/to/out/target/lib/halif \
+#         -DHALIF_INCLUDE_DIR=/path/to/out/build/include
+#     cmake --build build/<component>
+#
+# The repo's overall build path (build_modules.sh / build_interfaces.sh)
+# still uses the toolchain's CMakeLists.inc machinery to wire all
+# components together; this file is for the single-module case (#546).
+#
+# PRE-REQUISITE — regenerate the bindings first. Since #566, src/ and
+# include/ under current/ are gitignored toolchain output and do not
+# exist in a fresh clone. Before invoking this standalone CMakeLists,
+# run ./build_interfaces.sh <component> (from the repo root) to
+# regenerate current/src/ and current/include/.
+#
+# Inputs:
+#   BINDER_SDK_DIR          - linux_binder SDK root (lib/binder + include/binder_sdk)
+#   BINDER_SDK_INCLUDE_DIR  - alternate headers root (dev layout splits headers/runtime)
+#   HALIF_LIB_DIR           - directory holding dependency lib*-cpp.so
+#   HALIF_INCLUDE_DIR       - directory holding dependency headers
+cmake_minimum_required(VERSION 3.16)
+project(datasource-vcurrent-cpp LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(LIB_NAME "datasource-vcurrent-cpp")
+
+if (NOT DEFINED BINDER_SDK_DIR)
+    message(FATAL_ERROR "BINDER_SDK_DIR must be set")
+endif()
+
+set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
+if (NOT IS_DIRECTORY "${_BINDER_INC}")
+    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
+        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
+    else()
+        message(FATAL_ERROR
+            "Binder SDK headers not found at ${_BINDER_INC}. "
+            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+    endif()
+endif()
+
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+if (NOT SRCS)
+    message(FATAL_ERROR "No sources under src/. Run ./build_interfaces.sh datasource first to regenerate.")
+endif()
+
+add_library(${LIB_NAME} SHARED ${SRCS})
+
+target_include_directories(${LIB_NAME} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${_BINDER_INC}")
+
+# Dependency component headers (staged by the toolchain build into HALIF_INCLUDE_DIR).
+# Includes the transitive closure of imports so headers reachable via a direct
+# dependency (e.g. common via audiodecoder) are also on the search path.
+if (NOT DEFINED HALIF_INCLUDE_DIR)
+    message(FATAL_ERROR "HALIF_INCLUDE_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency headers (e.g. out/build/include).")
+endif()
+if (DEFINED HALIF_INCLUDE_DIR)
+    target_include_directories(${LIB_NAME} PRIVATE
+    "${HALIF_INCLUDE_DIR}/audiodecoder/current/include"
+    "${HALIF_INCLUDE_DIR}/common/current/include"
+    "${HALIF_INCLUDE_DIR}/videodecoder/current/include")
+endif()
+
+target_link_directories(${LIB_NAME} PRIVATE
+    "${BINDER_SDK_DIR}/lib/binder"
+)
+if (NOT DEFINED HALIF_LIB_DIR)
+    message(FATAL_ERROR "HALIF_LIB_DIR is required (this component has HAL dependencies). "
+        "Set it to the directory holding dependency lib*-cpp.so (e.g. out/target/lib/halif).")
+endif()
+if (DEFINED HALIF_LIB_DIR)
+    target_link_directories(${LIB_NAME} PRIVATE "${HALIF_LIB_DIR}")
+endif()
+
+target_link_libraries(${LIB_NAME} PRIVATE binder utils common-vcurrent-cpp)
+
+set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME "${LIB_NAME}")
+
+include(GNUInstallDirs)
+install(TARGETS ${LIB_NAME}
+    LIBRARY DESTINATION lib/halif
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE)

--- a/datasource/current/com/rdk/hal/datasource/BufferDescriptor.aidl
+++ b/datasource/current/com/rdk/hal/datasource/BufferDescriptor.aidl
@@ -1,0 +1,84 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+import com.rdk.hal.datasource.MemoryType;
+import com.rdk.hal.datasource.Plane;
+import com.rdk.hal.datasource.BufferMeta;
+
+/**
+ * @brief    A typed reference to shared memory produced by a data source.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * The single container that expresses every buffer-bearing payload in the media
+ * pipeline: a ring slice (MAPPABLE, one plane), an AVBuffer frame (SECURE_OPAQUE,
+ * handle), a graphics framebuffer (DMABUF, one plane + stride) and a capture slot
+ * (DMABUF, planar + pts).
+ *
+ * A buffer has one or more backings, and each plane references a backing by index
+ * plus an offset within it. This carries both platform layouts with one shape:
+ *
+ *   - single shared backing, offset-addressed planes — `fds`/`handles` has one
+ *     entry; planes differ by `offset` (single fd, many offsets);
+ *   - one backing per plane/slot — `fds`/`handles` has one entry per plane, each
+ *     plane at `offset` 0 (many fds, zero offset, e.g. Broadcom NEXUS surfaces).
+ *
+ * The backing lists are exchanged when the source is configured; on a stable-
+ * backing source they do not change per buffer, so the steady frame loop carries
+ * only plane offsets and the id.
+ *
+ * Prior art: Android AHardwareBuffer / graphics.common HardwareBuffer (a
+ * native_handle carrying multiple fds), PipeWire spa_buffer (n_datas, each with
+ * its own fd), GStreamer GstBuffer (multiple GstMemory).
+ */
+@VintfStability
+parcelable BufferDescriptor {
+    /** How the backings are stored and accessed. */
+    MemoryType memoryType;
+
+    /**
+     * Backing file descriptors for MAPPABLE and DMABUF. One entry for a shared,
+     * offset-addressed backing; one entry per plane/slot for the per-fd layout.
+     * Empty for SECURE_OPAQUE. Planes select an entry via Plane.backingIndex.
+     */
+    ParcelFileDescriptor[] fds;
+
+    /**
+     * Opaque backing tokens for SECURE_OPAQUE, resolvable only by a trusted
+     * entity. Same one-shared-or-one-per-plane rule as `fds`. Empty for
+     * MAPPABLE / DMABUF. Callers compare for equality only.
+     */
+    long[] handles;
+
+    /** One plane for a byte blob; one per plane for planar formats. */
+    Plane[] planes;
+
+    /**
+     * Identity for release correlation (acquire id / ring slot). Required where
+     * per-backing offsets are all 0 and cannot distinguish slots. 0 = none.
+     */
+    long id;
+
+    /** Present for framed, self-describing buffers; absent for a raw byte stream. */
+    @nullable BufferMeta meta;
+}

--- a/datasource/current/com/rdk/hal/datasource/BufferMeta.aidl
+++ b/datasource/current/com/rdk/hal/datasource/BufferMeta.aidl
@@ -1,0 +1,63 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+/**
+ * @brief    Optional per-buffer metadata carried in-band with a data-source buffer.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * Present when the source produces framed, self-describing buffers (video
+ * frames, timed audio). Absent for an undifferentiated byte stream, where the
+ * consumer derives structure from the negotiated format. Keeping timing and
+ * format with the buffer makes a frame atomic, rather than split across a
+ * separate metadata call.
+ *
+ * Prior art: PipeWire spa_meta_header, Android gralloc metadata + Dataspace.
+ */
+@VintfStability
+parcelable BufferMeta {
+    /** Presentation timestamp in nanoseconds. Long.MIN_VALUE when not present. */
+    long presentationTimeNs;
+
+    /** Decode timestamp in nanoseconds. Long.MIN_VALUE when not present. */
+    long decodeTimeNs;
+
+    /** DRM FOURCC of the pixel format, or 0 for non-image / unspecified. */
+    int fourcc;
+
+    /** Visible width in pixels, or 0 when not applicable. */
+    int width;
+
+    /** Visible height in pixels, or 0 when not applicable. */
+    int height;
+
+    /**
+     * Bitmask of buffer flags.
+     *
+     * FLAG_KEYFRAME      (1 << 0) - random-access point.
+     * FLAG_DISCONTINUITY (1 << 1) - a gap precedes this buffer.
+     * FLAG_CORRUPTED     (1 << 2) - payload is known to be damaged.
+     * FLAG_END_OF_STREAM (1 << 3) - last buffer of the stream.
+     */
+    int flags;
+}

--- a/datasource/current/com/rdk/hal/datasource/DeliveryMode.aidl
+++ b/datasource/current/com/rdk/hal/datasource/DeliveryMode.aidl
@@ -1,0 +1,49 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+/**
+ * @brief    How a data source delivers regions to its consumer.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * The one field that distinguishes a byte-stream ring from a framed buffer pool
+ * — the difference between IRingBuffer and ICapture — without a separate
+ * interface for each.
+ */
+@VintfStability
+@Backing(type="int")
+enum DeliveryMode {
+    /**
+     * Byte-window delivery over a contiguous backing. acquire() returns a region
+     * of the requested size; release() may release a prefix of it, advancing the
+     * read position. Buffers carry no meta. This is the IRingBuffer shape.
+     */
+    STREAM = 0,
+
+    /**
+     * Whole-buffer delivery from a set of slots. acquire() returns one complete,
+     * self-describing buffer (planes + meta); release() returns that slot for
+     * reuse. This is the ICapture / decoder-output shape.
+     */
+    FRAMED = 1,
+}

--- a/datasource/current/com/rdk/hal/datasource/IDataSource.aidl
+++ b/datasource/current/com/rdk/hal/datasource/IDataSource.aidl
@@ -24,6 +24,7 @@ import com.rdk.hal.AVSource;
 import com.rdk.hal.datasource.BufferDescriptor;
 import com.rdk.hal.datasource.DeliveryMode;
 import com.rdk.hal.datasource.MemoryType;
+import com.rdk.hal.datasource.MemoryStats;
 import com.rdk.hal.datasource.IDataSourceListener;
 
 /**
@@ -113,4 +114,17 @@ interface IDataSource {
      * effect when no call is blocked or the source is non-blocking.
      */
     void abortAcquire();
+
+    /**
+     * Returns the current memory accounting for this source's buffer pool.
+     *
+     * Because each consumer holds its own IDataSource, the snapshot is
+     * attributable to one consumer — enough to make pipeline memory usage
+     * visible and a leak (buffers reserved but never released) traceable to
+     * its owner. Callable in any state; before configure() the pool is empty
+     * and all counts are 0.
+     *
+     * @return  A MemoryStats snapshot of the pool.
+     */
+    MemoryStats getMemoryStats();
 }

--- a/datasource/current/com/rdk/hal/datasource/IDataSource.aidl
+++ b/datasource/current/com/rdk/hal/datasource/IDataSource.aidl
@@ -1,0 +1,116 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+import com.rdk.hal.AVSource;
+import com.rdk.hal.datasource.BufferDescriptor;
+import com.rdk.hal.datasource.DeliveryMode;
+import com.rdk.hal.datasource.MemoryType;
+import com.rdk.hal.datasource.IDataSourceListener;
+
+/**
+ * @brief    Common consumer contract for reading from a data source.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * One interface that a file source, a broadcast demux filter, a software
+ * injector, a capture ring or a decoder output can all present, so consumer
+ * code reads any of them through the same acquire / release lifecycle over a
+ * negotiated, typed BufferDescriptor.
+ *
+ * Lifecycle: configure() -> start() -> (acquire() / release())* -> stop().
+ *
+ * Negotiation resolves the memory type and delivery mode both ends support, so
+ * the same consumer code accepts a dma-buf on a target platform and a mappable
+ * segment on a reference host. An implementation is free to pass the backing
+ * fd once at configure() and run the steady acquire / release loop as shared
+ * index updates, keeping the per-buffer path off binder.
+ *
+ * Prior art: PipeWire node output port, Android BufferQueue consumer, GStreamer
+ * source pad.
+ */
+@VintfStability
+interface IDataSource {
+    /**
+     * Declares the memory types this consumer can accept, as a bitmask of
+     * (1 << MemoryType). The source intersects it with what it can produce and
+     * fixes the choice for the session.
+     *
+     * @param[in] acceptedMemoryTypeMask  OR of (1 << MemoryType) values.
+     * @param[in] mode                    Requested delivery mode.
+     * @param[in] listener                Readiness / error callbacks.
+     * @return    The MemoryType selected for the session.
+     */
+    MemoryType configure(in int acceptedMemoryTypeMask, in DeliveryMode mode, in IDataSourceListener listener);
+
+    /**
+     * Classifies where the stream originates (IP, TUNER, SYSTEM, HDMI, ...).
+     *
+     * @return  The AVSource of this data source.
+     */
+    AVSource getSource();
+
+    /**
+     * Begins production. After start(), the source delivers data and raises
+     * IDataSourceListener.onDataAvailable().
+     */
+    void start();
+
+    /**
+     * Stops production. Outstanding acquired buffers must be released. A stopped
+     * source may be started again.
+     */
+    void stop();
+
+    /**
+     * Acquires the next available data.
+     *
+     * STREAM: returns a descriptor whose single plane addresses up to `size`
+     * bytes at the current read position.
+     * FRAMED: `size` is ignored; returns the next ready buffer (planes + meta).
+     *
+     * Blocks until data is available, or returns a null descriptor immediately
+     * when the source is configured non-blocking and nothing is ready.
+     *
+     * @param[in] size  STREAM: requested byte count. FRAMED: ignored.
+     * @return          The acquired buffer, or null when nothing is ready.
+     */
+    @nullable BufferDescriptor acquire(in long size);
+
+    /**
+     * Releases a previously acquired buffer back to the source.
+     *
+     * STREAM: `size` may be less than the acquired size to release a prefix and
+     * advance the read position by that amount.
+     * FRAMED: `size` is ignored; the whole slot is returned for reuse.
+     *
+     * @param[in] descriptor  A descriptor returned by acquire().
+     * @param[in] size        STREAM: bytes to release. FRAMED: ignored.
+     */
+    void release(in BufferDescriptor descriptor, in long size);
+
+    /**
+     * Unblocks a thread waiting in acquire() (e.g. during teardown). Has no
+     * effect when no call is blocked or the source is non-blocking.
+     */
+    void abortAcquire();
+}

--- a/datasource/current/com/rdk/hal/datasource/IDataSourceListener.aidl
+++ b/datasource/current/com/rdk/hal/datasource/IDataSourceListener.aidl
@@ -1,0 +1,57 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+/**
+ * @brief    Consumer callback interface for IDataSource.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * A wake-up channel so a consumer need not poll acquire(). Implementations may
+ * coalesce onDataAvailable across several ready buffers. The callbacks report
+ * readiness only; buffers are collected through IDataSource.acquire().
+ */
+@VintfStability
+oneway interface IDataSourceListener {
+    /**
+     * Data is available to acquire.
+     *
+     * After this callback, the next acquire() with a size / count up to the
+     * reported amount will not block.
+     *
+     * @param[in] available  STREAM: bytes ready to read. FRAMED: buffers ready.
+     */
+    void onDataAvailable(in long available);
+
+    /**
+     * The stream has ended; no further data will be produced.
+     */
+    void onEndOfStream();
+
+    /**
+     * An error occurred on the source.
+     *
+     * @param[in] code     Implementation-defined error code.
+     * @param[in] message  Human-readable detail.
+     */
+    void onError(in int code, in String message);
+}

--- a/datasource/current/com/rdk/hal/datasource/MemoryStats.aidl
+++ b/datasource/current/com/rdk/hal/datasource/MemoryStats.aidl
@@ -1,0 +1,62 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+/**
+ * @brief    Memory accounting for the buffers a data source has allocated.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * A snapshot of the backing memory reserved for this source's buffer pool,
+ * read via IDataSource.getMemoryStats(). Because each consumer holds its own
+ * IDataSource, the snapshot is per-source and therefore attributable to one
+ * consumer — the unit needed to make pipeline memory usage visible and a leak
+ * (buffers reserved but never released) traceable to its owner.
+ *
+ * Counts are steady-state pool figures, not per-acquire deltas: they cover the
+ * backings exchanged at configure() plus any grown since, independent of how
+ * many buffers are currently acquired.
+ *
+ * Prior art: PipeWire node buffer accounting, Android gralloc allocation
+ * counters exposed through dumpsys meminfo.
+ */
+@VintfStability
+parcelable MemoryStats {
+    /**
+     * Total backing memory reserved for this source's buffer pool, in bytes —
+     * the sum across all `fds` / `handles` backings, mappable and secure alike.
+     */
+    long allocatedBytes;
+
+    /**
+     * Subset of `allocatedBytes` currently mapped into the consumer process,
+     * in bytes. 0 for a SECURE_OPAQUE session, which is never mapped into an
+     * unprivileged process (HAL.DSRC.4).
+     */
+    long mappedBytes;
+
+    /** Number of buffers in the pool. */
+    int bufferCount;
+
+    /** Number of those buffers currently acquired by the consumer. */
+    int acquiredCount;
+}

--- a/datasource/current/com/rdk/hal/datasource/MemoryType.aidl
+++ b/datasource/current/com/rdk/hal/datasource/MemoryType.aidl
@@ -1,0 +1,61 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+/**
+ * @brief    Backing and access discriminator for a data-source buffer.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * Selects how the bytes referenced by a BufferDescriptor are backed and how a
+ * consumer may reach them. This is the single axis that lets one consumer path
+ * accept a dma-buf on a target platform and a mappable segment on a reference
+ * host without branching in consumer code.
+ *
+ * Prior art: Android BufferUsage flags, PipeWire spa_data.type
+ * (MemFd/DmaBuf/MemId).
+ */
+@VintfStability
+@Backing(type="int")
+enum MemoryType {
+    /**
+     * POSIX shared memory / memfd. Any permitted process may mmap(2) the fd and
+     * read/write the region directly at the plane offsets.
+     */
+    MAPPABLE = 0,
+
+    /**
+     * A dma-buf file descriptor. Imported by hardware / EGL / a downstream
+     * device; the consumer may or may not CPU-map it depending on the negotiated
+     * usage. Planes may share one fd at different offsets, or arrive as separate
+     * fds.
+     */
+    DMABUF = 1,
+
+    /**
+     * A secure-opaque handle to memory that meets secure video / audio path
+     * requirements. There is no mappable fd; the region is resolvable only by a
+     * trusted entity (e.g. a trusted application or secure hardware peripheral).
+     * The descriptor carries the handle, not a ParcelFileDescriptor.
+     */
+    SECURE_OPAQUE = 2,
+}

--- a/datasource/current/com/rdk/hal/datasource/Plane.aidl
+++ b/datasource/current/com/rdk/hal/datasource/Plane.aidl
@@ -1,0 +1,58 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.rdk.hal.datasource;
+
+/**
+ * @brief    One addressable region within a data-source buffer.
+ * @author   Gerald Weatherup
+ *
+ * Proposed data-source interface. See issue #668 and data_source.md for rationale.
+ *
+ * A plane is addressed by a (backing, offset) pair: `backingIndex` selects one of
+ * the descriptor's backings and `offset` is the byte position within it. This one
+ * shape expresses both platform layouts:
+ *
+ *   - one shared backing, planes at different offsets (single fd, many offsets);
+ *   - one backing per plane, each at offset 0 (many fds, zero offset).
+ *
+ * A byte-blob payload uses a single plane. Planar video uses one plane per plane
+ * (e.g. NV12 = Y, then interleaved UV).
+ *
+ * Prior art: Android gralloc PlaneLayout, PipeWire spa_data + spa_chunk,
+ * GStreamer GstVideoMeta.
+ */
+@VintfStability
+parcelable Plane {
+    /**
+     * Index of the backing this plane lives in: into BufferDescriptor.fds for
+     * MAPPABLE / DMABUF, or into BufferDescriptor.handles for SECURE_OPAQUE.
+     */
+    int backingIndex;
+
+    /** Byte offset of this plane within its backing. 0 when each plane has its own backing. */
+    long offset;
+
+    /** Row stride in bytes. 0 for non-image / byte-stream payloads. */
+    int stride;
+
+    /** Number of valid bytes in this plane. */
+    long size;
+}

--- a/datasource/current/docs/data_source.md
+++ b/datasource/current/docs/data_source.md
@@ -1,0 +1,128 @@
+# Data Source
+
+The **Data Source HAL** defines a common typed buffer descriptor and a single consumer contract for reading data from a source in the media pipeline.
+
+- A **data source** presents data — a byte stream or a sequence of framed buffers — that a consumer reads through one `acquire` / `release` lifecycle.
+- A **buffer descriptor** is a typed reference to shared memory: a mappable segment, a dma-buf, or a secure-opaque handle, addressed by one or more planes.
+- The **memory type** and **delivery mode** are negotiated between producer and consumer, so the same consumer reads a dma-buf on a target platform and a mappable segment on a reference host without change.
+- A source classifies its origin with `AVSource` (IP, tuner, system, HDMI, composite).
+
+## References
+
+!!! info References
+    |||
+    |-|-|
+    |**Interface Definition**|[datasource/current](https://github.com/rdkcentral/rdk-halif-aidl/tree/develop/datasource/current)|
+    |**Interface Version**|`current`|
+    | **API Documentation** | *TBD - Doxygen* |
+    |**HAL Interface Type**|[AIDL and Binder](../introduction/aidl_and_binder.md)|
+    |**VTS Tests**| TBC |
+    |**Reference Implementation - vComponent**|**TBD**|
+    |**RFC / rationale**|[Issue #668](https://github.com/rdkcentral/rdk-halif-aidl/issues/668)|
+
+## Related Pages
+
+!!! tip "Related Pages"
+    - [AV Buffer](../avbuffer/av_buffer.md)
+    - [Video Decoder](../videodecoder/video_decoder.md)
+    - [Plane Control](../planecontrol/plane_control.md)
+    - [Broadcast](../broadcast/broadcast.md)
+
+## Implementation Requirements
+
+|#|Requirement|Comments|
+|-|-----------|--------|
+|**HAL.DSRC.1**|A data source shall expose a single consume lifecycle: `configure()` → `start()` → (`acquire()` / `release()`)\* → `stop()`.||
+|**HAL.DSRC.2**|`configure()` shall negotiate the memory type from the consumer's accepted mask and the delivery mode, and fix both for the session.|Consumer declares a bitmask of accepted `MemoryType`.|
+|**HAL.DSRC.3**|A buffer descriptor shall carry its backings as a list — `fds` for `MAPPABLE` / `DMABUF`, or `handles` for `SECURE_OPAQUE` — and each plane shall reference one backing by index plus an offset within it.||
+|**HAL.DSRC.4**|`SECURE_OPAQUE` buffers cannot be mapped into an unprivileged process and shall meet secure video / audio path requirements.|Resolvable only by a trusted entity. Mirrors `HAL.AVBUF.7`.|
+|**HAL.DSRC.5**|In `STREAM` mode, `acquire(size)` shall return a region of up to `size` bytes; `release(descriptor, size)` may release a prefix, advancing the read position by that amount.|Partial release supports progressive assembly.|
+|**HAL.DSRC.6**|In `FRAMED` mode, `acquire()` shall return one complete, self-describing buffer (planes + meta); `release()` shall return the whole slot for reuse.||
+|**HAL.DSRC.7**|A source shall signal readiness through `IDataSourceListener.onDataAvailable()`; implementations may coalesce notifications.||
+|**HAL.DSRC.8**|`abortAcquire()` shall unblock a thread waiting in `acquire()` and shall have no effect when no call is blocked.||
+|**HAL.DSRC.9**|The backing file descriptor(s) shall be exchanged at negotiation; the steady-state `acquire` / `release` loop shall not require a per-buffer file-descriptor transfer.|Enables an off-binder frame loop over a shared index.|
+|**HAL.DSRC.10**|A source shall report its origin via `getSource()` using `AVSource`.||
+|**HAL.DSRC.11**|Both backing layouts shall be representable: a single shared backing with offset-addressed planes (single fd, many offsets), and one backing per plane at offset 0 (many fds, zero offset). Where offsets cannot distinguish slots, `id` carries the release identity.|Broadcom NEXUS exports a per-surface fd per slot; other SoCs export one ring fd.|
+
+## Interface Definition
+
+|Interface Definition File|Description|
+|-------------------------|-----------|
+|`IDataSource.aidl`|The consumer contract: configure, start, acquire, release, stop.|
+|`IDataSourceListener.aidl`|Data-ready, end-of-stream and error callbacks.|
+|`BufferDescriptor.aidl`|Typed reference to shared memory: memory type + backing list (`fds` / `handles`) + planes + id + meta.|
+|`MemoryType.aidl`|Backing and access discriminator: `MAPPABLE`, `DMABUF`, `SECURE_OPAQUE`.|
+|`Plane.aidl`|One addressable region: `{backingIndex, offset, stride, size}`.|
+|`BufferMeta.aidl`|Optional per-buffer PTS / format / dimensions / flags.|
+|`DeliveryMode.aidl`|`STREAM` (byte-window) or `FRAMED` (whole-buffer).|
+
+## The Buffer Descriptor
+
+A `BufferDescriptor` is the single container that expresses every buffer-bearing payload in the pipeline. It decomposes a buffer along three axes:
+
+| Axis | Values | Field |
+|---|---|---|
+| **Backing / access** | `MAPPABLE` · `DMABUF` · `SECURE_OPAQUE` | `MemoryType memoryType` |
+| **Backings** | one shared, or one per plane | `ParcelFileDescriptor[] fds` / `long[] handles` |
+| **Shape** | single blob · N planes | `Plane[] planes` (each `{backingIndex, offset, stride, size}`) |
+| **Identity** | acquire id / ring slot | `long id` |
+
+### Per-platform buffer layout
+
+A buffer carries a *list* of backings, and each plane references one by `backingIndex` plus an `offset`. This is the same abstraction Android's `native_handle` (multiple fds) and PipeWire's `spa_data[]` (one fd per data) use, and it represents both layouts SoCs actually produce with no special case in consumer code:
+
+| Layout | `fds` / `handles` | Planes | Seen on |
+|---|---|---|---|
+| **Single fd, many offsets** | one shared entry | each plane `backingIndex = 0`, distinct `offset` | one ring dma-buf — most SoCs |
+| **Many fds, zero offset** | one entry per plane / slot | each plane its own `backingIndex`, `offset = 0` | per-surface dma-buf — Broadcom NEXUS |
+
+For NV12 with a single shared ring fd: `fds = [ringFd]`, planes `= [{0, yOffset, yStride, ySize}, {0, uvOffset, uvStride, uvSize}]`. For a per-surface SoC: `fds = [yFd, uvFd]`, planes `= [{0, 0, yStride, ySize}, {1, 0, uvStride, uvSize}]`. Because per-surface offsets are all 0 and cannot distinguish slots, `id` carries the release identity.
+
+Optional `BufferMeta` carries presentation timing, pixel format, dimensions and flags for framed, self-describing buffers; it is absent for an undifferentiated byte stream, where the consumer derives structure from the negotiated format.
+
+## Negotiation
+
+`configure()` takes a bitmask of the memory types the consumer can accept and the requested delivery mode. The source intersects the mask with what it can produce and returns the selected `MemoryType`, fixed for the session. The same consumer code therefore runs against a dma-buf on a target platform and a mappable segment on a reference host, because `MemoryType` abstracts the backing.
+
+## Delivery Modes
+
+- **`STREAM`** — byte-window delivery over a contiguous backing. `acquire(size)` returns a region of up to `size` bytes at the current read position; `release()` may release a prefix, advancing the read position. Buffers carry no meta.
+- **`FRAMED`** — whole-buffer delivery from a set of slots. `acquire()` returns one complete buffer (planes + meta); `release()` returns that slot for reuse.
+
+## Consolidating Existing Surfaces
+
+Each existing buffer-bearing surface is a binding of this interface:
+
+| Surface | Delivery mode | Memory type | Shape |
+|---|---|---|---|
+| `IRingBufferSource` | `STREAM` | `MAPPABLE` | one plane, moving offset |
+| `IAVBuffer` (consume) | `FRAMED` | `SECURE_OPAQUE` / `MAPPABLE` | one blob, handle |
+| `IGraphicsFbProvider` | `FRAMED` | `DMABUF` | one plane + stride |
+| `ICapture` | `FRAMED` | `DMABUF` | NV12 planes + `meta.pts` |
+
+### Wrapping the Ring Buffer
+
+`IRingBuffer` is the `STREAM` binding. Its consumer-side requirements map directly:
+
+| `IRingBuffer` requirement | Data Source equivalent |
+|---|---|
+| `getFileDescriptor()` — one shared, mmap-able fd | `BufferDescriptor.fd` with `MemoryType.MAPPABLE`, exchanged at `configure()` |
+| `acquire(size)` → `{id, offset, size}` | `acquire(size)` → `BufferDescriptor` (single plane at `offset`, `size`) |
+| `release(id, size)`, partial release of a prefix | `release(descriptor, size)` with `size` ≤ acquired (`HAL.DSRC.5`) |
+| offset-addressed read/write into mapped memory | `Plane.offset` into the mapped backing |
+| `setBlocking(true/false)` | blocking vs non-blocking `acquire()` fixed at `configure()` |
+| `abortAcquire()` | `abortAcquire()` (`HAL.DSRC.8`) |
+| `onDataAvailable(size)` / `onSpaceAvailable(size)` | `IDataSourceListener.onDataAvailable(available)` |
+| error codes (`PRODUCER_DISCONNECTED`, …) | `IDataSourceListener.onError(code, message)` |
+| DMA-backed backing behind the fd (custom driver) | `MemoryType.DMABUF` on the same descriptor, negotiated |
+| "no out-of-band sync besides the interface" | backing + wakeup exchanged at `configure()`; steady loop off binder (`HAL.DSRC.9`) |
+
+The ring's byte-granular `acquire` / partial-`release` — its distinguishing feature — is the `STREAM` delivery mode. The one thing the ring leaves as prose (a DMA-backed backing reachable through the fd) becomes an explicit, negotiated `MemoryType`, so a consumer knows whether it may mmap the region or must import it.
+
+## Initialization
+
+The vendor layer provides the systemd unit that starts a data-source service and registers its interface with the [Service Manager](../vsi/service_manager/current/service_manager.md).
+
+## Relationship to AVSource
+
+`common/current/com/rdk/hal/AVSource.aidl` classifies where a stream originates. `IDataSource.getSource()` returns an `AVSource` so a consumer can identify the origin of what it reads. `AVSource` names the origin; `IDataSource` is the contract for reading from it.

--- a/datasource/current/docs/data_source.md
+++ b/datasource/current/docs/data_source.md
@@ -43,6 +43,7 @@ The **Data Source HAL** defines a common typed buffer descriptor and a single co
 |**HAL.DSRC.9**|The backing file descriptor(s) shall be exchanged at negotiation; the steady-state `acquire` / `release` loop shall not require a per-buffer file-descriptor transfer.|Enables an off-binder frame loop over a shared index.|
 |**HAL.DSRC.10**|A source shall report its origin via `getSource()` using `AVSource`.||
 |**HAL.DSRC.11**|Both backing layouts shall be representable: a single shared backing with offset-addressed planes (single fd, many offsets), and one backing per plane at offset 0 (many fds, zero offset). Where offsets cannot distinguish slots, `id` carries the release identity.|Broadcom NEXUS exports a per-surface fd per slot; other SoCs export one ring fd.|
+|**HAL.DSRC.12**|A source shall report the memory accounting of its buffer pool via `getMemoryStats()`: total allocated backing bytes, the mapped subset, and the pool / acquired buffer counts. `mappedBytes` shall be 0 for a `SECURE_OPAQUE` session.|Each consumer holds its own `IDataSource`, so the figures are attributable to one consumer — pipeline memory usage is visible and a leak is traceable to its owner.|
 
 ## Interface Definition
 
@@ -55,6 +56,7 @@ The **Data Source HAL** defines a common typed buffer descriptor and a single co
 |`Plane.aidl`|One addressable region: `{backingIndex, offset, stride, size}`.|
 |`BufferMeta.aidl`|Optional per-buffer PTS / format / dimensions / flags.|
 |`DeliveryMode.aidl`|`STREAM` (byte-window) or `FRAMED` (whole-buffer).|
+|`MemoryStats.aidl`|Buffer-pool accounting: allocated / mapped bytes + pool / acquired counts.|
 
 ## The Buffer Descriptor
 

--- a/datasource/current/interface.yaml
+++ b/datasource/current/interface.yaml
@@ -1,0 +1,8 @@
+aidl_interface:
+  name: datasource
+  srcs:
+    - com/rdk/hal/datasource/*.aidl
+  imports:
+    - common@current
+  stability: vintf
+  layout: module-local

--- a/datasource/current/mkdocs.yml
+++ b/datasource/current/mkdocs.yml
@@ -1,0 +1,2 @@
+site_name: datasource
+docs_dir: docs

--- a/datasource/metadata.yaml
+++ b/datasource/metadata.yaml
@@ -1,0 +1,57 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2026 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# component   - Machine-readable component identifier                    [manual]
+# version     - Pre-baseline: 0.<generation>.<minor>.<patch>              [release.sh]
+# status      - RAG status: GREEN / AMBER / RED                          [manual]
+# description - One-line human-readable summary                          [manual]
+# type        - Responsibility: SOC or OEM                                [manual]
+component: datasource
+version: 0.1.0.0
+status: RED
+description: "Common typed buffer descriptor and consumer contract for data sources"
+type: SOC
+
+# lifecycle - 14+5 review cycle dates                                    [pr_cycle.sh]
+lifecycle:
+  review_started: ~
+  review_deadline: ~
+  target_green_date: ~
+
+# scope - High-level architectural responsibilities                       [manual]
+scope:
+  - Common typed buffer descriptor (mappable / dma-buf / secure-opaque) across the media pipeline
+  - Single consumer contract for reading from a data source (file, broadcast demux, injector, capture, decoder output)
+  - Memory-type and delivery-mode negotiation between producer and consumer
+  - Byte-stream and framed delivery over one lifecycle
+  - Consolidation target for IRingBuffer, IAVBuffer, IGraphicsFbProvider and ICapture
+
+# notes - Tracking metadata                                              [manual]
+notes:
+  priority: 2
+  status_detail: "RFC / requirement-gathering — see issue #668"
+  action: "Confirm the multi-source consumer that justifies consolidation (requirement gate)"
+  risk: "Proposal only; not adopted until the requirement gate in #668 is met"
+  owners: "Architecture + AV_Architecture"
+
+# reviewers - Sign-off status per stakeholder team                       [manual]
+#   Values: pending | in_review | changes_requested | recheck | reviewed | abstained
+reviewers:
+    Architecture: pending
+    Product_Architecture: pending
+    AV_Architecture: pending
+    Vendor_Layer_Team: pending


### PR DESCRIPTION
Implements the conceptual interface for #668. **Rationale, requirement gate and prior art live in the issue** — this PR is the interface itself, placed in its canonical module location for review.

## What this adds

A new **`datasource`** HAL module (`com.rdk.hal.datasource`), structured exactly like `avbuffer/`:

```
datasource/
  metadata.yaml                      (status: RED — proposal)
  current/
    interface.yaml                   (imports common@current)
    CMakeLists.txt  mkdocs.yml
    com/rdk/hal/datasource/*.aidl
    docs/data_source.md
```

- **`BufferDescriptor`** — one typed reference to shared memory (`MemoryType` = `MAPPABLE` / `DMABUF` / `SECURE_OPAQUE`, `Plane[]`, fd or opaque handle, optional `BufferMeta`).
- **`IDataSource`** / **`IDataSourceListener`** — one consumer contract: `configure` (negotiate memory type + delivery mode) → `start` → `acquire` / `release` → `stop`, in `STREAM` (byte-window) or `FRAMED` (whole-buffer) mode.
- **`docs/data_source.md`** — module doc in the standard format (References / Related Pages / Implementation Requirements `HAL.DSRC.N` / Interface Definition), including a table mapping every `IRingBuffer` consumer requirement onto this interface.

## Consolidation

`IRingBufferSource` → `STREAM`/`MAPPABLE`, `IAVBuffer` → `FRAMED`/`SECURE_OPAQUE`, `IGraphicsFbProvider` → `FRAMED`/`DMABUF`, `ICapture` → `FRAMED`/`DMABUF`+planes. Each becomes a binding of the one descriptor + one lifecycle.

## Requirement-first

Per #668 §3, adoption is gated on naming the consumer that must read **more than one source through one path**. `metadata.yaml` is `status: RED` and the module carries no released snapshot (falls back to `default: current`) — nothing is adopted until the gate is met.

## Related

#33 (Gralloc-as-AIDL, prior art), #37, #53, #494 (FMQ). Aligns with `feature/ring-buffer-proposal` and `avbuffer/current`. `NOTICE` already credits RDK Management.
