### PR TITLE
feat(governance): add independent `CR` label for ABI changes (#677)

### DIFF
--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -119,6 +119,28 @@ The PR author edits the component's `metadata.yaml` `version:` to the new
 value as part of the PR's diff. Reviewers check that the version bump matches
 the label and the actual change.
 
+#### The `CR` Label (independent — not a change-class)
+
+`CR` (Change Request) marks an **ABI change** that must go through wider review
+and deliberate scheduling. It is a **process/governance** label, **independent**
+of the change-class above. The change-class answers *"how does the version
+number move?"*; `CR` answers a **different** question — *"is this an ABI change
+that needs wider review and separate scheduling?"* The two axes are orthogonal,
+so a `CR` carries a change-class label alongside it (an ABI change is a
+`Breaking Change`).
+
+A PR/issue tagged `CR` requires:
+
+1. **Wider review sign-off on approval** — beyond the default CODEOWNERS review
+   team, the relevant `team:*` architecture reviewers must sign off.
+2. **Separate release scheduling** — it is not folded into the normal cohort
+   release sweep; it is scheduled into a release deliberately.
+
+`CR` does **not** affect the version bump — `scripts/release.sh` never reads it.
+It is therefore *not* a rename of `Breaking Change`: `Breaking Change` remains
+the change-class that drives the generation bump, and conflating the two would
+break the label-driven bump logic.
+
 #### The Subsume Rule
 
 Between releases, `metadata.yaml` `version:` represents the **intent for the
@@ -606,6 +628,7 @@ Idempotent — safe to re-run.
 | `Breaking Change` | Breaking interface change — bumps generation |
 | `Major Change` | Additive interface change — bumps minor (the default for real work) |
 | `Minor Change` | Doc-only / metadata-only / comment-only change — bumps patch |
+| `CR` | Change Request — ABI change needing wider review sign-off + separate release scheduling (independent of change-class; no bump effect) |
 | `scope:infrastructure` | Repo tooling, CI/CD, governance |
 | `scope:overview` | Tracking ticket spanning multiple components |
 

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -127,6 +127,23 @@ create_label "documentation"        "0075ca" "Documentation-only change — bump
 echo ""
 
 # ---------------------------------------------------------------------------
+# Process / governance labels
+#
+# `CR` marks an ABI change that must go through wider review sign-off and be
+# scheduled into a release deliberately. It is INDEPENDENT of the change-class
+# above: the change-class answers "how does the version number move?", `CR`
+# answers "is this an ABI change needing review + scheduling?" — so it is
+# orthogonal and co-exists with a change-class label (an ABI change is a
+# `Breaking Change`). It does NOT affect the version bump; `release.sh` never
+# reads it.
+# ---------------------------------------------------------------------------
+
+echo "Process / governance labels:"
+create_label "CR"                    "5319e7" "Change Request — ABI change needing wider review sign-off + separate release scheduling"
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # Scope labels (for cross-cutting / infrastructure work)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds **`CR`** (Change Request) as an **independent process/governance label**.

`CR` marks an **ABI change** that needs:

1. **Wider review sign-off on approval** — beyond the default CODEOWNERS team, the relevant `team:*` architecture reviewers must sign off.
2. **Separate release scheduling** — not folded into the normal cohort sweep; scheduled deliberately.

## Why independent (not a rename of `Breaking Change`)

The change-class labels (`Breaking Change` / `Major Change` / `Minor Change`) answer *"how does the version number move?"* and are matched **by name** in `scripts/release.sh` to compute the bump. `CR` answers a **different** question — *"is this an ABI change needing wider review + scheduling?"* — so it is orthogonal and co-exists with a change-class label (an ABI change is a `Breaking Change`).

Renaming `Breaking Change` → `CR` would conflate the two axes and break the generation-bump detection in `release.sh:1304`. So the axes stay separate; `release.sh` never reads `CR`.

## Changes

- `scripts/setup_labels.sh` — declare `CR` under a new *process/governance* section (color `5319e7`).
- `docs/governance/versioning-sop.md` — document `CR` as an independent, non-bump label + add it to the label reference table.

The live `CR` label is already created on the repo; this PR makes `setup_labels.sh` (the declarative source of truth) and the sop agree.

Closes #677