### PR TITLE
build: bump binder_sdk.version pin 2.4.0 → 2.5.0 (#686)

### DIFF
--- a/binder_sdk.version
+++ b/binder_sdk.version
@@ -5,16 +5,18 @@
 # clones the toolchain. Keep it pinned so the committed module-local
 # generated C++ always matches the generator that produced it.
 #
-# Pinned to release tag 2.4.0 (linux_binder_idl) which ships:
-#  - aidl-gen emits an explicit interface version ordinal for module-local
-#    snapshots (linux_binder_idl#33)
-#  - 4.9 kernel support: restored pre-5.16 binder freeze fallbacks
-#    (linux_binder_idl#36, closes linux_binder_idl#35)
-#  - CMake 3.8 compatibility: get_filename_component instead of
-#    file(REAL_PATH) (linux_binder_idl#34)
-#  - Aggregate test-suite runner at tests/run-tests.sh (linux_binder_idl#38)
-# Previously 2.3.0 (Yocto SDK M4 mismatch fix + regression test,
-# linux_binder_idl#30/#31).
+# Pinned to release tag 2.5.0 (linux_binder_idl) which ships:
+#  - binder wire protocol decoupled from compile bitness: a 32-bit userspace
+#    can run protocol 8 for mixed 32/64-bit platforms (linux_binder_idl#42/#45)
+#  - build-linux-binder-aidl.sh always passes BINDER_IPC_32BIT as a BOOL
+#    (defeats CMake cache-stick) + install.sh installs the -m32 toolchain
+#    (linux_binder_idl#46/#47)
+#  - QEMU kernel-matrix binder round-trip harness (linux_binder_idl#40/#41)
+# The AIDL generator is byte-identical to 2.4.0, so committed module-local C++
+# is unchanged by this bump — it is a toolchain-currency bump, not a regen.
+# Previously 2.4.0, which shipped the version-aware generator (explicit
+# interface version ordinal for module-local snapshots, linux_binder_idl#33) —
+# the generator half consumed by the freeze-time stamping in #634.
 #
 # Override for a one-off build with:  BINDER_VERSION=<ref> ./build_binder.sh
-2.4.0
+2.5.0


### PR DESCRIPTION
Closes #686.

Bumps the linux_binder_idl toolchain pin **2.4.0 → 2.5.0**.

## 2.5.0 contents
- Binder **wire protocol decoupled from compile bitness** (linux_binder_idl#42/#45)
- `build-linux-binder-aidl.sh` **always passes `BINDER_IPC_32BIT` as a BOOL** (defeats CMake cache-stick) + `tests/install.sh` installs the 32-bit `-m32` toolchain (linux_binder_idl#46/#47)
- QEMU kernel-matrix binder round-trip harness (linux_binder_idl#40/#41) + per-layer BUILD.md (linux_binder_idl#43/#44)

## No generated-output impact
The AIDL **generator is byte-identical** between 2.4.0 and 2.5.0 (2.5.0 is build-script / wire-protocol / test / docs only), so no committed module-local C++ changes — this is a toolchain-currency bump.

Companion to #683 (2.3.0 → 2.4.0).