### PR TITLE
build: add @agampa263 as CODEOWNERS reviewer for tests/ (#695)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default owners for everything in the repo
 *       @rdkcentral/rdk-halif-aidl-pr-review-team
+
+# Test harnesses: request review from the AIDL HAL tester.
+/tests/ @rdkcentral/rdk-halif-aidl-pr-review-team @agampa263


### PR DESCRIPTION
Closes #695. Adds Akshaykumar Gampa (@agampa263, akshaykumar_gampa@comcast.com — tester for the AIDL HAL) as a CODEOWNERS reviewer on `tests/`, alongside the existing review team. He has write access, so the rule is effective.