### PR TITLE
fix(build): decouple standalone Yocto build from linux_binder_idl toolchain (#635)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,10 +210,11 @@ message(STATUS "Headers will install to: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL
 #######################################################################
 # Include binder CMake infrastructure for interface builds.
 #
-# This one-shot root build (INTERFACE_TARGET=all) uses the linux_binder_idl
-# toolchain's CMakeLists.inc, so it needs that source tree present — i.e. the
-# local dev / integrated build. A standalone Yocto/staged-SDK build does NOT
-# have it: there, libbinder is built + staged by the `linux-binder` recipe and
+# Any root build (this top-level CMakeLists, for any INTERFACE_TARGET) includes
+# the linux_binder_idl toolchain's CMakeLists.inc unconditionally, so it needs
+# that source tree present — i.e. the local dev / integrated build. A standalone
+# Yocto/staged-SDK build does NOT have it: there, libbinder is built + staged by
+# the `linux-binder` recipe and
 # the HAL libraries are built PER COMPONENT from the staged SDK, using each
 # component's self-contained CMakeLists (no CMakeLists.inc):
 #     cmake -S <module>/<version> -B build \
@@ -223,7 +224,7 @@ message(STATUS "Headers will install to: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL
 if (NOT EXISTS "${HOST_AIDL_DIR}/CMakeLists.inc")
     message(FATAL_ERROR
         "linux_binder_idl toolchain not found at ${HOST_AIDL_DIR}.\n"
-        "The root (INTERFACE_TARGET=all) build requires the linux_binder_idl source. "
+        "The root build (this top-level CMakeLists, any INTERFACE_TARGET) requires the linux_binder_idl source. "
         "For a staged-SDK / Yocto build, build components individually from the "
         "staged SDK instead:\n"
         "  cmake -S <module>/<version> -B build "
@@ -231,7 +232,7 @@ if (NOT EXISTS "${HOST_AIDL_DIR}/CMakeLists.inc")
         "Each <module>/<version>/CMakeLists.txt is self-contained. See the "
         "production-build section of the README.")
 endif()
-include(${HOST_AIDL_DIR}/CMakeLists.inc)
+include("${HOST_AIDL_DIR}/CMakeLists.inc")
 
 #######################################################################
 # Build interface libraries based on INTERFACE_TARGET and INTERFACE_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,9 +208,29 @@ message(STATUS "Libraries will install to: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTA
 message(STATUS "Headers will install to: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
 
 #######################################################################
-# Include binder CMake infrastructure for interface builds
+# Include binder CMake infrastructure for interface builds.
+#
+# This one-shot root build (INTERFACE_TARGET=all) uses the linux_binder_idl
+# toolchain's CMakeLists.inc, so it needs that source tree present — i.e. the
+# local dev / integrated build. A standalone Yocto/staged-SDK build does NOT
+# have it: there, libbinder is built + staged by the `linux-binder` recipe and
+# the HAL libraries are built PER COMPONENT from the staged SDK, using each
+# component's self-contained CMakeLists (no CMakeLists.inc):
+#     cmake -S <module>/<version> -B build \
+#           -DBINDER_SDK_DIR=<sysroot> -DBINDER_SDK_INCLUDE_DIR=<sysroot>
+# Fail fast with that pointer rather than a cryptic include() error. (#635)
 #######################################################################
-
+if (NOT EXISTS "${HOST_AIDL_DIR}/CMakeLists.inc")
+    message(FATAL_ERROR
+        "linux_binder_idl toolchain not found at ${HOST_AIDL_DIR}.\n"
+        "The root (INTERFACE_TARGET=all) build requires the linux_binder_idl source. "
+        "For a staged-SDK / Yocto build, build components individually from the "
+        "staged SDK instead:\n"
+        "  cmake -S <module>/<version> -B build "
+        "-DBINDER_SDK_DIR=<sysroot> -DBINDER_SDK_INCLUDE_DIR=<sysroot>\n"
+        "Each <module>/<version>/CMakeLists.txt is self-contained. See the "
+        "production-build section of the README.")
+endif()
 include(${HOST_AIDL_DIR}/CMakeLists.inc)
 
 #######################################################################

--- a/README.md
+++ b/README.md
@@ -116,20 +116,30 @@ single-component release would have been.
 
 ### Production build (Yocto/BitBake)
 
+libbinder is built and staged by the separate **`linux-binder`** recipe
+(`DEPENDS = "linux-binder"`). The HAL libraries are then built **per component**
+from that staged SDK — each `<module>/<version>/` is self-contained (committed
+C++, its own CMakeLists, **no linux_binder_idl toolchain source needed**):
+
 ```bash
-# linux_binder SDK is staged by the Yocto dependency system (DEPENDS = "linux-binder").
-# A staged SDK is flat, so headers and libs share one prefix — pass both
-# BINDER_SDK_DIR and BINDER_SDK_INCLUDE_DIR (they differ only in the local dev tree).
-cmake -S . -B build -DINTERFACE_TARGET=all \
+# For each released <module>/<version>. A staged SDK is flat, so headers and
+# libs share one prefix — point both BINDER_SDK_DIR and BINDER_SDK_INCLUDE_DIR
+# at it (they differ only in the local dev tree).
+cmake -S <module>/<version> -B build \
       -DBINDER_SDK_DIR=${STAGING_DIR}/usr \
       -DBINDER_SDK_INCLUDE_DIR=${STAGING_DIR}/usr
 cmake --build build
 cmake --install build
 ```
 
-Compiles the committed module-local C++ into `lib<module>-vcurrent-cpp.so` and
-installs to `${OUT_DIR}/target/lib/halif/`. Requires only CMake, a C++ compiler
-and the linux_binder SDK — no Python, no AIDL compiler.
+Compiles the committed module-local C++ into `lib<module>-v<version>-cpp.so`.
+Requires only CMake, a C++ compiler and the staged linux_binder SDK — no Python,
+no AIDL compiler, and no linux_binder_idl source.
+
+> **Note (#635):** the one-shot root build (`cmake -S . -DINTERFACE_TARGET=all`)
+> is the **integrated dev** path — it pulls in the linux_binder_idl toolchain
+> (`CMakeLists.inc`) and so requires that source tree. It is **not** for a
+> standalone Yocto recipe; use the per-component build above.
 
 ### Version manifest (`versions.yaml`)
 


### PR DESCRIPTION
Closes #635. Sibling of #644 (flexible binder include path).

## Problem
The root `CMakeLists.txt` does `include(${HOST_AIDL_DIR}/CMakeLists.inc)` (line 214) — the linux_binder_idl toolchain infra. So the documented one-shot production build (`cmake -S . -DINTERFACE_TARGET=all`) **requires the linux_binder_idl source tree**, which a standalone Yocto recipe building from a *staged* SDK doesn't have → the "not compactable for Yocto" failure.

## Fix (option 2: per-component Yocto build)
In Yocto, libbinder is built + staged by the separate **`linux-binder`** recipe; the HAL libraries are then built **per component** from the staged SDK — each `<module>/<version>/CMakeLists.txt` is self-contained (committed C++, no `CMakeLists.inc`):
```bash
cmake -S <module>/<version> -B build \
      -DBINDER_SDK_DIR=${STAGING_DIR}/usr -DBINDER_SDK_INCLUDE_DIR=${STAGING_DIR}/usr
cmake --build build && cmake --install build
```
Both paths are supported — the split is by wrapper: **`.sh` / dev** uses the integrated root build; **`.bb` / Yocto** uses the per-component build.

- **Guard the root include**: if `CMakeLists.inc` is absent, fail fast pointing to the per-component build instead of a cryptic error. Non-regression — present in the dev tree, so the guard passes and the root build is unchanged.
- **README**: production-build section now recommends the per-component Yocto build (was recommending the coupled root path) and marks the root path as integrated-dev only.

## Verified
Guard passes when `CMakeLists.inc` present (dev), FATALs with the per-component pointer when absent. The per-component build itself is already exercised by the #644 flat-layout fake-yocto check.