### PR TITLE
feat(audiodecoder,videodecoder)!: activate InputBufferMetadata.discontinuity — remove signalDiscontinuity() (#706)

### DIFF
--- a/audiodecoder/current/com/rdk/hal/audiodecoder/FrameMetadata.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/FrameMetadata.aidl
@@ -110,7 +110,13 @@ parcelable FrameMetadata {
 	boolean bitstreamEOS;
 
 	/**
-	 * Discontinuity indicator where the PTS for this frame is likely to be discontinuous to the previous.
+	 * Discontinuity indicator where the PTS for this frame is discontinuous
+	 * to the previous frame.
+	 *
+	 * Set true on the first output frame decoded from an input buffer that
+	 * carried `InputBufferMetadata.discontinuity = true`.
+	 *
+	 * @see InputBufferMetadata.discontinuity
 	 */
 	boolean discontinuity;
 

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/IAudioDecoderController.aidl
@@ -118,8 +118,9 @@ interface IAudioDecoderController {
      * Each call is self-describing; the HAL MUST NOT carry any field of
      * `InputBufferMetadata` (including `trimStartNs`/`trimEndNs`) across calls.
      *
-     * The `metadata.discontinuity` field is reserved in v1 and MUST be false.
-     * Use `signalDiscontinuity()` to signal a PTS discontinuity.
+     * Setting `metadata.discontinuity = true` marks this buffer as the first
+     * following a PTS discontinuity: the decoder MUST reset its PTS tracking
+     * and interpolation state before decoding it. See `InputBufferMetadata`.
      *
      * @param[in] bufferHandle  A handle to the AV buffer containing the encoded
      *                          audio frame. MUST be a valid handle.
@@ -136,7 +137,7 @@ interface IAudioDecoderController {
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if `bufferHandle` is
-     *            invalid or if `metadata.discontinuity` is true.
+     *            invalid.
      *
      * @pre The resource must be in State::STARTED.
      *
@@ -161,24 +162,6 @@ interface IAudioDecoderController {
      * @pre The resource must be in State::STARTED.
      */
 	void flush(in boolean reset);
-
-    /**
-	 * Signals a discontinuity in the audio stream.
-     *
-     * The audio decoder must be in a state of `STARTED`.
-     * Buffers that follow this call passed in `decodeBufferWithMetadata()` shall be
-     * regarded as PTS discontinuous to any audio frames previously passed.
-     *
-     * This method remains the authoritative path for signalling discontinuity in
-     * v1. The `InputBufferMetadata.discontinuity` field is reserved and MUST be
-     * false until a later release migrates the signalling path.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
-     *
-     * @pre The resource must be in State::STARTED.
-     */
-    void signalDiscontinuity();
 
     /**
      * Signals client-driven end-of-stream and drains the decoder.

--- a/audiodecoder/current/com/rdk/hal/audiodecoder/InputBufferMetadata.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/InputBufferMetadata.aidl
@@ -45,13 +45,21 @@ parcelable InputBufferMetadata {
     long nsPresentationTime;
 
     /**
-     * Reserved for a future release. Clients MUST set this to false in v1.
+     * Marks this buffer as the first following a PTS discontinuity.
      *
-     * Use `IAudioDecoderController.signalDiscontinuity()` to signal a PTS
-     * discontinuity in v1. This field will become authoritative in a later
-     * release once migration is complete.
+     * When true, the PTS of this buffer is discontinuous with previously
+     * submitted buffers: the decoder MUST reset its PTS tracking and
+     * interpolation state before decoding this buffer, and MUST NOT
+     * interpolate timestamps across the discontinuity. Decoded output from
+     * this buffer onward reports the new timeline; the corresponding output
+     * frame carries `FrameMetadata.discontinuity = true`.
      *
-     * @see IAudioDecoderController.signalDiscontinuity()
+     * This is the sole discontinuity signal and is per-buffer in-band: it
+     * MAY be combined with `endOfStream` on the same buffer. `flush()` also
+     * resets PTS state; this flag covers in-band discontinuities without
+     * flushing queued data.
+     *
+     * @see FrameMetadata.discontinuity
      */
     boolean discontinuity;
 

--- a/audiodecoder/current/docs/audio_decoder.md
+++ b/audiodecoder/current/docs/audio_decoder.md
@@ -121,7 +121,7 @@ flowchart TD
     RDKClientComponent -- getIAudioDecoderIds() <br> getIAudioDecoder() --> IAudioDecoderManager
     RDKClientComponent -- getCapabilities() <br> getState() <br> open() <br> close() --> IAudioDecoder
     RDKClientComponent -- registerEventListener() <br> unregisterEventListener() --> IAudioDecoder
-    RDKClientComponent -- start() <br> stop() <br> setProperty() <br> decodeBufferWithMetadata() <br> flush() <br> signalDiscontinuity() <br> parseCodecSpecificData() --> IAudioDecoderController
+    RDKClientComponent -- start() <br> stop() <br> setProperty() <br> decodeBufferWithMetadata() <br> flush() <br> parseCodecSpecificData() --> IAudioDecoderController
     IAudioDecoderManager --> IAudioDecoder --> IAudioDecoderController
     IAudioDecoder -- onStateChanged() <br> onDecodeError() --> IAudioDecoderEventListener
     IAudioDecoderEventListener --> RDKClientComponent
@@ -307,9 +307,9 @@ Any metadata associated with the supplementary/primary audio mix levels is left 
 
 ## Audio Stream Discontinuities
 
-Where the client has knowledge of PTS discontinuities in the audio stream, it shall call `IAudioDecoderController.signalDiscontinuity()` between the AV buffers passed to `decodeBufferWithMetadata()`.
+Where the client has knowledge of PTS discontinuities in the audio stream, it shall set `InputBufferMetadata.discontinuity = true` on the first [AV Buffer](../avbuffer/av_buffer.md) passed to `decodeBufferWithMetadata()` after the discontinuity. The decoder resets its PTS tracking and interpolation state before decoding that buffer.
 
-For the first input [AV Buffer](../avbuffer/av_buffer.md) audio frame passed in for decode after the discontinuity, it shall indicate the discontinuity in its next output `FrameMetadata`.
+The first output frame decoded from that buffer indicates the discontinuity in its `FrameMetadata.discontinuity` field.
 
 ## End of Stream Signalling
 

--- a/audiodecoder/metadata.yaml
+++ b/audiodecoder/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: audiodecoder
-version: 0.2.0.0
+version: 0.3.0.0
 status: GREEN
 description: "Audio decoder resource management and codec format support"
 type: SOC

--- a/videodecoder/current/com/rdk/hal/videodecoder/FrameMetadata.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/FrameMetadata.aidl
@@ -131,7 +131,13 @@ parcelable FrameMetadata {
 	boolean bitstreamEOS;
 
 	/**
-	 * Discontinuity indicator where the PTS for this frame is likely to be discontinuous to the previous.
+	 * Discontinuity indicator where the PTS for this frame is discontinuous
+	 * to the previous frame.
+	 *
+	 * Set true on the first output frame decoded from an input buffer that
+	 * carried `InputBufferMetadata.discontinuity = true`.
+	 *
+	 * @see InputBufferMetadata.discontinuity
 	 */
 	boolean discontinuity;
 

--- a/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/IVideoDecoderController.aidl
@@ -119,8 +119,9 @@ interface IVideoDecoderController
      * Each call is self-describing; the HAL MUST NOT carry any field of
      * `InputBufferMetadata` across calls.
      *
-     * The `metadata.discontinuity` field is reserved in v1 and MUST be false.
-     * Use `signalDiscontinuity()` to signal a PTS discontinuity.
+     * Setting `metadata.discontinuity = true` marks this buffer as the first
+     * following a PTS discontinuity: the decoder MUST reset its PTS tracking
+     * and interpolation state before decoding it. See `InputBufferMetadata`.
      *
      * @param[in] bufferHandle  A handle to the AV buffer containing the encoded
      *                          video frame. MUST be a valid handle.
@@ -137,7 +138,7 @@ interface IVideoDecoderController
      * @exception binder::Status::Exception::EX_NONE for success
      * @exception binder::Status::Exception::EX_ILLEGAL_STATE
      * @exception binder::Status::Exception::EX_ILLEGAL_ARGUMENT if `bufferHandle` is
-     *            invalid or if `metadata.discontinuity` is true.
+     *            invalid.
      *
      * @pre The resource must be in State::STARTED.
      *
@@ -164,25 +165,6 @@ interface IVideoDecoderController
      * @pre The resource must be in State::STARTED.
      */
     void flush(in boolean reset);
-
-    /**
-     * Signals a discontinuity in the video stream.
-     *
-     * The Video Decoder must be in a state of `STARTED`.
-     * Buffers that follow this call passed in `decodeBufferWithMetadata()` shall be
-     * regarded as PTS discontinuous to any video frames past or already held in the
-     * Video Decoder.
-     *
-     * This method remains the authoritative path for signalling discontinuity in
-     * v1. The `InputBufferMetadata.discontinuity` field is reserved and MUST be
-     * false until a later release migrates the signalling path.
-     *
-     * @exception binder::Status::Exception::EX_NONE for success
-     * @exception binder::Status::Exception::EX_ILLEGAL_STATE
-     *
-     * @pre The resource must be in State::STARTED.
-     */
-    void signalDiscontinuity();
 
     /**
      * Signals client-driven end-of-stream and drains the decoder.

--- a/videodecoder/current/com/rdk/hal/videodecoder/InputBufferMetadata.aidl
+++ b/videodecoder/current/com/rdk/hal/videodecoder/InputBufferMetadata.aidl
@@ -91,13 +91,21 @@ parcelable InputBufferMetadata {
     long nsPresentationTime;
 
     /**
-     * Reserved for a future release. Clients MUST set this to false in v1.
+     * Marks this buffer as the first following a PTS discontinuity.
      *
-     * Use `IVideoDecoderController.signalDiscontinuity()` to signal a PTS
-     * discontinuity in v1. This field will become authoritative in a later
-     * release once migration is complete.
+     * When true, the PTS of this buffer is discontinuous with previously
+     * submitted buffers: the decoder MUST reset its PTS tracking and
+     * interpolation state before decoding this buffer, and MUST NOT
+     * interpolate timestamps across the discontinuity. Decoded output from
+     * this buffer onward reports the new timeline; the corresponding output
+     * frame carries `FrameMetadata.discontinuity = true`.
      *
-     * @see IVideoDecoderController.signalDiscontinuity()
+     * This is the sole discontinuity signal and is per-buffer in-band: it
+     * MAY be combined with `endOfStream` on the same buffer. `flush()` also
+     * resets PTS state; this flag covers in-band discontinuities without
+     * flushing queued data.
+     *
+     * @see FrameMetadata.discontinuity
      */
     boolean discontinuity;
 

--- a/videodecoder/current/docs/video_decoder.md
+++ b/videodecoder/current/docs/video_decoder.md
@@ -118,7 +118,7 @@ flowchart TD
     RDKClientComponent -- getVideoDecoderIds() <br> getVideoDecoder() getSupportedOperationModes()--> IVideoDecoderManager
     RDKClientComponent -- getCapabilities() <br> getProperty() <br> getPropertyMulti() <br> getState() <br> open() <br> close() <br> registerEventListener() <br> unregisterEventListener()--> IVideoDecoder
     RDKClientComponent -- registerEventListener() <br> unregisterEventListener() --> IVideoDecoder
-    RDKClientComponent -- start() <br> stop() <br> setProperty() <br> decodeBufferWithMetadata() <br> flush() <br> signalDiscontinuity() <br> parseCodecSpecificData() --> IVideoDecoderController
+    RDKClientComponent -- start() <br> stop() <br> setProperty() <br> decodeBufferWithMetadata() <br> flush() <br> parseCodecSpecificData() --> IVideoDecoderController
     IVideoDecoderManager --> IVideoDecoder --> IVideoDecoderController
     IVideoDecoder -- onStateChanged() <br> onDecodeError() --> IVideoDecoderEventListener
     IVideoDecoderEventListener --> RDKClientComponent
@@ -342,9 +342,9 @@ A media pipeline is operating in low latency mode when the video decoder and aud
 
 ## Video Stream Discontinuities
 
-Where the client has knowledge of PTS discontinuities in the video stream, it shall call `IVideoDecoderController.signalDiscontinuity()` between the AV buffers passed to `decodeBufferWithMetadata()`.
+Where the client has knowledge of PTS discontinuities in the video stream, it shall set `InputBufferMetadata.discontinuity = true` on the first [AV Buffer](../avbuffer/av_buffer.md) passed to `decodeBufferWithMetadata()` after the discontinuity. The decoder resets its PTS tracking and interpolation state before decoding that buffer.
 
-For the first input [AV Buffer](../avbuffer/av_buffer.md) video frame passed in for decode after the discontinuity, it shall indicate the discontinuity in its next output `FrameMetadata`.
+The first output frame decoded from that buffer indicates the discontinuity in its `FrameMetadata.discontinuity` field.
 
 ## End of Stream Signalling
 

--- a/videodecoder/metadata.yaml
+++ b/videodecoder/metadata.yaml
@@ -21,7 +21,7 @@
 # description - One-line human-readable summary                          [manual]
 # type        - Responsibility: SOC or OEM                                [manual]
 component: videodecoder
-version: 0.2.0.0
+version: 0.3.0.0
 status: GREEN
 description: "Video decoder resource management and codec support"
 type: SOC


### PR DESCRIPTION
Closes #706. Completes the reserve-then-activate plan from #403.

**DRAFT — must not merge before the 0.22.0 cut** (rides the 0.23.0 decoder major-bump wave). Carries `CR`: ABI change requiring wider architecture sign-off per the versioning SOP.

## Changes (symmetric across both decoders)
- **`signalDiscontinuity()` removed** from `IAudioDecoderController` / `IVideoDecoderController` (method + doc block).
- **`InputBufferMetadata.discontinuity` is authoritative**: `true` marks the first buffer after a PTS discontinuity; the decoder MUST reset PTS tracking/interpolation state before decoding it and MUST NOT interpolate across the discontinuity. May combine with `endOfStream`; `flush()` remains the reset-with-data-drop path.
- **`decodeBufferWithMetadata()`** docs: reserved-in-v1 passages replaced with the flag contract; the `EX_ILLEGAL_ARGUMENT`-if-discontinuity-true exception is gone.
- **`FrameMetadata.discontinuity`**: set on the first output frame decoded from a flagged input buffer (input↔output linkage now explicit).
- **Component docs**: Stream Discontinuities sections rewritten to the in-band flag; `signalDiscontinuity()` removed from the interface diagrams.
- **metadata.yaml**: both decoders pre-bumped to **0.3.0.0** (subsumes the pending 0.2.0.1 doc bumps from #705 per the subsume rule).

## Client migration
`signalDiscontinuity()` call sites → set `metadata.discontinuity = true` on the first buffer submitted after the discontinuity. No wire-format change — the field has been in the parcelable since #403.

## Validation
- Both components regenerate + compile green.
- `release.sh --audit` classifies both **breaking** (`method_removed: signalDiscontinuity`), expected next 0.3.0.0 == declared metadata — label and structural class agree.
- Zero `signalDiscontinuity` references remain in `current/` AIDL or docs; frozen snapshots untouched.