### PR TITLE
chore(rag): panel + planecontrol back to AMBER — breaking changes in flight (#684)

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,10 +2,10 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-07-05 |
+| **Generated** | 2026-07-07 |
 | **Components** | 31 |
-| 🟢 **GREEN** | 19 |
-| 🟡 **AMBER** | 12 |
+| 🟢 **GREEN** | 17 |
+| 🟡 **AMBER** | 14 |
 | 🔴 **RED** | 0 |
 
 ---
@@ -14,8 +14,8 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **19** | Reviewed & Approved — Interface stable on develop |
-| 🟡 AMBER | **12** | Under Active Ingestion — Will enter sprint review when ready |
+| 🟢 GREEN | **17** | Reviewed & Approved — Interface stable on develop |
+| 🟡 AMBER | **14** | Under Active Ingestion — Will enter sprint review when ready |
 | 🔴 RED | **0** | Not Started / Blocked — Strategy or definition required |
 
 ---
@@ -35,7 +35,6 @@
 | 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
-| 🟢 | planecontrol | 0.1.0.0 | Graphics and video plane composition control | 0/5 | Architecture + Graphics_Architecture |
 | 🟢 | videodecoder | 0.2.0.0 | Video decoder resource management and codec support | 0/4 | Architecture + AV_Architecture |
 | 🟢 | videosink | 0.2.0.0 | Video output rendering and display sink management | 0/4 | Architecture + AV_Architecture |
 
@@ -49,7 +48,6 @@
 | 🟢 | deepsleep | 0.1.0.0 | Deep sleep and low-power state management | 3/4 | Architecture |
 | 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/4 | Architecture + Kernel_Architecture |
 | 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/4 | Architecture + Graphics_Architecture |
-| 🟢 | panel | 0.1.0.0 | Front panel display and button control | 2/4 | Architecture + Graphics_Architecture |
 | 🟢 | sensor | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
 
 
@@ -64,6 +62,7 @@
 | 🟡 | audiomixer | 0.3.0.0 | — | AQ parameter API in review | Land the AQ processor interface (#411 / #410, PR #573) — a breaking interface addition still under review; V1 not yet complete. Flip to GREEN on merge. | — | — | Architecture + Vendor_Layer_Team + AV_Architecture |
 | 🟡 | avbuffer *(SVP risk)* | 0.2.0.0 | 1 | Encrypted buffer (DRM/SVP) - Pending on DRM strategy | May change due to SVP changes from DRM which is being worked on | — | — | Architecture + AV_Architecture |
 | 🟡 | vsi/kernel | 0.0.0.1 | 1 | Strategy required | Not blocking progress - Architecture Strategy | — | — | Architecture |
+| 🟡 | planecontrol | 0.1.0.0 | 3 | Breaking change on develop unreleased: #621 removals (0.2.0.0 at next cut); #622/#329 open; GREEN when shipped | Design simplification tracked in #622, #329 | — | — | Architecture + Graphics_Architecture |
 | 🟡 | vsi/graphics | 0.0.0.1 | 6 | Docs required | Not blocking progress - Define Versions & write up vision and direction, Planning Out Evolution of the platform, RDK-M | — | — | Architecture + Graphics_Architecture |
 
 
@@ -71,6 +70,7 @@
 
 | | Component | Current Version | Priority | Detail | Action Required | Review Deadline | Target GREEN | Owners |
 |---|-----------|---------|----------|--------|-----------------|-----------------|--------------|--------|
+| 🟡 | panel | 0.1.0.0 | 3 | Breaking change in flight: #688 PQ capability normalization (0.2.0.0) in review; GREEN when shipped | PQ capability work tracked in #674, #497, #516, #276 | — | — | Architecture + Graphics_Architecture |
 | 🟡 | broadcast | 0.1.0.0 | 5 | Not integrated into the AIDL build - blocked on FMQ (#494) | Blocked: needs the android.hardware.common.fmq AIDL package in the binder SDK (linux_binder_idl#18); then add broadcast/current/interface.yaml - see #494. | — | — | Vendor_Layer_Team + Broadcast_Team |
 | 🟡 | firmwareupdate | 0.2.0.0 | 5 | Renamed from flash — fresh review cycle | Re-review under new name and broadened scope | — | — | Architecture + Kernel_Architecture |
 | 🟡 | r4ce | 0.0.0.1 | 5 | API Definition in progress | Control Manager Team - API Definition started | — | — | Architecture + Control_Manager_Architecture |
@@ -117,7 +117,6 @@
 | 🟢 | hdmicec | 4/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ |
 | 🟢 | hdmiinput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
 | 🟢 | hdmioutput | 3/4 | ✅ | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | 🔄 |
-| 🟢 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟢 | videodecoder | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 | 🟢 | videosink | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
@@ -126,6 +125,7 @@
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
 | 🟡 | vsi/kernel | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
+| 🟡 | planecontrol | 0/5 | ☐ | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟡 | vsi/graphics | 0/4 | ☐ | ☐ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟡 | audiomixer | 0/4 | ☐ | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ |
 
@@ -143,13 +143,13 @@
 | 🟢 | deepsleep | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟢 | deviceinfo | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 | 🟢 | indicator | 4/4 | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | panel | 2/4 | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟢 | sensor | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 
 | | Component | Progress | Arch | Prod | AV | Broadcast | Ctrl Mgr | Graphics | Connectivity | Kernel | Vendor |
 |---|-----------|----------|------|------|-----|-----------|----------|----------|--------------|--------|--------|
+| 🟡 | panel | 2/4 | ✅ | ✅ | N/A | N/A | N/A | ☐ | N/A | N/A | ☐ |
 | 🟡 | broadcast | 0/4 | ☐ | ☐ | N/A | ☐ | N/A | N/A | N/A | N/A | ☐ |
 | 🟡 | firmwareupdate | 0/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ☐ |
 | 🟡 | r4ce | 0/4 | ☐ | ☐ | N/A | N/A | ☐ | N/A | N/A | N/A | ☐ |

--- a/panel/metadata.yaml
+++ b/panel/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: panel
 version: 0.1.0.0
-status: GREEN
+status: AMBER
 description: "Front panel display and button control"
 type: OEM
 
@@ -51,7 +51,7 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 3
-  status_detail: "V1 stable"
+  status_detail: "Breaking change in flight: #688 PQ capability normalization (0.2.0.0) in review; GREEN when shipped"
   action: "PQ capability work tracked in #674, #497, #516, #276"
   owners: "Architecture + Graphics_Architecture"
 

--- a/planecontrol/metadata.yaml
+++ b/planecontrol/metadata.yaml
@@ -22,7 +22,7 @@
 # type        - Responsibility: SOC or OEM                                [manual]
 component: planecontrol
 version: 0.1.0.0
-status: GREEN
+status: AMBER
 description: "Graphics and video plane composition control"
 type: SOC
 
@@ -52,7 +52,7 @@ scope:
 #   owners        - Responsible architecture teams
 notes:
   priority: 3
-  status_detail: "V1 stable"
+  status_detail: "Breaking change on develop unreleased: #621 removals (0.2.0.0 at next cut); #622/#329 open; GREEN when shipped"
   action: "Design simplification tracked in #622, #329"
   owners: "Architecture + Graphics_Architecture"
 


### PR DESCRIPTION
Closes #684 (final slice — the 5-component GREEN flip + uplink refresh already landed via #685).

Applies the breaking-in-flight refinement recorded on #684: **a component with a breaking interface change in flight stays AMBER regardless of V1 completion** — GREEN signals a surface consumers can build against. Pending *additive* work does not hold RAG.

- **panel** GREEN → AMBER: #688 (PQ capability normalization, breaking → 0.2.0.0) in review; #516/#276 may add more surface. `status_detail` names the GREEN condition.
- **planecontrol** GREEN → AMBER: #621's breaking removals are on develop unreleased (0.2.0.0 at the next cut, flagged by `release.sh --audit`); #622/#329 open. `status_detail` names the GREEN condition.
- bootreason / deepsleep / drm stay GREEN (no interface work or patch-class only); audiomixer stays AMBER (now conditioned on #573 **and** #708).
- `RAG_STATUS_REPORT.md` regenerated.

ABI impact: none — metadata/report only, zero `.aidl` changes.