### PR TITLE
Revert "build: add @agampa263 as CODEOWNERS reviewer for tests/" (#696)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Default owners for everything in the repo
 *       @rdkcentral/rdk-halif-aidl-pr-review-team
-
-# Test harnesses: request review from the AIDL HAL tester.
-/tests/ @rdkcentral/rdk-halif-aidl-pr-review-team @agampa263


### PR DESCRIPTION
Reverts #696 — change was not requested. Restores .github/CODEOWNERS to the default review team only. Refs #695.