### PR TITLE
fix(build): flexible binder header path for Yocto/sysroot (#644)

### DIFF
--- a/audiodecoder/0.1.0.0/CMakeLists.txt
+++ b/audiodecoder/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiodecoder/0.1.0.0/CMakeLists.txt
+++ b/audiodecoder/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiodecoder/0.1.0.0/CMakeLists.txt
+++ b/audiodecoder/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiodecoder/0.2.0.0/CMakeLists.txt
+++ b/audiodecoder/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiodecoder/0.2.0.0/CMakeLists.txt
+++ b/audiodecoder/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiodecoder/0.2.0.0/CMakeLists.txt
+++ b/audiodecoder/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiodecoder/current/CMakeLists.txt
+++ b/audiodecoder/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiodecoder/current/CMakeLists.txt
+++ b/audiodecoder/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiodecoder/current/CMakeLists.txt
+++ b/audiodecoder/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiomixer/0.1.0.1/CMakeLists.txt
+++ b/audiomixer/0.1.0.1/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiomixer/0.1.0.1/CMakeLists.txt
+++ b/audiomixer/0.1.0.1/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiomixer/0.1.0.1/CMakeLists.txt
+++ b/audiomixer/0.1.0.1/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiomixer/0.2.0.0/CMakeLists.txt
+++ b/audiomixer/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiomixer/0.2.0.0/CMakeLists.txt
+++ b/audiomixer/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiomixer/0.2.0.0/CMakeLists.txt
+++ b/audiomixer/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiomixer/0.3.0.0/CMakeLists.txt
+++ b/audiomixer/0.3.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiomixer/0.3.0.0/CMakeLists.txt
+++ b/audiomixer/0.3.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiomixer/0.3.0.0/CMakeLists.txt
+++ b/audiomixer/0.3.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiomixer/current/CMakeLists.txt
+++ b/audiomixer/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiomixer/current/CMakeLists.txt
+++ b/audiomixer/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiomixer/current/CMakeLists.txt
+++ b/audiomixer/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiosink/0.1.0.0/CMakeLists.txt
+++ b/audiosink/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiosink/0.1.0.0/CMakeLists.txt
+++ b/audiosink/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiosink/0.1.0.0/CMakeLists.txt
+++ b/audiosink/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiosink/0.2.0.0/CMakeLists.txt
+++ b/audiosink/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiosink/0.2.0.0/CMakeLists.txt
+++ b/audiosink/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiosink/0.2.0.0/CMakeLists.txt
+++ b/audiosink/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/audiosink/current/CMakeLists.txt
+++ b/audiosink/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/audiosink/current/CMakeLists.txt
+++ b/audiosink/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/audiosink/current/CMakeLists.txt
+++ b/audiosink/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/avbuffer/0.1.0.0/CMakeLists.txt
+++ b/avbuffer/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/avbuffer/0.1.0.0/CMakeLists.txt
+++ b/avbuffer/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/avbuffer/0.1.0.0/CMakeLists.txt
+++ b/avbuffer/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/avbuffer/0.2.0.0/CMakeLists.txt
+++ b/avbuffer/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/avbuffer/0.2.0.0/CMakeLists.txt
+++ b/avbuffer/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/avbuffer/0.2.0.0/CMakeLists.txt
+++ b/avbuffer/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/avbuffer/current/CMakeLists.txt
+++ b/avbuffer/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/avbuffer/current/CMakeLists.txt
+++ b/avbuffer/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/avbuffer/current/CMakeLists.txt
+++ b/avbuffer/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/avclock/0.1.0.0/CMakeLists.txt
+++ b/avclock/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/avclock/0.1.0.0/CMakeLists.txt
+++ b/avclock/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/avclock/0.1.0.0/CMakeLists.txt
+++ b/avclock/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/avclock/0.2.0.0/CMakeLists.txt
+++ b/avclock/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/avclock/0.2.0.0/CMakeLists.txt
+++ b/avclock/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/avclock/0.2.0.0/CMakeLists.txt
+++ b/avclock/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/avclock/current/CMakeLists.txt
+++ b/avclock/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/avclock/current/CMakeLists.txt
+++ b/avclock/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/avclock/current/CMakeLists.txt
+++ b/avclock/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/bootreason/0.1.0.0/CMakeLists.txt
+++ b/bootreason/0.1.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/bootreason/0.1.0.0/CMakeLists.txt
+++ b/bootreason/0.1.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/bootreason/0.1.0.0/CMakeLists.txt
+++ b/bootreason/0.1.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/bootreason/current/CMakeLists.txt
+++ b/bootreason/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/bootreason/current/CMakeLists.txt
+++ b/bootreason/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/bootreason/current/CMakeLists.txt
+++ b/bootreason/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/common/0.1.0.0/CMakeLists.txt
+++ b/common/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/common/0.1.0.0/CMakeLists.txt
+++ b/common/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/common/0.1.0.0/CMakeLists.txt
+++ b/common/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/common/0.2.0.0/CMakeLists.txt
+++ b/common/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/common/0.2.0.0/CMakeLists.txt
+++ b/common/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/common/0.2.0.0/CMakeLists.txt
+++ b/common/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/common/current/CMakeLists.txt
+++ b/common/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/common/current/CMakeLists.txt
+++ b/common/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/common/current/CMakeLists.txt
+++ b/common/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/compositeinput/0.2.0.0/CMakeLists.txt
+++ b/compositeinput/0.2.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/compositeinput/0.2.0.0/CMakeLists.txt
+++ b/compositeinput/0.2.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/compositeinput/0.2.0.0/CMakeLists.txt
+++ b/compositeinput/0.2.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/compositeinput/current/CMakeLists.txt
+++ b/compositeinput/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/compositeinput/current/CMakeLists.txt
+++ b/compositeinput/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/compositeinput/current/CMakeLists.txt
+++ b/compositeinput/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/deepsleep/0.1.0.0/CMakeLists.txt
+++ b/deepsleep/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/deepsleep/0.1.0.0/CMakeLists.txt
+++ b/deepsleep/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/deepsleep/0.1.0.0/CMakeLists.txt
+++ b/deepsleep/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/deepsleep/current/CMakeLists.txt
+++ b/deepsleep/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/deepsleep/current/CMakeLists.txt
+++ b/deepsleep/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/deepsleep/current/CMakeLists.txt
+++ b/deepsleep/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/deviceinfo/0.1.0.0/CMakeLists.txt
+++ b/deviceinfo/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/deviceinfo/0.1.0.0/CMakeLists.txt
+++ b/deviceinfo/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/deviceinfo/0.1.0.0/CMakeLists.txt
+++ b/deviceinfo/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/deviceinfo/current/CMakeLists.txt
+++ b/deviceinfo/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/deviceinfo/current/CMakeLists.txt
+++ b/deviceinfo/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/deviceinfo/current/CMakeLists.txt
+++ b/deviceinfo/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/drm/0.1.0.0/CMakeLists.txt
+++ b/drm/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/drm/0.1.0.0/CMakeLists.txt
+++ b/drm/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/drm/0.1.0.0/CMakeLists.txt
+++ b/drm/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/drm/current/CMakeLists.txt
+++ b/drm/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/drm/current/CMakeLists.txt
+++ b/drm/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/drm/current/CMakeLists.txt
+++ b/drm/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/firmwareupdate/0.2.0.0/CMakeLists.txt
+++ b/firmwareupdate/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/firmwareupdate/0.2.0.0/CMakeLists.txt
+++ b/firmwareupdate/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/firmwareupdate/0.2.0.0/CMakeLists.txt
+++ b/firmwareupdate/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/firmwareupdate/current/CMakeLists.txt
+++ b/firmwareupdate/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/firmwareupdate/current/CMakeLists.txt
+++ b/firmwareupdate/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/firmwareupdate/current/CMakeLists.txt
+++ b/firmwareupdate/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/hdmicec/0.1.0.0/CMakeLists.txt
+++ b/hdmicec/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/hdmicec/0.1.0.0/CMakeLists.txt
+++ b/hdmicec/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/hdmicec/0.1.0.0/CMakeLists.txt
+++ b/hdmicec/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/hdmicec/current/CMakeLists.txt
+++ b/hdmicec/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/hdmicec/current/CMakeLists.txt
+++ b/hdmicec/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/hdmicec/current/CMakeLists.txt
+++ b/hdmicec/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/hdmiinput/0.1.0.0/CMakeLists.txt
+++ b/hdmiinput/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/hdmiinput/0.1.0.0/CMakeLists.txt
+++ b/hdmiinput/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/hdmiinput/0.1.0.0/CMakeLists.txt
+++ b/hdmiinput/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/hdmiinput/current/CMakeLists.txt
+++ b/hdmiinput/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/hdmiinput/current/CMakeLists.txt
+++ b/hdmiinput/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/hdmiinput/current/CMakeLists.txt
+++ b/hdmiinput/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/hdmioutput/0.1.0.0/CMakeLists.txt
+++ b/hdmioutput/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/hdmioutput/0.1.0.0/CMakeLists.txt
+++ b/hdmioutput/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/hdmioutput/0.1.0.0/CMakeLists.txt
+++ b/hdmioutput/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/hdmioutput/current/CMakeLists.txt
+++ b/hdmioutput/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/hdmioutput/current/CMakeLists.txt
+++ b/hdmioutput/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/hdmioutput/current/CMakeLists.txt
+++ b/hdmioutput/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/indicator/0.1.0.0/CMakeLists.txt
+++ b/indicator/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/indicator/0.1.0.0/CMakeLists.txt
+++ b/indicator/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/indicator/0.1.0.0/CMakeLists.txt
+++ b/indicator/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/indicator/current/CMakeLists.txt
+++ b/indicator/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/indicator/current/CMakeLists.txt
+++ b/indicator/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/indicator/current/CMakeLists.txt
+++ b/indicator/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/panel/0.1.0.0/CMakeLists.txt
+++ b/panel/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/panel/0.1.0.0/CMakeLists.txt
+++ b/panel/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/panel/0.1.0.0/CMakeLists.txt
+++ b/panel/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/panel/current/CMakeLists.txt
+++ b/panel/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/panel/current/CMakeLists.txt
+++ b/panel/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/panel/current/CMakeLists.txt
+++ b/panel/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/planecontrol/0.1.0.0/CMakeLists.txt
+++ b/planecontrol/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/planecontrol/0.1.0.0/CMakeLists.txt
+++ b/planecontrol/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/planecontrol/0.1.0.0/CMakeLists.txt
+++ b/planecontrol/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/planecontrol/current/CMakeLists.txt
+++ b/planecontrol/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/planecontrol/current/CMakeLists.txt
+++ b/planecontrol/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/planecontrol/current/CMakeLists.txt
+++ b/planecontrol/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/sensor/0.1.0.0/CMakeLists.txt
+++ b/sensor/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/sensor/0.1.0.0/CMakeLists.txt
+++ b/sensor/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/sensor/0.1.0.0/CMakeLists.txt
+++ b/sensor/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/sensor/0.2.0.0/CMakeLists.txt
+++ b/sensor/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/sensor/0.2.0.0/CMakeLists.txt
+++ b/sensor/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/sensor/0.2.0.0/CMakeLists.txt
+++ b/sensor/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/sensor/current/CMakeLists.txt
+++ b/sensor/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/tests/fake-yocto/run-fake-yocto.sh
+++ b/tests/fake-yocto/run-fake-yocto.sh
@@ -140,10 +140,12 @@ echo "    expected ${EXPECTED} HAL libraries, installed ${INSTALLED}"
 # Task 5 - flexible binder header path: FLAT (Yocto sysroot) layout (#644).
 #######################################################################
 # Tasks 1-4 stage headers under include/binder_sdk (the dev subdir). Real Yocto
-# stages them flat under <sysroot>/usr/include (no binder_sdk subdir). Verify a
-# component's CMake resolves headers there via BINDER_SDK_INCLUDE_DIR as a
-# direct include dir — the #644 fix. Configure-only (fast); the pre-fix logic
-# FATALs at the binder-header check, so absence of that error == resolved.
+# stages them flat under <sysroot>/usr/include (binder/ directly, no binder_sdk
+# subdir). Pass BINDER_SDK_INCLUDE_DIR as the staging *prefix* — the form the
+# README documents (`${STAGING_DIR}/usr`) — and verify the component CMake
+# resolves prefix/include via the #644 flexible candidate. Configure-only
+# (fast); the pre-fix logic FATALs at the binder-header check, so absence of
+# that error == resolved.
 echo ""
 echo "[verify] flat-layout binder header resolution (#644) ..."
 FLAT="${WORK}/flat-sysroot/usr"
@@ -152,7 +154,7 @@ cp -r "${REPO_ROOT}/out/build/include/binder_sdk/." "${FLAT}/include/"   # flat:
 cp -r "${REPO_ROOT}/out/target/lib/binder"          "${FLAT}/lib/"
 cmake -S "${REPO_ROOT}/common/current" -B "${WORK}/flat-build" \
     -DBINDER_SDK_DIR="${FLAT}" \
-    -DBINDER_SDK_INCLUDE_DIR="${FLAT}/include" \
+    -DBINDER_SDK_INCLUDE_DIR="${FLAT}" \
     -DHALIF_INCLUDE_DIR="${FLAT}/include" -DHALIF_LIB_DIR="${FLAT}/lib" \
     > "${WORK}/flat-configure.log" 2>&1 || true
 if grep -q 'Binder SDK headers not found' "${WORK}/flat-configure.log"; then

--- a/tests/fake-yocto/run-fake-yocto.sh
+++ b/tests/fake-yocto/run-fake-yocto.sh
@@ -136,6 +136,31 @@ echo "    expected ${EXPECTED} HAL libraries, installed ${INSTALLED}"
 
 [ "${INSTALLED}" -eq "${EXPECTED}" ] || fail "expected ${EXPECTED} HAL libraries in the image, found ${INSTALLED}"
 
+#######################################################################
+# Task 5 - flexible binder header path: FLAT (Yocto sysroot) layout (#644).
+#######################################################################
+# Tasks 1-4 stage headers under include/binder_sdk (the dev subdir). Real Yocto
+# stages them flat under <sysroot>/usr/include (no binder_sdk subdir). Verify a
+# component's CMake resolves headers there via BINDER_SDK_INCLUDE_DIR as a
+# direct include dir — the #644 fix. Configure-only (fast); the pre-fix logic
+# FATALs at the binder-header check, so absence of that error == resolved.
+echo ""
+echo "[verify] flat-layout binder header resolution (#644) ..."
+FLAT="${WORK}/flat-sysroot/usr"
+mkdir -p "${FLAT}/include" "${FLAT}/lib"
+cp -r "${REPO_ROOT}/out/build/include/binder_sdk/." "${FLAT}/include/"   # flat: binder/, utils/, ...
+cp -r "${REPO_ROOT}/out/target/lib/binder"          "${FLAT}/lib/"
+cmake -S "${REPO_ROOT}/common/current" -B "${WORK}/flat-build" \
+    -DBINDER_SDK_DIR="${FLAT}" \
+    -DBINDER_SDK_INCLUDE_DIR="${FLAT}/include" \
+    -DHALIF_INCLUDE_DIR="${FLAT}/include" -DHALIF_LIB_DIR="${FLAT}/lib" \
+    > "${WORK}/flat-configure.log" 2>&1 || true
+if grep -q 'Binder SDK headers not found' "${WORK}/flat-configure.log"; then
+    tail -15 "${WORK}/flat-configure.log" | sed 's/^/    /'
+    fail "#644: flat binder header layout not resolved (BINDER_SDK_INCLUDE_DIR as a direct include dir)"
+fi
+echo "    ✓ flat binder headers resolved via BINDER_SDK_INCLUDE_DIR (#644)"
+
 echo ""
 echo "========================================="
 echo "✅ fake-yocto: production build + install OK (${INSTALLED} HAL libraries)"

--- a/videodecoder/0.1.0.0/CMakeLists.txt
+++ b/videodecoder/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/videodecoder/0.1.0.0/CMakeLists.txt
+++ b/videodecoder/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/videodecoder/0.1.0.0/CMakeLists.txt
+++ b/videodecoder/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/videodecoder/0.2.0.0/CMakeLists.txt
+++ b/videodecoder/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/videodecoder/0.2.0.0/CMakeLists.txt
+++ b/videodecoder/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/videodecoder/0.2.0.0/CMakeLists.txt
+++ b/videodecoder/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/videodecoder/current/CMakeLists.txt
+++ b/videodecoder/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/videodecoder/current/CMakeLists.txt
+++ b/videodecoder/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/videodecoder/current/CMakeLists.txt
+++ b/videodecoder/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/videosink/0.1.0.0/CMakeLists.txt
+++ b/videosink/0.1.0.0/CMakeLists.txt
@@ -23,16 +23,25 @@ endif()
 # ${BINDER_SDK_DIR}/include/binder_sdk. The local dev layout splits headers
 # (out/build/include/binder_sdk) from runtime libs (out/target/lib/binder),
 # so allow BINDER_SDK_INCLUDE_DIR to point at the headers root.
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/videosink/0.1.0.0/CMakeLists.txt
+++ b/videosink/0.1.0.0/CMakeLists.txt
@@ -28,11 +28,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/videosink/0.1.0.0/CMakeLists.txt
+++ b/videosink/0.1.0.0/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/videosink/0.2.0.0/CMakeLists.txt
+++ b/videosink/0.2.0.0/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/videosink/0.2.0.0/CMakeLists.txt
+++ b/videosink/0.2.0.0/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/videosink/0.2.0.0/CMakeLists.txt
+++ b/videosink/0.2.0.0/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

--- a/videosink/current/CMakeLists.txt
+++ b/videosink/current/CMakeLists.txt
@@ -63,11 +63,22 @@ endif()
 # dir). First existing candidate wins; the dev layout is tried first so local
 # builds are unaffected (#644).
 set(_BINDER_INC "")
-foreach(_cand
-        "${BINDER_SDK_DIR}/include/binder_sdk"
+# Only consider a candidate whose base variable is actually set — otherwise an
+# unset BINDER_SDK_INCLUDE_DIR would expand to an absolute "/include/..." path
+# that could accidentally match a host directory.
+set(_binder_inc_cands "")
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include/binder_sdk")
+endif()
+if (BINDER_SDK_INCLUDE_DIR)
+    list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}"
-        "${BINDER_SDK_DIR}/include/binder")
+        "${BINDER_SDK_INCLUDE_DIR}")
+endif()
+if (BINDER_SDK_DIR)
+    list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")
+endif()
+foreach(_cand IN LISTS _binder_inc_cands)
     if (IS_DIRECTORY "${_cand}")
         set(_BINDER_INC "${_cand}")
         break()

--- a/videosink/current/CMakeLists.txt
+++ b/videosink/current/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 if (BINDER_SDK_INCLUDE_DIR)
     list(APPEND _binder_inc_cands
         "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
-        "${BINDER_SDK_INCLUDE_DIR}")
+        "${BINDER_SDK_INCLUDE_DIR}/include")
 endif()
 if (BINDER_SDK_DIR)
     list(APPEND _binder_inc_cands "${BINDER_SDK_DIR}/include")

--- a/videosink/current/CMakeLists.txt
+++ b/videosink/current/CMakeLists.txt
@@ -58,16 +58,25 @@ if (NOT DEFINED BINDER_SDK_DIR)
     message(FATAL_ERROR "BINDER_SDK_DIR must be set")
 endif()
 
-set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
-if (NOT IS_DIRECTORY "${_BINDER_INC}")
-    if (DEFINED BINDER_SDK_INCLUDE_DIR AND
-        IS_DIRECTORY "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-        set(_BINDER_INC "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk")
-    else()
-        message(FATAL_ERROR
-            "Binder SDK headers not found at ${_BINDER_INC}. "
-            "Set BINDER_SDK_INCLUDE_DIR to the headers root.")
+# Resolve the Binder header root across the local-dev layout
+# (<prefix>/include/binder_sdk) and Yocto/sysroot layouts (a direct include
+# dir). First existing candidate wins; the dev layout is tried first so local
+# builds are unaffected (#644).
+set(_BINDER_INC "")
+foreach(_cand
+        "${BINDER_SDK_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"
+        "${BINDER_SDK_INCLUDE_DIR}"
+        "${BINDER_SDK_DIR}/include/binder")
+    if (IS_DIRECTORY "${_cand}")
+        set(_BINDER_INC "${_cand}")
+        break()
     endif()
+endforeach()
+if (_BINDER_INC STREQUAL "")
+    message(FATAL_ERROR
+        "Binder SDK headers not found. Set BINDER_SDK_INCLUDE_DIR to the headers "
+        "root (local dev: <prefix>/include/binder_sdk; Yocto: the staged include dir).")
 endif()
 
 file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")


### PR DESCRIPTION
Closes #644. Sibling of #635 (both Yocto CMake portability; different root cause).

## Problem
Each component's `CMakeLists.txt` resolved binder headers only under a fixed `include/binder_sdk` subdir:
```cmake
set(_BINDER_INC "${BINDER_SDK_DIR}/include/binder_sdk")
if (NOT IS_DIRECTORY ...) ... "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk" ... else() FATAL
```
Yocto/cross builds stage headers **flat** (`<sysroot>/usr/include/...`), so they hit the FATAL. The reporter's proposed fix (treat `BINDER_SDK_INCLUDE_DIR` as a direct path) would have **broken local dev** (which needs the subdir).

## Fix
A candidate list — first existing dir wins, dev layout tried first (no regression):
```cmake
foreach(_cand
    "${BINDER_SDK_DIR}/include/binder_sdk"          # local dev
    "${BINDER_SDK_INCLUDE_DIR}/include/binder_sdk"  # dev split
    "${BINDER_SDK_INCLUDE_DIR}"                     # Yocto: direct include dir
    "${BINDER_SDK_DIR}/include/binder")             # alt sysroot name
  if (IS_DIRECTORY "${_cand}") set(_BINDER_INC "${_cand}") break() endif()
endforeach()
if (_BINDER_INC STREQUAL "") message(FATAL_ERROR ...) endif()
```

Applied across **52 `CMakeLists.txt`** — all component `current/` templates **and** the committed `<version>/` snapshots. Snapshots are build-config only (the `.hash` covers the AIDL contract, not `CMakeLists.txt`; precedent: #629), so this doesn't touch any frozen contract.

## Verified
- Synthetic CMake test: local-dev subdir → resolves subdir; Yocto flat → resolves direct dir; nothing set → FATAL.
- Real `./build_modules.sh common` still builds (`libcommon-vcurrent-cpp.so`).