### PR TITLE
fix(release): getInterfaceVersion() reports the release version as positional int (#633)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1783,37 +1783,44 @@ is_buildable_component() {
 # Frozen interface VERSION + contract HASH (#633)
 # ----------------------------------------------------------------------------
 # getInterfaceVersion() reports the RELEASE version itself, encoded as a
-# fixed-width positional int32 — self-describing, no lookup table: each
-# X.Y.Z.W field is zero-padded to two digits and concatenated, so
-#   0.2.0.0 -> 00 02 00 00 ->   20000
-#   0.3.0.0 -> 00 03 00 00 ->   30000
-#   0.1.0.1 -> 00 01 00 01 ->   10001
-#   1.0.0.0 -> 01 00 00 00 -> 1000000
-# Decode: prefix=(v/1000000)%100 generation=(v/10000)%100 minor=(v/100)%100
-# patch=v%100. Monotonic across ALL releases (0.x < 1.x < ...) because the
-# same scheme is used forever — there is no later switch to bare ordinals.
-# Max 99.99.99.99 = 99,999,999, well under int32 max; a field >= 100 is not
-# encodable and leaves the snapshot unfrozen rather than emit a wrong number.
+# fixed-width positional int32 — self-describing, no lookup table. Field
+# widths are 1-2-2-1 over X.Y.Z.W (era.major.minor.doc): era is a single
+# digit (0 = pre-android-versioning, 1 = post), major/minor get two digits,
+# the doc/bugfix respin one digit. So:
+#   0.2.0.0  -> 0|02|00|0 ->   2000
+#   0.3.0.0  -> 0|03|00|0 ->   3000
+#   0.1.0.1  -> 0|01|00|1 ->   1001
+#   0.10.0.0 -> 0|10|00|0 ->  10000
+#   1.0.0.0  -> 1|00|00|0 -> 100000
+# Decode: pad to 6 digits, read 1|2|2|1 — era=v/100000, major=(v/1000)%100,
+# minor=(v/10)%100, doc=v%10. Monotonic across ALL releases (0.x < 1.x)
+# because the same scheme is used forever — there is no later switch to bare
+# ordinals. Max 9.99.99.9 = 999,999, tiny next to int32 max. A field beyond
+# its width (era/doc > 9, major/minor > 99) is not encodable and leaves the
+# snapshot unfrozen rather than emit a wrong number — note the doc field caps
+# at 9: a 10th doc-only respin of the same minor forces a minor bump.
 # getInterfaceHash() is the toolchain's aidl_hash_gen digest. current/ carries
 # neither field, so dev builds report HASH="notfrozen" — the pre-freeze
 # marker. Snapshots are compile-only (their CMakeLists glob src/*.cpp and
 # never regenerate), so both values are baked in at freeze time: stamp
 # current/, regenerate, copy into the snapshot, restore current/.
 _snapshot_version_int() {
-    local ver="$1" out="" f
+    local ver="$1" out="" f i
     # Require EXACTLY four numeric dot-separated fields (X.Y.Z.W); malformed
     # inputs (0.2.0, 0.2.0.0., 0.2..0) could otherwise collide after encoding.
     if ! [[ "${ver}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo ""
         return 0
     fi
-    local IFS='.'
-    for f in ${ver}; do
-        if (( 10#${f} > 99 )); then
+    local widths=(1 2 2 1) fields
+    IFS='.' read -ra fields <<< "${ver}"
+    for i in 0 1 2 3; do
+        f="$((10#${fields[i]}))"
+        if (( f >= 10 ** widths[i] )); then
             echo ""
             return 0
         fi
-        out+=$(printf '%02d' "$((10#${f}))")
+        out+=$(printf "%0${widths[i]}d" "${f}")
     done
     echo "$((10#${out}))"        # base-10 (avoid octal on leading zeros)
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1827,17 +1827,20 @@ _snapshot_version_int() {
 
 # Contract hash via the toolchain's own hasher (aidl_hash_gen), so the
 # committed .hash is exactly what the generator bakes into getInterfaceHash()
-# and what future toolchain verification recomputes. The hashgen label is the
-# emitted version int, binding the hash to both content and version.
+# and what its check_integrity() recomputes at every regeneration. The hashgen
+# label MUST be 'latest-version' — check_integrity() rehashes with
+# version_for_hashgen(), which resolves to 'latest-version' for module-local
+# interfaces (gen version 1); any other label fails the integrity check and
+# aborts generation.
 _toolchain_hash() {
-    local aidl_dir="$1" label="$2" out="$3"
+    local aidl_dir="$1" out="$2"
     local hash_gen="${BINDER_TOOLCHAIN_ROOT:-${REPO_ROOT}/build-tools/linux_binder_idl}/host/aidl_hash_gen"
     if [[ ! -x "${hash_gen}" ]]; then
         warn "aidl_hash_gen not found/executable at ${hash_gen} — is the binder toolchain cloned?"
         return 1
     fi
     rm -f "${out}"
-    "${hash_gen}" "${aidl_dir}" "${label}" "${out}"
+    "${hash_gen}" "${aidl_dir}" "latest-version" "${out}"
 }
 
 # Insert/replace `version: N` in an interface.yaml (top-level, after name:).
@@ -1897,7 +1900,7 @@ create_snapshot() {
     if [[ -z "${_iface_version}" ]]; then
         warn "  [${comp}] version ${version} is not encodable (needs X.Y.Z.W, fields 0-99); ${version}/ will be left unfrozen (VERSION=1/notfrozen)."
     elif [[ -f "${_cur}/interface.yaml" ]]; then
-        if _toolchain_hash "${_cur}" "${_iface_version}" "${_cur}/.hash"; then
+        if _toolchain_hash "${_cur}" "${_cur}/.hash"; then
             _ifyaml_bak="$(mktemp)"
             cp "${_cur}/interface.yaml" "${_ifyaml_bak}"
             _set_interface_version "${_cur}/interface.yaml" "${_iface_version}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1782,51 +1782,53 @@ is_buildable_component() {
 # ----------------------------------------------------------------------------
 # Frozen interface VERSION + contract HASH (#633)
 # ----------------------------------------------------------------------------
-# getInterfaceVersion() is the standard AIDL ordinal: a component's 1st frozen
-# snapshot reports 1, the 2nd reports 2, ... The X.Y.Z.W release label stays
-# the snapshot directory name; the snapshot's interface.yaml `version:` and
-# `.hash` record the ordinal <-> label <-> hash mapping. getInterfaceHash() is
-# the toolchain's aidl_hash_gen digest. current/ carries neither field, so dev
-# builds report HASH="notfrozen" — the pre-freeze marker. Snapshots are
-# compile-only (their CMakeLists glob src/*.cpp and never regenerate), so both
-# values are baked in at freeze time: stamp current/, regenerate, copy into
-# the snapshot, restore current/.
-
-# Ordinal of <version> = its 1-based position in the version-sorted list of
-# the component's snapshot dirs (including <version> itself, which may not
-# exist yet). Positional, so refreshing an existing snapshot re-derives the
-# same ordinal.
-_snapshot_ordinal() {
-    local comp="$1" version="$2" i=0 d
-    local vers=("${version}")
-    for d in "${REPO_ROOT}/${comp}"/[0-9]*; do
-        [[ -d "${d}" ]] || continue
-        d="$(basename "${d}")"
-        [[ "${d}" =~ ^[0-9]+(\.[0-9]+){3}$ ]] && vers+=("${d}")
-    done
-    while IFS= read -r d; do
-        i=$((i + 1))
-        if [[ "${d}" == "${version}" ]]; then
-            echo "${i}"
+# getInterfaceVersion() reports the RELEASE version itself, encoded as a
+# fixed-width positional int32 — self-describing, no lookup table: each
+# X.Y.Z.W field is zero-padded to two digits and concatenated, so
+#   0.2.0.0 -> 00 02 00 00 ->   20000
+#   0.3.0.0 -> 00 03 00 00 ->   30000
+#   0.1.0.1 -> 00 01 00 01 ->   10001
+#   1.0.0.0 -> 01 00 00 00 -> 1000000
+# Decode: prefix=(v/1000000)%100 generation=(v/10000)%100 minor=(v/100)%100
+# patch=v%100. Monotonic across ALL releases (0.x < 1.x < ...) because the
+# same scheme is used forever — there is no later switch to bare ordinals.
+# Max 99.99.99.99 = 99,999,999, well under int32 max; a field >= 100 is not
+# encodable and leaves the snapshot unfrozen rather than emit a wrong number.
+# getInterfaceHash() is the toolchain's aidl_hash_gen digest. current/ carries
+# neither field, so dev builds report HASH="notfrozen" — the pre-freeze
+# marker. Snapshots are compile-only (their CMakeLists glob src/*.cpp and
+# never regenerate), so both values are baked in at freeze time: stamp
+# current/, regenerate, copy into the snapshot, restore current/.
+_snapshot_version_int() {
+    local ver="$1" out="" f
+    # Require EXACTLY four numeric dot-separated fields (X.Y.Z.W); malformed
+    # inputs (0.2.0, 0.2.0.0., 0.2..0) could otherwise collide after encoding.
+    if ! [[ "${ver}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo ""
+        return 0
+    fi
+    local IFS='.'
+    for f in ${ver}; do
+        if (( 10#${f} > 99 )); then
+            echo ""
             return 0
         fi
-    done < <(printf '%s\n' "${vers[@]}" | sort -uV)
+        out+=$(printf '%02d' "$((10#${f}))")
+    done
+    echo "$((10#${out}))"        # base-10 (avoid octal on leading zeros)
 }
 
 # Contract hash via the toolchain's own hasher (aidl_hash_gen), so the
 # committed .hash is exactly what the generator bakes into getInterfaceHash()
-# and what future toolchain verification recomputes. Label convention is the
-# toolchain's version_for_hashgen(): the previous ordinal, or 'latest-version'
-# for a component's first freeze.
+# and what future toolchain verification recomputes. The hashgen label is the
+# emitted version int, binding the hash to both content and version.
 _toolchain_hash() {
-    local aidl_dir="$1" ordinal="$2" out="$3"
+    local aidl_dir="$1" label="$2" out="$3"
     local hash_gen="${BINDER_TOOLCHAIN_ROOT:-${REPO_ROOT}/build-tools/linux_binder_idl}/host/aidl_hash_gen"
     if [[ ! -x "${hash_gen}" ]]; then
         warn "aidl_hash_gen not found/executable at ${hash_gen} — is the binder toolchain cloned?"
         return 1
     fi
-    local label="latest-version"
-    (( ordinal > 1 )) && label="$((ordinal - 1))"
     rm -f "${out}"
     "${hash_gen}" "${aidl_dir}" "${label}" "${out}"
 }
@@ -1873,23 +1875,26 @@ create_snapshot() {
     fi
 
     # Freeze-stamp current/ so the regenerated bindings carry the real
-    # interface VERSION (standard AIDL ordinal) + contract HASH instead of
-    # 1/"notfrozen" (#633). Restored right after the copy below; current/'s
-    # own generated code returns to notfrozen at the next dev build.
+    # interface VERSION (positional release int, e.g. 0.2.0.0 -> 20000) +
+    # contract HASH instead of 1/"notfrozen" (#633). Restored right after the
+    # copy below; current/'s own generated code returns to notfrozen at the
+    # next dev build.
     local _cur="${REPO_ROOT}/${comp}/current"
-    local _ordinal _ifyaml_bak=""
-    _ordinal="$(_snapshot_ordinal "${comp}" "${version}")"
+    local _iface_version _ifyaml_bak=""
+    _iface_version="$(_snapshot_version_int "${version}")"
     _restore_current() {
         [[ -n "${_ifyaml_bak}" ]] && mv -f "${_ifyaml_bak}" "${_cur}/interface.yaml"
         rm -f "${_cur}/.hash"
         _ifyaml_bak=""
     }
-    if [[ -f "${_cur}/interface.yaml" ]]; then
-        if _toolchain_hash "${_cur}" "${_ordinal}" "${_cur}/.hash"; then
+    if [[ -z "${_iface_version}" ]]; then
+        warn "  [${comp}] version ${version} is not encodable (needs X.Y.Z.W, fields 0-99); ${version}/ will be left unfrozen (VERSION=1/notfrozen)."
+    elif [[ -f "${_cur}/interface.yaml" ]]; then
+        if _toolchain_hash "${_cur}" "${_iface_version}" "${_cur}/.hash"; then
             _ifyaml_bak="$(mktemp)"
             cp "${_cur}/interface.yaml" "${_ifyaml_bak}"
-            _set_interface_version "${_cur}/interface.yaml" "${_ordinal}"
-            [[ "${VERBOSE}" -eq 1 ]] && log "  [${comp}] freezing ${version} as interface version ${_ordinal} (hash $(head -c12 "${_cur}/.hash")…)"
+            _set_interface_version "${_cur}/interface.yaml" "${_iface_version}"
+            [[ "${VERBOSE}" -eq 1 ]] && log "  [${comp}] freezing ${version} as interface version ${_iface_version} (hash $(head -c12 "${_cur}/.hash")…)"
         else
             warn "  [${comp}] contract-hash generation failed; ${version}/ will be left unfrozen (VERSION=1/notfrozen)."
             rm -f "${_cur}/.hash"


### PR DESCRIPTION
Refs #633. Corrects #690's version scheme to the decided design.

## What a client sees
| State | `getInterfaceVersion()` | `getInterfaceHash()` |
|---|---|---|
| Frozen 0.2.0.0 | `20000` (decodes to 0.2.0.0 on sight) | real hash |
| Frozen 0.3.0.0 | `30000` | real hash |
| Frozen 1.0.0.0 | `1000000` | real hash |
| Dev tree (`current/`) | unchanged | `"notfrozen"` ← pre-freeze marker |

- **Version = the release version itself**, fixed-width positional int (two digits per field): self-describing, no lookup table needed — the requirement for pre-AIDL-versioning reporting. Decode: `prefix=(v/1000000)%100, generation=(v/10000)%100, minor=(v/100)%100, patch=v%100`.
- **Monotonic forever**: the same scheme covers 0.x and 1.x+ (`20000 < 30000 < 1000000`), so `server >= client` ordering never breaks — no scheme switch, ever.
- **Collision-safe**: two-digit fields mean `0.10.0.0 → 100000` ≠ `1.0.0.0 → 1000000`; malformed or >99 fields leave the snapshot unfrozen rather than emit a wrong number.
- **Hash unchanged from #690**: toolchain `aidl_hash_gen`, labelled with the emitted version int (hash binds content + version).

## Verification
- Encoding: `0.1.0.0→10000, 0.2.0.0→20000, 0.1.0.1→10001, 1.2.3.4→1020304, 0.10.0.0→100000≠1.0.0.0→1000000`; `0.2.0`/`0.100.0.0`/garbage → unfrozen.
- Hash deterministic, version-bound (label 20000 vs 30000 → different digests).
- `interface.yaml` stamp round-trip OK; `current/` restored on every exit path; `bash -n` clean.

The change-class enforcement gate (was #658) remains open scope on #633, pending linux_binder_idl#27.