### PR TITLE
chore: RAG → GREEN for 5 V1-complete components (audiomixer stays AMBER) + uplink.yaml refresh

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,11 +2,11 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-06-11 |
+| **Generated** | 2026-07-03 |
 | **Components** | 31 |
-| 🟢 **GREEN** | 14 |
-| 🟡 **AMBER** | 16 |
-| 🔴 **RED** | 1 |
+| 🟢 **GREEN** | 20 |
+| 🟡 **AMBER** | 11 |
+| 🔴 **RED** | 0 |
 
 ---
 
@@ -14,9 +14,9 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **14** | Reviewed & Approved — Interface stable on develop |
-| 🟡 AMBER | **16** | Under Active Ingestion — Will enter sprint review when ready |
-| 🔴 RED | **1** | Not Started / Blocked — Strategy or definition required |
+| 🟢 GREEN | **20** | Reviewed & Approved — Interface stable on develop |
+| 🟡 AMBER | **11** | Under Active Ingestion — Will enter sprint review when ready |
+| 🔴 RED | **0** | Not Started / Blocked — Strategy or definition required |
 
 ---
 
@@ -27,13 +27,16 @@
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | audiodecoder | 0.2.0.0 | Audio decoder resource management and codec format support | 0/4 | Architecture + AV_Architecture |
+| 🟢 | audiomixer | 0.3.0.0 | Audio mixing and routing for multi-stream output | 0/4 | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟢 | audiosink | 0.2.0.0 | Audio output rendering and sink device management | 0/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.2.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avclock | 0.2.0.0 | Audio/video clock synchronization and timing control | 0/4 | Architecture + AV_Architecture |
 | 🟢 | common | 0.2.0.0 | Shared base AIDL types and definitions used across all HAL interfaces | 0/2 | Architecture |
+| 🟢 | drm | 0.1.0.0 | DRM plugin and crypto plugin interfaces for content protection | 0/4 | Architecture + AV_Architecture |
 | 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
+| 🟢 | planecontrol | 0.1.0.0 | Graphics and video plane composition control | 0/5 | Architecture + Graphics_Architecture |
 | 🟢 | videodecoder | 0.2.0.0 | Video decoder resource management and codec support | 0/4 | Architecture + AV_Architecture |
 | 🟢 | videosink | 0.2.0.0 | Video output rendering and display sink management | 0/4 | Architecture + AV_Architecture |
 
@@ -42,9 +45,12 @@
 
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
+| 🟢 | bootreason | 0.1.0.0 | Boot reason tracking and reboot management | 3/4 | Architecture + MW_Team |
 | 🟢 | compositeinput | 0.2.0.0 | Composite video input capture and control | 2/4 | Architecture + AV_Architecture |
+| 🟢 | deepsleep | 0.1.0.0 | Deep sleep and low-power state management | 3/4 | Architecture |
 | 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/4 | Architecture + Kernel_Architecture |
 | 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/4 | Architecture + Graphics_Architecture |
+| 🟢 | panel | 0.1.0.0 | Front panel display and button control | 2/4 | Architecture + Graphics_Architecture |
 | 🟢 | sensor | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
 
 
@@ -56,10 +62,8 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
-| 🟡 | audiomixer | 0.3.0.0 | — | — | — | — | — | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟡 | avbuffer *(SVP risk)* | 0.2.0.0 | 1 | Encrypted buffer (DRM/SVP) - Pending on DRM strategy | May change due to SVP changes from DRM which is being worked on | — | — | Architecture + AV_Architecture |
 | 🟡 | vsi/kernel | 0.0.0.1 | 1 | Strategy required | Not blocking progress - Architecture Strategy | — | — | Architecture |
-| 🟡 | planecontrol | 0.1.0.0 | 3 | Re-review required | Discussions with MW team - Simplify design. Architecture requires simplified design and restructured review. | — | — | Architecture + Graphics_Architecture |
 | 🟡 | vsi/graphics | 0.0.0.1 | 6 | Docs required | Not blocking progress - Define Versions & write up vision and direction, Planning Out Evolution of the platform, RDK-M | — | — | Architecture + Graphics_Architecture |
 
 
@@ -67,9 +71,6 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
-| 🟡 | panel | 0.1.0.0 | 3 | Re-review required | Review PQ settings for multiple video and PQ panel mixing | — | — | Architecture + Graphics_Architecture |
-| 🟡 | deepsleep | 0.1.0.0 | 4 | Feedback-loop review | Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue | — | — | Architecture |
-| 🟡 | bootreason | 0.1.0.0 | 5 | Migrate -> Reboot Reason | Rename Module | — | — | Architecture + MW_Team |
 | 🟡 | broadcast | 0.1.0.0 | 5 | Not integrated into the AIDL build - blocked on FMQ (#494) | Blocked: needs the android.hardware.common.fmq AIDL package in the binder SDK (linux_binder_idl#18); then add broadcast/current/interface.yaml - see #494. | — | — | Vendor_Layer_Team + Broadcast_Team |
 | 🟡 | firmwareupdate | 0.2.0.0 | 5 | Renamed from flash — fresh review cycle | Re-review under new name and broadened scope | — | — | Architecture + Kernel_Architecture |
 | 🟡 | r4ce | 0.0.0.1 | 5 | API Definition in progress | Control Manager Team - API Definition started | — | — | Architecture + Control_Manager_Architecture |
@@ -89,7 +90,6 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
-| 🔴 | drm | 0.1.0.0 | 1 | Initial interface definition — under review | Architecture review and vendor alignment | — | — | Architecture + AV_Architecture |
 
 
 ### OEM Components
@@ -109,13 +109,16 @@
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟢 | audiodecoder | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | audiomixer | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | audiosink | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | avbuffer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | avclock | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | common | 0/2 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | N/A | N/A |
+| 🟢 | drm | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | hdmicec | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | hdmiinput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
 | 🟢 | hdmioutput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
+| 🟢 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟢 | videodecoder | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | videosink | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
@@ -124,32 +127,29 @@
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟡 | vsi/kernel | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
-| 🟡 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟡 | vsi/graphics | 0/4 | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | audiomixer | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🔴 | drm | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### OEM — 🟢 GREEN
 
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟢 | bootreason | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟢 | compositeinput | 2/4 | ✅ | ✅ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
+| 🟢 | deepsleep | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟢 | deviceinfo | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 | 🟢 | indicator | 4/4 | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
+| 🟢 | panel | 2/4 | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟢 | sensor | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
-| 🟡 | panel | 2/4 | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
-| 🟡 | deepsleep | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
-| 🟡 | bootreason | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟡 | broadcast | 0/4 | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
 | 🟡 | firmwareupdate | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 | 🟡 | r4ce | 0/4 | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |

--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,10 +2,10 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-07-03 |
+| **Generated** | 2026-07-05 |
 | **Components** | 31 |
-| 🟢 **GREEN** | 20 |
-| 🟡 **AMBER** | 11 |
+| 🟢 **GREEN** | 19 |
+| 🟡 **AMBER** | 12 |
 | 🔴 **RED** | 0 |
 
 ---
@@ -14,8 +14,8 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **20** | Reviewed & Approved — Interface stable on develop |
-| 🟡 AMBER | **11** | Under Active Ingestion — Will enter sprint review when ready |
+| 🟢 GREEN | **19** | Reviewed & Approved — Interface stable on develop |
+| 🟡 AMBER | **12** | Under Active Ingestion — Will enter sprint review when ready |
 | 🔴 RED | **0** | Not Started / Blocked — Strategy or definition required |
 
 ---
@@ -27,7 +27,6 @@
 | | Component | Current Version | Description | Reviews | Owners |
 |---|-----------|---------|-------------|---------|--------|
 | 🟢 | audiodecoder | 0.2.0.0 | Audio decoder resource management and codec format support | 0/4 | Architecture + AV_Architecture |
-| 🟢 | audiomixer | 0.3.0.0 | Audio mixing and routing for multi-stream output | 0/4 | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟢 | audiosink | 0.2.0.0 | Audio output rendering and sink device management | 0/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.2.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
 | 🟢 | avclock | 0.2.0.0 | Audio/video clock synchronization and timing control | 0/4 | Architecture + AV_Architecture |
@@ -62,6 +61,7 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
+| 🟡 | audiomixer | 0.3.0.0 | — | AQ parameter API in review | Land the AQ processor interface (#411 / #410, PR #573) — a breaking interface addition still under review; V1 not yet complete. Flip to GREEN on merge. | — | — | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟡 | avbuffer *(SVP risk)* | 0.2.0.0 | 1 | Encrypted buffer (DRM/SVP) - Pending on DRM strategy | May change due to SVP changes from DRM which is being worked on | — | — | Architecture + AV_Architecture |
 | 🟡 | vsi/kernel | 0.0.0.1 | 1 | Strategy required | Not blocking progress - Architecture Strategy | — | — | Architecture |
 | 🟡 | vsi/graphics | 0.0.0.1 | 6 | Docs required | Not blocking progress - Define Versions & write up vision and direction, Planning Out Evolution of the platform, RDK-M | — | — | Architecture + Graphics_Architecture |
@@ -109,7 +109,6 @@
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟢 | audiodecoder | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
-| 🟢 | audiomixer | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | audiosink | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | avbuffer | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | avclock | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
@@ -128,6 +127,7 @@
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟡 | vsi/kernel | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 | 🟡 | vsi/graphics | 0/4 | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
+| 🟡 | audiomixer | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
 ### SOC — 🔴 RED
 

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiomixer
 version: 0.3.0.0
-status: GREEN
+status: AMBER
 description: "Audio mixing and routing for multi-stream output"
 type: SOC
 
@@ -50,6 +50,8 @@ scope:
 #   risk          - Risk notes (appears as watch item on dashboard)
 #   owners        - Responsible architecture teams
 notes:
+  status_detail: "AQ parameter API in review"
+  action: "Land the AQ processor interface (#411 / #410, PR #573) — a breaking interface addition still under review; V1 not yet complete. Flip to GREEN on merge."
   owners: "Architecture + Vendor_Layer_Team + AV_Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]

--- a/audiomixer/metadata.yaml
+++ b/audiomixer/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiomixer
 version: 0.3.0.0
-status: AMBER
+status: GREEN
 description: "Audio mixing and routing for multi-stream output"
 type: SOC
 

--- a/bootreason/metadata.yaml
+++ b/bootreason/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: bootreason
 version: 0.1.0.0
-status: AMBER
+status: GREEN
 description: "Boot reason tracking and reboot management"
 type: OEM
 
@@ -51,8 +51,7 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 5
-  status_detail: "Migrate -> Reboot Reason"
-  action: "Rename Module"
+  status_detail: "V1 stable; module rename landed (#575)"
   owners: "Architecture + MW_Team"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]

--- a/deepsleep/metadata.yaml
+++ b/deepsleep/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: deepsleep
 version: 0.1.0.0
-status: AMBER
+status: GREEN
 description: "Deep sleep and low-power state management"
 type: OEM
 
@@ -51,8 +51,8 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 4
-  status_detail: "Feedback-loop review"
-  action: "Review design based on learnings from current platforms. Examine findings and investigation on Shutdown issue"
+  status_detail: "V1 stable"
+  action: "Design feedback tracked in #165"
   owners: "Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]

--- a/drm/metadata.yaml
+++ b/drm/metadata.yaml
@@ -24,7 +24,7 @@
 component: drm
 version: 0.1.0.0
 generation: 1
-status: RED
+status: GREEN
 description: "DRM plugin and crypto plugin interfaces for content protection"
 type: SOC
 
@@ -54,8 +54,7 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 1
-  status_detail: "Initial interface definition — under review"
-  action: "Architecture review and vendor alignment"
+  status_detail: "V1 interface merged (#341)"
   owners: "Architecture + AV_Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: panel
 version: 0.1.0.0
-status: AMBER
+status: GREEN
 description: "Front panel display and button control"
 type: OEM
 
@@ -51,8 +51,8 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 3
-  status_detail: "Re-review required"
-  action: "Review PQ settings for multiple video and PQ panel mixing"
+  status_detail: "V1 stable"
+  action: "PQ capability work tracked in #674, #497, #516, #276"
   owners: "Architecture + Graphics_Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: planecontrol
 version: 0.1.0.0
-status: AMBER
+status: GREEN
 description: "Graphics and video plane composition control"
 type: SOC
 
@@ -52,8 +52,8 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 3
-  status_detail: "Re-review required"
-  action: "Discussions with MW team - Simplify design. Architecture requires simplified design and restructured review."
+  status_detail: "V1 stable"
+  action: "Design simplification tracked in #622, #329"
   owners: "Architecture + Graphics_Architecture"
 
 # reviewers - Sign-off status per stakeholder team                       [manual]

--- a/uplink.yaml
+++ b/uplink.yaml
@@ -27,7 +27,6 @@ videodecoder:
   mw_teams: [AV_Architecture]
   vts_team:
     - { id: CPESP-9032, url: "https://ccp.sys.comcast.net/browse/CPESP-9032", title: "RDK-E Video Decoder - VTS", status: Closed }
-    - { id: CPESP-8647, url: "https://ccp.sys.comcast.net/browse/CPESP-8647", title: "RDK-E Video Decoder HAL - vDevice", status: In Progress }
   vdevice: { id: CPESP-8649, url: "https://ccp.sys.comcast.net/browse/CPESP-8649", title: "RDK-E Video Decoder HAL - Amlogic", status: In Progress }
 
 audiosink:

--- a/uplink.yaml
+++ b/uplink.yaml
@@ -14,9 +14,9 @@
 # MW Teams (middleware review teams in metadata.yaml):
 #   AV_Architecture, Control_Manager_Architecture, Graphics_Architecture
 #
-# Jira statuses last refreshed: 2026-03-20T23:00Z (must be re-pulled from
-# Confluence before this file is relied on for current status).
-# Last edited: 2026-05-26 — renamed flash -> firmwareupdate (see #523).
+# Jira statuses last refreshed: 2026-07-03 (live corp-sync pull; must be re-pulled
+# before this file is relied on for current status).
+# Last edited: 2026-07-03 — live status refresh, boot -> bootreason (see #684).
 
 # SOC Components
 videodecoder:
@@ -27,8 +27,8 @@ videodecoder:
   mw_teams: [AV_Architecture]
   vts_team:
     - { id: CPESP-9032, url: "https://ccp.sys.comcast.net/browse/CPESP-9032", title: "RDK-E Video Decoder - VTS", status: Closed }
-    - { id: CPESP-8647, url: "https://ccp.sys.comcast.net/browse/CPESP-8647", title: "RDK-E Video Decoder HAL - vDevice", status: Ready to Define }
-  vdevice: { id: CPESP-8649, url: "https://ccp.sys.comcast.net/browse/CPESP-8649", title: "RDK-E Video Decoder HAL - Amlogic", status: Ready to Define }
+    - { id: CPESP-8647, url: "https://ccp.sys.comcast.net/browse/CPESP-8647", title: "RDK-E Video Decoder HAL - vDevice", status: In Progress }
+  vdevice: { id: CPESP-8649, url: "https://ccp.sys.comcast.net/browse/CPESP-8649", title: "RDK-E Video Decoder HAL - Amlogic", status: In Progress }
 
 audiosink:
   metadata: audiosink/metadata.yaml
@@ -39,7 +39,7 @@ audiosink:
   vts_team:
     - { id: CPESP-9030, url: "https://ccp.sys.comcast.net/browse/CPESP-9030", title: "RDK-E Audio Sink - VTS", status: Closed }
     - { id: CPESP-8163, url: "https://ccp.sys.comcast.net/browse/CPESP-8163", title: "RDK-E Audio Sink HAL VTS", status: Closed }
-  vdevice: { id: CPESP-9029, url: "https://ccp.sys.comcast.net/browse/CPESP-9029", title: "RDK-E Audio Sink HAL Implementation - vDevice", status: Ready to Define }
+  vdevice: { id: CPESP-9029, url: "https://ccp.sys.comcast.net/browse/CPESP-9029", title: "RDK-E Audio Sink HAL Implementation - vDevice", status: In Progress }
 
 audiodecoder:
   metadata: audiodecoder/metadata.yaml
@@ -50,7 +50,7 @@ audiodecoder:
   vts_team:
     - { id: CPESP-9031, url: "https://ccp.sys.comcast.net/browse/CPESP-9031", title: "RDK-E Audio Decoder - VTS", status: Closed }
     - { id: CPESP-8161, url: "https://ccp.sys.comcast.net/browse/CPESP-8161", title: "RDK-E Audio Decoder HAL VTS", status: Closed }
-  vdevice: { id: CPESP-8651, url: "https://ccp.sys.comcast.net/browse/CPESP-8651", title: "RDK-E Audio Decoder HAL - vDevice", status: Ready to Define }
+  vdevice: { id: CPESP-8651, url: "https://ccp.sys.comcast.net/browse/CPESP-8651", title: "RDK-E Audio Decoder HAL - vDevice", status: In Progress }
 
 videosink:
   metadata: videosink/metadata.yaml
@@ -61,7 +61,7 @@ videosink:
   vts_team:
     - { id: CPESP-8162, url: "https://ccp.sys.comcast.net/browse/CPESP-8162", title: "RDK-E Video Sink HAL VTS", status: Closed }
     - { id: CPESP-9033, url: "https://ccp.sys.comcast.net/browse/CPESP-9033", title: "RDK-E Video Sink - VTS", status: Closed }
-  vdevice: { id: CPESP-9023, url: "https://ccp.sys.comcast.net/browse/CPESP-9023", title: "RDK-E Video Sink HAL Implementation - vDevice", status: Ready to Define }
+  vdevice: { id: CPESP-9023, url: "https://ccp.sys.comcast.net/browse/CPESP-9023", title: "RDK-E Video Sink HAL Implementation - vDevice", status: In Progress }
 
 avclock:
   metadata: avclock/metadata.yaml
@@ -88,11 +88,11 @@ avbuffer:
 audiomixer:
   metadata: audiomixer/metadata.yaml
   feature: { id: ENT-8634, url: "https://ccp.sys.comcast.net/browse/ENT-8634", title: "RDK-E Audio Mixer HAL", status: Ideation }
-  hal_spec: { id: CPESP-4474, url: "https://ccp.sys.comcast.net/browse/CPESP-4474", title: "RDK-E Audio Mixer HAL Interface Specification", status: In Progress }
+  hal_spec: { id: CPESP-4474, url: "https://ccp.sys.comcast.net/browse/CPESP-4474", title: "RDK-E Audio Mixer HAL Interface Specification", status: Closed }
   mw_review: Complete
   mw_teams: [AV_Architecture]
   vts_team:
-    - { id: CPESP-8646, url: "https://ccp.sys.comcast.net/browse/CPESP-8646", title: "RDK-E Audio Mixer HAL VTS", status: Closed }
+    - { id: CPESP-8646, url: "https://ccp.sys.comcast.net/browse/CPESP-8646", title: "RDK-E Audio Mixer HAL VTS", status: Ready for Work }
   vdevice: { id: CPESP-5195, url: "https://ccp.sys.comcast.net/browse/CPESP-5195", title: "RDK-E Audio Mixer HAL - vDevice", status: Ready to Define }
 
 planecontrol:
@@ -113,7 +113,7 @@ hdmicec:
   mw_teams: [AV_Architecture]
   vts_team:
     - { id: CPESP-5391, url: "https://ccp.sys.comcast.net/browse/CPESP-5391", title: "RDK-E HDMI-CEC HAL VTS", status: Released }
-  vdevice: { id: CPESP-5493, url: "https://ccp.sys.comcast.net/browse/CPESP-5493", title: "RDK-E HDMI-CEC HAL - vDevice", status: Ready to Define }
+  vdevice: { id: CPESP-5493, url: "https://ccp.sys.comcast.net/browse/CPESP-5493", title: "RDK-E HDMI-CEC HAL - vDevice", status: In Progress }
 
 hdmiinput:
   metadata: hdmiinput/metadata.yaml
@@ -122,8 +122,8 @@ hdmiinput:
   mw_review: Complete
   mw_teams: [AV_Architecture]
   vts_team:
-    - { id: CPESP-5398, url: "https://ccp.sys.comcast.net/browse/CPESP-5398", title: "RDK-E HDMI Input HAL VTS", status: In Progress }
-  vdevice: { id: CPESP-5488, url: "https://ccp.sys.comcast.net/browse/CPESP-5488", title: "RDK-E HDMI Input HAL - vDevice", status: Ready to Define }
+    - { id: CPESP-5398, url: "https://ccp.sys.comcast.net/browse/CPESP-5398", title: "RDK-E HDMI Input HAL VTS", status: Released }
+  vdevice: { id: CPESP-5488, url: "https://ccp.sys.comcast.net/browse/CPESP-5488", title: "RDK-E HDMI Input HAL - vDevice", status: Ready for Work }
 
 hdmioutput:
   metadata: hdmioutput/metadata.yaml
@@ -132,14 +132,14 @@ hdmioutput:
   mw_review: Complete
   mw_teams: [AV_Architecture]
   vts_team:
-    - { id: CPESP-5397, url: "https://ccp.sys.comcast.net/browse/CPESP-5397", title: "RDK-E HDMI Output HAL VTS", status: In Progress }
-  vdevice: { id: CPESP-5489, url: "https://ccp.sys.comcast.net/browse/CPESP-5489", title: "RDK-E HDMI Output HAL - vDevice", status: Ready to Define }
+    - { id: CPESP-5397, url: "https://ccp.sys.comcast.net/browse/CPESP-5397", title: "RDK-E HDMI Output HAL VTS", status: Released }
+  vdevice: { id: CPESP-5489, url: "https://ccp.sys.comcast.net/browse/CPESP-5489", title: "RDK-E HDMI Output HAL - vDevice", status: Ready for Work }
 
 drm:
   metadata: drm/metadata.yaml
   # Reuses the ENT-8653 "RDK-E DRM HAL" initiative previously attached to cdm.
   feature: { id: ENT-8653, url: "https://ccp.sys.comcast.net/browse/ENT-8653", title: "RDK-E DRM HAL", status: Ideation }
-  hal_spec: ~  # TODO: link DRM HAL Interface Specification CPESP ticket once raised
+  hal_spec: ~  # interface delivered in-repo at v0.1.0.0 (#341); no CPESP raised
   mw_review: ~
   mw_teams: [AV_Architecture]
   vts_team: ~  # TODO: link DRM HAL VTS CPESP ticket once raised
@@ -153,8 +153,8 @@ compositeinput:
   mw_review: Complete
   mw_teams: [AV_Architecture]
   vts_team:
-    - { id: CPESP-5396, url: "https://ccp.sys.comcast.net/browse/CPESP-5396", title: "RDK-E Composite Input HAL VTS", status: Ready to Define }
-  vdevice: { id: CPESP-5490, url: "https://ccp.sys.comcast.net/browse/CPESP-5490", title: "RDK-E Composite Input HAL - vDevice", status: Ready to Define }
+    - { id: CPESP-5396, url: "https://ccp.sys.comcast.net/browse/CPESP-5396", title: "RDK-E Composite Input HAL VTS", status: Released }
+  vdevice: { id: CPESP-5490, url: "https://ccp.sys.comcast.net/browse/CPESP-5490", title: "RDK-E Composite Input HAL - vDevice", status: Ready for Work }
 
 indicator:
   metadata: indicator/metadata.yaml
@@ -163,13 +163,13 @@ indicator:
   mw_review: Complete
   mw_teams: [Graphics_Architecture]
   vts_team:
-    - { id: CPESP-5405, url: "https://ccp.sys.comcast.net/browse/CPESP-5405", title: "RDK-E Indicator HAL VTS", status: In Progress }
-  vdevice: { id: CPESP-5467, url: "https://ccp.sys.comcast.net/browse/CPESP-5467", title: "RDK-E Indicator HAL - vDevice", status: Ready to Define }
+    - { id: CPESP-5405, url: "https://ccp.sys.comcast.net/browse/CPESP-5405", title: "RDK-E Indicator HAL VTS", status: Closed }
+  vdevice: { id: CPESP-5467, url: "https://ccp.sys.comcast.net/browse/CPESP-5467", title: "RDK-E Indicator HAL - vDevice", status: In Progress }
 
 panel:
   metadata: panel/metadata.yaml
   feature: { id: ENT-8642, url: "https://ccp.sys.comcast.net/browse/ENT-8642", title: "RDK-E Panel HAL", status: Ideation }
-  hal_spec: { id: CPESP-5614, url: "https://ccp.sys.comcast.net/browse/CPESP-5614", title: "RDK-E Panel HAL Interface Specification", status: In Progress }
+  hal_spec: { id: CPESP-5614, url: "https://ccp.sys.comcast.net/browse/CPESP-5614", title: "RDK-E Panel HAL Interface Specification", status: Closed }
   mw_review: Complete
   mw_teams: [Graphics_Architecture]
   vts_team:
@@ -179,11 +179,11 @@ panel:
 sensor:
   metadata: sensor/metadata.yaml
   feature: { id: ENT-8650, url: "https://ccp.sys.comcast.net/browse/ENT-8650", title: "RDK-E Sensor HAL", status: Ideation }
-  hal_spec: { id: CPESP-4577, url: "https://ccp.sys.comcast.net/browse/CPESP-4577", title: "RDK-E Sensor HAL Interface Specification", status: In Progress }
+  hal_spec: { id: CPESP-4577, url: "https://ccp.sys.comcast.net/browse/CPESP-4577", title: "RDK-E Sensor HAL Interface Specification", status: Closed }
   mw_review: Complete
   mw_teams: ~
   vts_team:
-    - { id: CPESP-5403, url: "https://ccp.sys.comcast.net/browse/CPESP-5403", title: "RDK-E Sensor HAL VTS", status: Ready to Define }
+    - { id: CPESP-5403, url: "https://ccp.sys.comcast.net/browse/CPESP-5403", title: "RDK-E Sensor HAL VTS", status: Released }
   vdevice: { id: CPESP-5469, url: "https://ccp.sys.comcast.net/browse/CPESP-5469", title: "RDK-E Sensor HAL - vDevice", status: Ready to Define }
 
 deviceinfo:
@@ -193,28 +193,28 @@ deviceinfo:
   mw_review: Complete
   mw_teams: ~
   vts_team:
-    - { id: CPESP-5399, url: "https://ccp.sys.comcast.net/browse/CPESP-5399", title: "RDK-E DeviceInfo HAL VTS", status: In Progress }
-  vdevice: { id: CPESP-5487, url: "https://ccp.sys.comcast.net/browse/CPESP-5487", title: "RDK-E DeviceInfo HAL - vDevice", status: Ready to Define }
+    - { id: CPESP-5399, url: "https://ccp.sys.comcast.net/browse/CPESP-5399", title: "RDK-E DeviceInfo HAL VTS", status: Released }
+  vdevice: { id: CPESP-5487, url: "https://ccp.sys.comcast.net/browse/CPESP-5487", title: "RDK-E DeviceInfo HAL - vDevice", status: In Progress }
 
 deepsleep:
   metadata: deepsleep/metadata.yaml
   feature: { id: ENT-8655, url: "https://ccp.sys.comcast.net/browse/ENT-8655", title: "RDK-E DeepSleep HAL", status: Ideation }
-  hal_spec: { id: CPESP-4395, url: "https://ccp.sys.comcast.net/browse/CPESP-4395", title: "RDK-E DeepSleep HAL Interface Specification", status: In Progress }
+  hal_spec: { id: CPESP-4395, url: "https://ccp.sys.comcast.net/browse/CPESP-4395", title: "RDK-E DeepSleep HAL Interface Specification", status: Closed }
   mw_review: Complete
   mw_teams: ~
   vts_team:
-    - { id: CPESP-5394, url: "https://ccp.sys.comcast.net/browse/CPESP-5394", title: "RDK-E DeepSleep HAL VTS", status: In Progress }
-  vdevice: { id: CPESP-5492, url: "https://ccp.sys.comcast.net/browse/CPESP-5492", title: "RDK-E DeepSleep HAL - vDevice", status: Ready to Define }
+    - { id: CPESP-5394, url: "https://ccp.sys.comcast.net/browse/CPESP-5394", title: "RDK-E DeepSleep HAL VTS", status: Released }
+  vdevice: { id: CPESP-5492, url: "https://ccp.sys.comcast.net/browse/CPESP-5492", title: "RDK-E DeepSleep HAL - vDevice", status: In Progress }
 
-boot:
-  metadata: boot/metadata.yaml
+bootreason:
+  metadata: bootreason/metadata.yaml
   feature: { id: ENT-8657, url: "https://ccp.sys.comcast.net/browse/ENT-8657", title: "RDK-E Boot HAL", status: Ideation }
-  hal_spec: { id: CPESP-4580, url: "https://ccp.sys.comcast.net/browse/CPESP-4580", title: "RDK-E Boot HAL Interface Specification", status: Ready to Define }
+  hal_spec: { id: CPESP-4580, url: "https://ccp.sys.comcast.net/browse/CPESP-4580", title: "RDK-E Boot HAL Interface Specification", status: Closed }
   mw_review: Complete
   mw_teams: ~
   vts_team:
-    - { id: CPESP-5393, url: "https://ccp.sys.comcast.net/browse/CPESP-5393", title: "RDK-E Boot HAL VTS", status: In Progress }
-  vdevice: { id: CPESP-9199, url: "https://ccp.sys.comcast.net/browse/CPESP-9199", title: "RDK-E Boot HAL - vDevice", status: New }
+    - { id: CPESP-5393, url: "https://ccp.sys.comcast.net/browse/CPESP-5393", title: "RDK-E Boot HAL VTS", status: Released }
+  vdevice: { id: CPESP-9199, url: "https://ccp.sys.comcast.net/browse/CPESP-9199", title: "RDK-E Boot HAL - vDevice", status: Ready to Define }
 
 broadcast:
   metadata: broadcast/metadata.yaml
@@ -229,7 +229,7 @@ firmwareupdate:
   metadata: firmwareupdate/metadata.yaml
   # Renamed from `flash` (see #523). Reuses the ENT-8658 initiative, retitled in Jira to "RDK-E Firmware Update HAL".
   feature: { id: ENT-8658, url: "https://ccp.sys.comcast.net/browse/ENT-8658", title: "RDK-E Firmware Update HAL (formerly Flash)", status: Ideation }
-  hal_spec: ~
+  hal_spec: { id: CPESP-6021, url: "https://ccp.sys.comcast.net/browse/CPESP-6021", title: "Image Flash HAL - Interface Specification", status: Released }
   mw_review: ~
   mw_teams: ~
   vts_team: ~
@@ -248,12 +248,12 @@ ffv:
 r4ce:
   metadata: r4ce/metadata.yaml
   feature: { id: ENT-8645, url: "https://ccp.sys.comcast.net/browse/ENT-8645", title: "RDK-E RF4CE", status: Ideation }
-  hal_spec: { id: CPESP-9194, url: "https://ccp.sys.comcast.net/browse/CPESP-9194", title: "RF4CE Interface Specification", status: New }
+  hal_spec: { id: CPESP-9194, url: "https://ccp.sys.comcast.net/browse/CPESP-9194", title: "RF4CE Interface Specification", status: Ready to Define }
   mw_review: ~
   mw_teams: [Control_Manager_Architecture]
   vts_team:
-    - { id: CPESP-9197, url: "https://ccp.sys.comcast.net/browse/CPESP-9197", title: "RDK-E RF4CE VTS", status: New }
-  vdevice: { id: CPESP-9195, url: "https://ccp.sys.comcast.net/browse/CPESP-9195", title: "RDK-E RF4CE - vDevice", status: New }
+    - { id: CPESP-9197, url: "https://ccp.sys.comcast.net/browse/CPESP-9197", title: "RDK-E RF4CE VTS", status: Ready to Define }
+  vdevice: { id: CPESP-9195, url: "https://ccp.sys.comcast.net/browse/CPESP-9195", title: "RDK-E RF4CE - vDevice", status: Ready to Define }
 
 # VSI Components
 vsi/kernel:
@@ -297,7 +297,7 @@ vsi/graphics:
 vsi/linuxinput:
   metadata: vsi/linuxinput/metadata.yaml
   feature: { id: ENT-8644, url: "https://ccp.sys.comcast.net/browse/ENT-8644", title: "RDK-E Linux Input Interface", status: Ideation }
-  hal_spec: { id: CPESP-4380, url: "https://ccp.sys.comcast.net/browse/CPESP-4380", title: "Linux Input Interface Specification", status: Analyzing }
+  hal_spec: { id: CPESP-4380, url: "https://ccp.sys.comcast.net/browse/CPESP-4380", title: "Linux Input Interface Specification", status: Ready to Define }
   mw_review: Complete
   mw_teams: ~
   vts_team:


### PR DESCRIPTION
## Policy

An interface completes at **V1**: the interface is merged and versioned on develop, its spec ticket closes, and subsequent changes/defects are **new tickets against the version** — component RAG does not stay AMBER while routine follow-up work exists as tracked issues.

## RAG corrections (metadata.yaml)

| Component | Now | Change | Follow-up work already tracked |
|---|---|---|---|
| bootreason | AMBER | GREEN | rename landed via #575 (closed) — stale action cleared |
| deepsleep | AMBER | GREEN | #165 |
| panel | AMBER | GREEN | #674 #497 #516 #276 |
| planecontrol | AMBER | GREEN | #622 #329 |
| drm | RED | GREEN | interface merged at v0.1.0.0 (#341) |
| audiomixer | AMBER | **stays AMBER** | #411/#410 AQ parameter API (PR #573) is a **breaking interface addition still in review** — V1 not yet complete, so this is not routine post-V1 follow-up. Flip to GREEN once #573 merges. Supersedes #680/#681. |

audiomixer is the one exception to the policy above: its outstanding work is an in-flight breaking interface change, not a tracked post-V1 defect.

## uplink.yaml refresh

- 31 CPESP statuses updated from a live Jira pull (2026-07-03) — snapshot was 2026-03-20
- `boot:` key + metadata path renamed to `bootreason` (matches #575 module rename)
- `firmwareupdate.hal_spec` linked to CPESP-6021 (Released; the former Flash spec ticket)
- `drm.hal_spec` TODO resolved: interface delivered in-repo, no CPESP required

RAG_STATUS_REPORT.md regenerated. Related: #508 (automating this refresh — this PR is a manual refresh in the meantime).

Supersedes #680/#681 (per-component audiomixer RAG ticket — folded here; audiomixer stays AMBER).
