### PR TITLE
docs(avclock,planecontrol,videodecoder): retired sink model in open() + contradictory error semantics (#704)

### DIFF
--- a/avclock/current/com/rdk/hal/avclock/IAVClock.aidl
+++ b/avclock/current/com/rdk/hal/avclock/IAVClock.aidl
@@ -111,7 +111,7 @@ interface IAVClock
      * passing this clock's `IAVClock.Id`. The AV Clock holds no sink state.
      * 
      * If successful the AV Clock transitions to the `OPENING` state and then to the `READY` state.
-     * If an internal errors occurs, the AV Clock transitions to the `OPENING` state and then back to the `CLOSED` state
+     * If an internal error occurs, the AV Clock transitions to the `OPENING` state and then back to the `CLOSED` state
      * with a null interface returned.
      *
      * If the client that opened the `IAVClockController` crashes,

--- a/avclock/current/com/rdk/hal/avclock/IAVClock.aidl
+++ b/avclock/current/com/rdk/hal/avclock/IAVClock.aidl
@@ -102,11 +102,13 @@ interface IAVClock
 	 * Opens the AV Clock.
      * 
      * While the AV Clock is in the `OPENING` state, these defaults are set on the AV Clock:
-     *  - Primary audio sink is set to -1
-     *  - Supplementary audio sink is set to -1
-     *  - Video sink is set to -1
      *  - Mode is set to `ClockMode::AUTO`
      *  - Playback rate is set to 1.0
+     *
+     * Sink association is owned by the sinks, not the AV Clock: clients call
+     * `attachClock()` / `detachClock()` / `getClock()` on the audio and video
+     * sink controllers (`IAudioSinkController`, `IVideoSinkController`),
+     * passing this clock's `IAVClock.Id`. The AV Clock holds no sink state.
      * 
      * If successful the AV Clock transitions to the `OPENING` state and then to the `READY` state.
      * If an internal errors occurs, the AV Clock transitions to the `OPENING` state and then back to the `CLOSED` state

--- a/avclock/metadata.yaml
+++ b/avclock/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: avclock
-version: 0.2.0.0
+version: 0.2.0.1
 status: GREEN
 description: "Audio/video clock synchronization and timing control"
 type: SOC

--- a/planecontrol/current/com/rdk/hal/planecontrol/IPlaneControl.aidl
+++ b/planecontrol/current/com/rdk/hal/planecontrol/IPlaneControl.aidl
@@ -150,11 +150,12 @@ interface IPlaneControl
      * the requested key and `propertyValue` is populated on success.
      *
      * Error handling and return semantics:
-     * - Passing an empty `properties` array is an error.
-     * - If any key in `properties` is invalid, no values are populated and the call
-     *   returns `false` with `EX_ILLEGAL_ARGUMENT`.
+     * - Passing an empty `properties` array fails with `EX_ILLEGAL_ARGUMENT`.
+     * - If any key in `properties` is invalid, no values are populated and the
+     *   call fails with `EX_ILLEGAL_ARGUMENT`.
      * - If a required out-parameter is null (e.g. `propertyKVList`), the call fails
      *   with `EX_NULL_POINTER`.
+     * - When an exception is raised, no return value is transmitted.
      *
      * @param[in] planeResourceIndex    The plane resource index.
      * @param[in] properties            Non-empty list of property keys to query.
@@ -162,7 +163,7 @@ interface IPlaneControl
      *
      * @returns boolean
      * @retval true                     All property values were returned successfully.
-     * @retval false                    One or more keys are invalid, or input list is empty.
+     * @retval false                    The property values could not be retrieved.
      *
      * @exception binder::Status::Exception::EX_NONE             Success.
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT Invalid plane index, property key(s) or empty input list.

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoder.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoder.aidl
@@ -96,18 +96,19 @@ interface IVideoDecoder
      * the requested key and `propertyValue` is populated on success.
      *
      * Error handling and return semantics:
-     * - Passing an empty `properties` array is an error.
-     * - If any key in `properties` is invalid, no values are populated and the call
-     *   returns `false` with `EX_ILLEGAL_ARGUMENT`.
+     * - Passing an empty `properties` array fails with `EX_ILLEGAL_ARGUMENT`.
+     * - If any key in `properties` is invalid, no values are populated and the
+     *   call fails with `EX_ILLEGAL_ARGUMENT`.
      * - If a required out-parameter is null (e.g. `propertyKVList`), the call fails
      *   with `EX_NULL_POINTER`.
+     * - When an exception is raised, no return value is transmitted.
      *
      * @param[in] properties      Non-empty list of property keys to query.
      * @param[out] propertyKVList Returned key/value pairs corresponding to `properties`.
      *
      * @returns boolean
      * @retval true               All property values were retrieved successfully.
-     * @retval false              One or more keys are invalid, or input list is empty.
+     * @retval false              The property values could not be retrieved.
      *
      * @exception binder::Status::Exception::EX_NONE            Success.
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT Invalid property key(s) or empty input list.

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videodecoder
-version: 0.2.0.0
+version: 0.2.0.1
 status: GREEN
 description: "Video decoder resource management and codec support"
 type: SOC


### PR DESCRIPTION
Closes #704. Raised from discussion #703 (@shafi12).

## IAVClock.open() — retired clock-owns-sinks model
The OPENING-state defaults still listed "Primary audio sink = -1 / Supplementary audio sink = -1 / Video sink = -1", but the module has **no sink surface at all** — no sink setters or properties exist on `IAVClockController`, and the only ID in avclock is the clock's own (`IAVClock.Id`, `Property.RESOURCE_ID`). Association is **sink-owned**: `attachClock()`/`detachClock()`/`getClock()` on `IAudioSinkController`/`IVideoSinkController`, per their stated contract ("the sink owns the clock relationship; the AVClock does not need to be made aware"). The doc block now states the real defaults (`ClockMode::AUTO`, rate 1.0) and points at the sink-side contract.

## getPropertyMulti — self-contradictory error semantics
`IPlaneControl.getPropertyMulti` and `IVideoDecoder.getPropertyMulti` claimed the call "returns `false` with `EX_ILLEGAL_ARGUMENT`" — impossible: when a binder exception is raised, **no return value is transmitted**. The `@retval false` conditions also duplicated the exception table. Now: argument failures (empty list, invalid key, null out-param) are exception-only, with an explicit "no return value is transmitted" note; `@retval false` is redefined to non-exception retrieval failure.

## Validation
- Doc-only by construction and by tool: `release.sh --audit` classifies avclock and videodecoder **doc-only**, expected 0.2.0.1 == pre-bumped metadata.
- planecontrol metadata deliberately untouched: its pending breaking (#621 → 0.2.0.0) subsumes a doc patch per the subsume rule.
- Frozen snapshots untouched (immutable).