### PR TITLE
chore(audiomixer): RAG status AMBER → GREEN (#680)

### DIFF
--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiomixer
 version: 0.3.0.0
-status: AMBER
+status: GREEN
 description: "Audio mixing and routing for multi-stream output"
 type: SOC
 


### PR DESCRIPTION
## Summary

RAG-status reconciliation sweep (#680). `audiomixer/metadata.yaml` carried `AMBER` with **no `status_detail` and no `action`** — a stale status, not a live blocker. Work is completed (only awaiting a review slot), so it moves to **GREEN**.

## Sweep result

audiomixer was the **only** stale AMBER. Every other AMBER/RED component has a genuine recorded action and is left unchanged (bootreason, broadcast, deepsleep, drm, ffv, firmwareupdate, panel, planecontrol, r4ce).

Closes #680