### PR TITLE
governance: field-aligned change-class labels + default-on strict audit (#712, #714)

### DIFF
--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -195,11 +195,13 @@ tagged.
 
 #### Pre-Tag Structural Audit
 
-Before tagging a release, run the structural audit:
+The release flow enforces the structural audit itself: every stage and
+`--apply` invocation first audits the components being written and refuses
+to proceed while their structural class, PR labels and `metadata.yaml`
+disagree. The full-repo sweep is available at any time:
 
 ```bash
-./scripts/release.sh --audit            # report
-./scripts/release.sh --audit --strict   # gate: non-zero exit on any flag
+./scripts/release.sh --audit   # every component; non-zero exit on any flag
 ```
 
 For **every** component — including ones untouched since the last release —

--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -96,23 +96,23 @@ Every PR carries **exactly one change-class label**. The label is the
 single signal of intent — there is no implicit-default class. An
 unlabelled PR is an unfinished PR.
 
-| PR label | Implied bump | Applied when |
-|----------|--------------|--------------|
-| `Breaking Change` | **Generation** (`0.g.m.p` → `0.(g+1).0.0`) | Conventional-commit `!:` marker in the PR title (e.g. `feat(avclock)!: ...`) — renames, removals, signature changes, design re-direction |
-| `Major Change` | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Default for real interface work — new methods, new fields appended to parcelables, new enum values added with fallback handling, new sub-interfaces |
-| `documentation` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Every changed file is doc-like (see `scripts/configure_pr.sh:is_doc()`) — doc tweaks, metadata corrections, HFP YAML changes, comment-only refactors. Auto-applied by `configure_pr.sh`. |
-| `Minor Change` | **Patch** (`0.g.m.p` → `0.g.m.(p+1)`) | Manually applied for a small non-doc change that still belongs at patch level — typo fix in code, log message tweak, internal comment reword. Equivalent to `documentation` from the release-bump perspective; the distinction is semantic (docs-only vs. small code) and only matters to the human reading the label. |
+The label names mean what the version fields mean — the label tier IS the
+field it bumps:
 
-`documentation` and `Minor Change` produce the same release bump
-(`patch`). They exist as separate labels because they describe different
-classes of work: `documentation` is the auto-applied label for the
-docs-only subset; `Minor Change` is the manually-applied label for the
-non-doc patch-class.
+| PR label | Implied bump | Applied when |
+| --- | --- | --- |
+| `Major Change` | **Major** (`0.g.m.p` → `0.(g+1).0.0`) | Breaking interface change — conventional-commit `!:` marker in the PR title (e.g. `feat(avclock)!: ...`): renames, removals, signature changes, design re-direction. Auto-applied by `configure_pr.sh` on the `!:` marker. |
+| `Minor Change` | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Backwards-compatible addition — the default for real interface work: new methods, new fields appended to parcelables, new enum values added with fallback handling, new sub-interfaces. |
+| `documentation` | **Bugfix** (`0.g.m.p` → `0.g.m.(p+1)`) | The interface surface is untouched — doc tweaks, metadata corrections, HFP YAML changes, comment-only refactors, trivial non-interface fixes. Auto-applied by `configure_pr.sh` when every changed file is doc-like (see `is_doc()`). |
+
+The `Breaking Change` label is retired — breaking IS the major bump, so a
+separate label was redundant. `scripts/release.sh` still accepts it as a
+deprecated alias of `Major Change` while historical and in-flight PRs
+migrate; do not apply it to new PRs.
 
 If multiple change-class labels are accidentally applied to a single
-PR, `scripts/release.sh` resolves by severity: `Breaking Change` >
-`Major Change` > `Minor Change` / `documentation` (the latter two are
-equivalent at the patch tier). Reviewers should still clean the
+PR, `scripts/release.sh` resolves by severity: `Major Change` >
+`Minor Change` > `documentation`. Reviewers should still clean the
 labelling so each PR carries exactly one.
 
 The PR author edits the component's `metadata.yaml` `version:` to the new
@@ -126,8 +126,8 @@ and deliberate scheduling. It is a **process/governance** label, **independent**
 of the change-class above. The change-class answers *"how does the version
 number move?"*; `CR` answers a **different** question — *"is this an ABI change
 that needs wider review and separate scheduling?"* The two axes are orthogonal,
-so a `CR` carries a change-class label alongside it (an ABI change is a
-`Breaking Change`).
+so a `CR` carries a change-class label alongside it (an ABI change carries
+`Major Change`).
 
 A PR/issue tagged `CR` requires:
 
@@ -137,9 +137,9 @@ A PR/issue tagged `CR` requires:
    release sweep; it is scheduled into a release deliberately.
 
 `CR` does **not** affect the version bump — `scripts/release.sh` never reads it.
-It is therefore *not* a rename of `Breaking Change`: `Breaking Change` remains
-the change-class that drives the generation bump, and conflating the two would
-break the label-driven bump logic.
+It is therefore *not* a change-class: `Major Change` remains the class that
+drives the major bump, and conflating the two would break the label-driven
+bump logic.
 
 #### The Subsume Rule
 
@@ -554,10 +554,10 @@ that deployed implementations are never broken by upstream changes.
 
 ### Breaking Changes
 
-Breaking changes are signalled via the `Breaking Change` label on the PR or
+Breaking changes are signalled via the `Major Change` label on the PR or
 issue at creation time. This is visible to reviewers immediately and drives
 review prioritisation. When the change is merged and the component is released,
-the version is bumped accordingly (generation bump for pre-baseline, new module
+the version is bumped accordingly (major bump for pre-baseline, new module
 for post-baseline).
 
 ---
@@ -656,24 +656,24 @@ Idempotent — safe to re-run.
 | Label | Purpose |
 |-------|---------|
 | `component:<name>` | Maps PRs to a specific HAL/VSI component (auto-detected from metadata.yaml) |
-| `Breaking Change` | Breaking interface change — bumps generation |
-| `Major Change` | Additive interface change — bumps minor (the default for real work) |
-| `Minor Change` | Doc-only / metadata-only / comment-only change — bumps patch |
+| `Major Change` | Breaking interface change — bumps major |
+| `Minor Change` | Additive, backwards-compatible interface change — bumps minor (the default for real work) |
+| `documentation` | Doc-only / metadata-only / comment-only change — bumps bugfix |
 | `CR` | Change Request — ABI change needing wider review sign-off + separate release scheduling (independent of change-class; no bump effect) |
 | `scope:infrastructure` | Repo tooling, CI/CD, governance |
 | `scope:overview` | Tracking ticket spanning multiple components |
 
-Every PR carries **exactly one** of `Breaking Change` / `Major Change` /
-`Minor Change`. The label signals the bump intent; the PR author bumps
+Every PR carries **exactly one** of `Major Change` / `Minor Change` /
+`documentation`. The label signals the bump intent; the PR author bumps
 `metadata.yaml` `version:` accordingly as part of the PR diff (see
 [How PRs Drive the Version Bump](#how-prs-drive-the-version-bump) above
 for the full subsume rule and snapshot-timing model):
 
 | Label | Version bump | Example |
 |-------|-------------|---------|
-| `Breaking Change` | Bump generation, reset minor + patch | `0.1.2.1` → `0.2.0.0` |
-| `Major Change` | Bump minor, reset patch | `0.1.0.0` → `0.1.1.0` |
-| `Minor Change` | Bump patch | `0.1.1.0` → `0.1.1.1` |
+| `Major Change` | Bump major, reset minor + bugfix | `0.1.2.1` → `0.2.0.0` |
+| `Minor Change` | Bump minor, reset bugfix | `0.1.0.0` → `0.1.1.0` |
+| `documentation` | Bump bugfix | `0.1.1.0` → `0.1.1.1` |
 
 Release-time execution (manual):
 

--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -105,6 +105,13 @@ field it bumps:
 | `Minor Change` | **Minor** (`0.g.m.p` → `0.g.(m+1).0`) | Backwards-compatible addition — the default for real interface work: new methods, new fields appended to parcelables, new enum values added with fallback handling, new sub-interfaces. |
 | `documentation` | **Bugfix** (`0.g.m.p` → `0.g.m.(p+1)`) | The interface surface is untouched — doc tweaks, metadata corrections, HFP YAML changes, comment-only refactors, trivial non-interface fixes. Auto-applied by `configure_pr.sh` when every changed file is doc-like (see `is_doc()`). |
 
+A PR that carries **no** change-class label but whose linked (closing)
+issue is GitHub type **`Bug`** implies the bugfix bump — the native issue
+type carries the signal, no label needed. An explicit change-class label
+always wins over the issue type (a bug whose fix changes the interface
+surface carries `Minor Change` or `Major Change` accordingly, and the
+structural audit checks the declared class either way).
+
 The `Breaking Change` label is retired — breaking IS the major bump, so a
 separate label was redundant. `scripts/release.sh` still accepts it as a
 deprecated alias of `Major Change` while historical and in-flight PRs

--- a/scripts/configure_pr.sh
+++ b/scripts/configure_pr.sh
@@ -22,10 +22,10 @@
 #
 # configure_pr.sh — apply the standard configuration to a pull request:
 #   * Labels       — component:<name> for each affected component, plus
-#                    exactly one change-class label (see #545):
-#                      Breaking Change — conventional-commit "!:" in title
-#                      Minor Change    — every changed file is docs-like
-#                      Major Change    — anything else (the default)
+#                    exactly one change-class label (see #712):
+#                      Major Change    — conventional-commit "!:" in title (breaking)
+#                      documentation   — every changed file is docs-like (bugfix)
+#                      Minor Change    — anything else (additive, the default)
 #   * Assignees    — the PR author.
 #   * Reviewers    — every reviewer team declared in the affected components'
 #                    metadata.yaml, mapped to GitHub team slugs. A PR always
@@ -113,25 +113,22 @@ print(" ".join(sorted(comps)))
     current_labels=$(echo "$meta" | python3 -c 'import json,sys;print(",".join(l["name"] for l in json.load(sys.stdin)["labels"]))')
     for c in $components; do desired_labels+="component:${c}\n"; done
 
-    # Exactly one change-class label per PR. The selection cascade below
-    # is *predicate-based*, not severity-based — each branch checks the
+    # Exactly one change-class label per PR (#712 — label names mean what
+    # the version fields mean). The selection cascade below is
+    # *predicate-based*, not severity-based — each branch checks the
     # condition that signals that class:
-    #   Breaking Change — conventional-commit "!:" marker in the title
-    #   documentation   — every changed file is doc-like (else branch)
-    #   Major Change    — fallback when neither predicate matches
-    #
-    # `Minor Change` is NOT auto-applied — it's a manually-applied label
-    # for non-doc small changes (typo / log message / comment-only refactor
-    # in code) that should still bump only the patch segment. Both
-    # `documentation` and `Minor Change` drive a patch bump in
-    # scripts/release.sh; `documentation` is the narrower form
-    # (docs-only PRs) and is what this cascade detects automatically.
+    #   Major Change    — conventional-commit "!:" marker in the title
+    #                     (breaking => major bump)
+    #   documentation   — every changed file is doc-like (else branch;
+    #                     bugfix bump)
+    #   Minor Change    — fallback when neither predicate matches
+    #                     (additive interface work => minor bump)
     #
     # The `is_doc()` predicate mirrors scripts/release.sh:is_doc_like_path
     # so the two scripts agree on what counts as docs-only.
     local change_class=""
     if [[ "$title" =~ ^[a-z]+(\([^\)]*\))?!: ]]; then
-        change_class="Breaking Change"
+        change_class="Major Change"
     else
         local docs_only
         docs_only=$(echo "$meta" | python3 -c '
@@ -151,7 +148,7 @@ print("yes" if fs and all(is_doc(p) for p in fs) else "no")
         if [ "$docs_only" = "yes" ]; then
             change_class="documentation"
         else
-            change_class="Major Change"
+            change_class="Minor Change"
         fi
     fi
     desired_labels+="${change_class}\n"

--- a/scripts/configure_pr.sh
+++ b/scripts/configure_pr.sh
@@ -153,18 +153,29 @@ print("yes" if fs and all(is_doc(p) for p in fs) else "no")
     fi
     desired_labels+="${change_class}\n"
 
+    # Exactly one change-class label: remove any other class label already
+    # on the PR (including the retired "Breaking Change") so recalculation
+    # never leaves duplicates behind during the #712 transition.
+    local remove_labels=()
+    local cls
+    for cls in "Major Change" "Minor Change" "documentation" "Breaking Change"; do
+        [ "$cls" = "$change_class" ] && continue
+        if [[ ",${current_labels}," == *",${cls},"* ]]; then remove_labels+=("$cls"); fi
+    done
+
     local add_labels=()
     while IFS= read -r lbl; do
         [ -z "$lbl" ] && continue
         if [[ ",${current_labels}," != *",${lbl},"* ]]; then add_labels+=("$lbl"); fi
     done < <(echo -e "$desired_labels")
 
-    if [ ${#add_labels[@]} -eq 0 ]; then
+    if [ ${#add_labels[@]} -eq 0 ] && [ ${#remove_labels[@]} -eq 0 ]; then
         echo "  labels: up to date"
     else
-        echo "  labels: + ${add_labels[*]}"
+        echo "  labels: + ${add_labels[*]:-} - ${remove_labels[*]:-}"
         if ! $DRY_RUN; then
             local args=(); for l in "${add_labels[@]}"; do args+=(--add-label "$l"); done
+            for l in "${remove_labels[@]}"; do args+=(--remove-label "$l"); done
             if gh pr edit "$pr" --repo "$REPO" "${args[@]}" >/dev/null; then
                 echo "    applied"
             else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1328,6 +1328,7 @@ else
 fi
 
 declare -A PR_LABEL_CACHE=()
+declare -A PR_TYPE_CACHE=()
 declare -A COMMIT_PR_CACHE=()
 declare -A COMP_TOUCHED=()
 declare -A COMP_BREAKING=()
@@ -1358,6 +1359,7 @@ gh_cache_load() {
             l)  # Restore newlines from |-encoded labels
                 PR_LABEL_CACHE[$key]="${value//|/$'\n'}"
                 ;;
+            t)  PR_TYPE_CACHE[$key]="${value}" ;;
         esac
     done < "${GH_CACHE_FILE}"
 }
@@ -1412,6 +1414,30 @@ get_pr_labels() {
     # Encode newlines as | for disk storage.
     gh_cache_append "l" "${pr}" "${labels//$'\n'/|}"
     printf '%s\n' "${labels}"
+}
+
+# GitHub-native issue type of the PR's linked (closing) issue. A PR with
+# no change-class label whose linked issue is type "Bug" implies the
+# bugfix bump (#712) — the type field carries the signal; no label needed.
+# Returns "Bug" when any linked issue is a Bug, else the first linked
+# issue's type, else "".
+get_pr_issue_type() {
+    local pr="$1"
+    if [[ -n "${PR_TYPE_CACHE[$pr]+x}" ]]; then
+        printf '%s\n' "${PR_TYPE_CACHE[$pr]}"
+        return 0
+    fi
+    local t=""
+    if [[ "${ENABLE_GH_LABELS}" -eq 1 ]]; then
+        t="$(gh api graphql \
+            -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){closingIssuesReferences(first:5){nodes{issueType{name}}}}}}' \
+            -f o="${GH_REPO%%/*}" -f r="${GH_REPO##*/}" -F n="${pr}" \
+            --jq '[.data.repository.pullRequest.closingIssuesReferences.nodes[].issueType.name // empty] | if any(. == "Bug") then "Bug" else (first // "") end' \
+            2>/dev/null || true)"
+    fi
+    PR_TYPE_CACHE[$pr]="${t}"
+    gh_cache_append "t" "${pr}" "${t}"
+    printf '%s\n' "${t}"
 }
 
 phase "Analyzing ${#FP_COMMITS[@]} commit(s) for component impact..."
@@ -1489,6 +1515,9 @@ for sha in "${FP_COMMITS[@]}"; do
         elif [[ "${has_bugfix_label}" -eq 1 ]]; then
             COMP_DOC[$comp]=1
             COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: documentation label (bugfix)"$'\n'
+        elif [[ -n "${pr_number}" ]] && [[ "$(get_pr_issue_type "${pr_number}")" == "Bug" ]]; then
+            COMP_DOC[$comp]=1
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: linked issue type Bug (bugfix)"$'\n'
         elif [[ "${COMMIT_COMP_DOCS_ONLY[$comp]}" -eq 1 ]]; then
             COMP_DOC[$comp]=1
             COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: docs-only heuristic"$'\n'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -649,17 +649,20 @@ Release run (no subcommand):
                        [--no-gh] [--no-snapshot] [--no-mkdocs]
                        [--no-build] [--verbose]
 
-Structural audit (pre-release gate):
-  ./scripts/release.sh --audit [--since <ref>] [--strict] [--verbose]
+Structural audit:
+  ./scripts/release.sh --audit [--since <ref>] [--verbose]
 
-  Read-only. For EVERY component (not just touched ones) classifies the
-  structural AIDL diff between the last frozen snapshot and current/ via
-  the binder toolchain (aidl_ops dump-surface / diff-surface), then
-  cross-checks it against the PR-label-implied change class and the
-  metadata.yaml declared version. Mismatches are flagged; --strict exits
-  non-zero on any flagged row so release tagging can be gated on a clean
-  audit. Detail of every structural change is printed for flagged rows
+  Read-only, always strict (exits non-zero on any flagged row). For EVERY
+  component (not just touched ones) classifies the structural AIDL diff
+  between the last frozen snapshot and current/ via the binder toolchain
+  (aidl_ops dump-surface / diff-surface), then cross-checks it against
+  the PR-label-implied change class and the metadata.yaml declared
+  version. Detail of every structural change is printed for flagged rows
   (all rows with --verbose).
+
+  The gate also runs AUTOMATICALLY on every write/branch path (stage and
+  --apply), scoped to the components being written — no switches needed.
+  --no-audit bypasses it (testing only; a real release MUST audit).
 
   Only components staged in the worktree are processed. The detector
   computes the bump level from PR labels since the base ref; an explicit
@@ -713,8 +716,10 @@ Options:
   --no-mkdocs            Skip updating mkdocs.yml.
   --no-build             Skip the verification build (./build_modules.sh
                          all). Testing only — a real release MUST build.
-  --audit                Structural change-class audit (see above). Read-only.
-  --strict               With --audit: exit non-zero if any row is flagged.
+  --audit                Structural change-class audit (see above). Read-only,
+                         always strict.
+  --no-audit             Skip the automatic write-path audit gate. Testing
+                         only — a real release MUST audit.
   --verbose              Print extra diagnostics.
   --help                 Show this help.
 
@@ -771,7 +776,7 @@ NO_SNAPSHOT=0
 NO_MKDOCS=0
 NO_BUILD=0
 AUDIT=0
-AUDIT_STRICT=0
+NO_AUDIT=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -822,7 +827,11 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --strict)
-            AUDIT_STRICT=1
+            warn "--strict is deprecated: the audit is always strict (#714)."
+            shift
+            ;;
+        --no-audit)
+            NO_AUDIT=1
             shift
             ;;
         --verbose|-v)
@@ -2838,7 +2847,12 @@ aidl_hash_status() {
 # classify breaking (standard AIDL discipline) — that row hard-fails
 # regardless of labels. Any disagreement flags the row; --strict turns
 # flags into a non-zero exit so tagging can be gated on a clean audit.
-if [[ "${AUDIT}" -eq 1 ]]; then
+# Runs the structural audit over the given components (all buildable
+# components when none are given). Strict is the only mode: returns
+# non-zero when any row is flagged or errors. (#714)
+run_structural_audit() {
+    local _audit_targets=("$@")
+    [[ ${#_audit_targets[@]} -gt 0 ]] || _audit_targets=("${COMPONENTS[@]}")
     _audit_toolchain="${BINDER_TOOLCHAIN_ROOT:-${REPO_ROOT}/build-tools/linux_binder_idl}"
     _audit_ops="${_audit_toolchain}/host/aidl_ops.py"
     [[ -f "${_audit_ops}" ]] \
@@ -2847,7 +2861,7 @@ if [[ "${AUDIT}" -eq 1 ]]; then
         || die "toolchain at ${_audit_toolchain} predates dump-surface/diff-surface — needs linux_binder_idl >= 2.6.0 (the binder_sdk.version pin); re-run ./build_binder.sh."
 
     log ""
-    phase "Structural change-class audit — ${#COMPONENTS[@]} components"
+    phase "Structural change-class audit — ${#_audit_targets[@]} component(s)"
     log ""
 
     _audit_tmp="$(mktemp -d)"
@@ -2887,7 +2901,7 @@ if [[ "${AUDIT}" -eq 1 ]]; then
     _audit_flagged=0
     _audit_errors=0
 
-    for comp in $(printf '%s\n' "${COMPONENTS[@]}" | sort); do
+    for comp in $(printf '%s\n' "${_audit_targets[@]}" | sort); do
         if ! is_buildable_component "${comp}"; then
             AUDIT_ROWS+=("$(printf "%-24s %-10s %-11s %-11s %-10s %-10s %s" \
                 "${comp}" "-" "-" "-" "-" "-" "skipped (not buildable)")")
@@ -3021,10 +3035,28 @@ if [[ "${AUDIT}" -eq 1 ]]; then
     else
         log "⚠️  Audit flagged ${_audit_flagged} mismatch(es) + ${_audit_errors} error(s) — see rows above."
     fi
-    if [[ "${AUDIT_STRICT}" -eq 1 && "${_audit_total}" -gt 0 ]]; then
-        exit 1
+    [[ "${_audit_total}" -eq 0 ]] || return 1
+    return 0
+}
+
+if [[ "${AUDIT}" -eq 1 ]]; then
+    run_structural_audit
+    exit $?
+fi
+
+# Write and branch paths run the audit automatically (#714): the
+# components being staged (DO_WRITES) or released (--apply/DO_BRANCH)
+# must have agreeing structural class, labels and metadata BEFORE
+# anything is written or branched. The full-repo sweep remains the
+# standalone --audit; --no-audit (testing only) bypasses this gate.
+if [[ ( "${DO_WRITES}" -eq 1 || "${DO_BRANCH}" -eq 1 ) && "${NO_AUDIT}" -ne 1 ]]; then
+    _gate_targets=()
+    for _c in "${!PLAN_COMPONENTS[@]}"; do
+        is_buildable_component "${_c}" && _gate_targets+=("${_c}")
+    done
+    if [[ ${#_gate_targets[@]} -gt 0 ]] && ! run_structural_audit "${_gate_targets[@]}"; then
+        die "structural audit failed for the staged component(s) — fix the label/metadata/AIDL disagreement before writing (full report: ./scripts/release.sh --audit; bypass for testing ONLY: --no-audit)."
     fi
-    exit 0
 fi
 
 mapfile -t TOUCHED_COMPONENTS < <(printf '%s\n' "${!COMP_TOUCHED[@]}" | sort)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -664,7 +664,9 @@ Structural audit:
   --apply), scoped to the components being written — no switches needed.
   --no-audit bypasses it (testing only; a real release MUST audit).
 
-  Only components staged in the worktree are processed. The detector
+  (Release run only — the standalone --audit above always covers every
+  buildable component.) Only components staged in the worktree are
+  processed. The detector
   computes the bump level from PR labels since the base ref; an explicit
   --version pin from the plan overrides that.
 
@@ -2874,8 +2876,9 @@ aidl_hash_status() {
 # minor, surface-identical respin => bugfix, identical => none. Era >= 1
 # components must never
 # classify breaking (standard AIDL discipline) — that row hard-fails
-# regardless of labels. Any disagreement flags the row; --strict turns
-# flags into a non-zero exit so tagging can be gated on a clean audit.
+# regardless of labels. Any disagreement flags the row, and flags
+# produce a non-zero exit (strict is the only mode, #714) so tagging
+# is gated on a clean audit.
 # Runs the structural audit over the given components (all buildable
 # components when none are given). Strict is the only mode: returns
 # non-zero when any row is flagged or errors. (#714)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,7 @@
 # Manual release-time script that:
 #   1) Looks at first-parent changes since the previous release tag/ref.
 #   2) Maps changes to HAL/VSI components via component-level metadata.yaml.
-#   3) Uses PR labels (Breaking Change / Major Change / Minor Change / documentation) when available.
+#   3) Uses PR labels (Major Change / Minor Change / documentation) when available.
 #   4) Computes version bumps and optionally updates metadata.yaml.
 #
 # Default mode is dry-run. Use --apply to write changes.
@@ -718,14 +718,14 @@ Options:
   --verbose              Print extra diagnostics.
   --help                 Show this help.
 
-Behavior (#545 change-class labels):
-  - "Breaking Change" label   => generation bump (0.g.m.p -> 0.(g+1).0.0)
-  - "Major Change"    label   => minor bump (0.g.m.p -> 0.g.(m+1).0)
-  - "Minor Change"    label   => patch bump (0.g.m.p -> 0.g.m.(p+1))
-  - "documentation"   label   => patch bump (docs-only; equivalent to Minor Change
-                                 from a release-bump perspective)
+Behavior (#712 change-class labels — label names mean what the fields mean):
+  - "Major Change"    label   => major bump (0.g.m.p -> 0.(g+1).0.0) — breaking
+  - "Minor Change"    label   => minor bump (0.g.m.p -> 0.g.(m+1).0) — additive
+  - "documentation"   label   => bugfix bump (0.g.m.p -> 0.g.m.(p+1))
+  - "Breaking Change" label   => retired; accepted as a deprecated alias of
+                                 Major Change during transition
   - no relevant label         => minor bump (default), unless docs-only heuristic
-                                 says patch
+                                 says bugfix
 
 Per bumped component the script:
   1. ./build_modules.sh <component>        # regenerate current/include + current/src
@@ -1428,17 +1428,20 @@ for sha in "${FP_COMMITS[@]}"; do
         labels="$(get_pr_labels "${pr_number}")"
     fi
 
-    # Change-class labels (#545). The legacy lowercase forms are still
-    # accepted for backwards compatibility while in-flight PRs migrate.
-    has_breaking_label=0
+    # Change-class labels (#712): the label names mean what the version
+    # fields mean — Major Change = breaking (major bump), Minor Change =
+    # additive (minor bump), documentation = bugfix bump. The retired
+    # "Breaking Change" label (and its legacy lowercase form) is accepted
+    # as a deprecated alias of Major Change while in-flight PRs migrate.
     has_major_label=0
     has_minor_label=0
+    has_bugfix_label=0
     while IFS= read -r lbl; do
         [[ -n "${lbl}" ]] || continue
         case "${lbl}" in
-            "Breaking Change"|"breaking-change")   has_breaking_label=1 ;;
-            "Major Change")                         has_major_label=1 ;;
-            "Minor Change"|"documentation")         has_minor_label=1 ;;
+            "Major Change"|"Breaking Change"|"breaking-change") has_major_label=1 ;;
+            "Minor Change")                                     has_minor_label=1 ;;
+            "documentation")                                    has_bugfix_label=1 ;;
         esac
     done <<< "${labels}"
 
@@ -1466,17 +1469,17 @@ for sha in "${FP_COMMITS[@]}"; do
         [[ -n "${pr_number}" ]] && reason_prefix="PR #${pr_number} (${sha:0:8})"
 
         # Order matters: highest severity wins if multiple change-class
-        # labels are (accidentally) present on a single PR. Breaking >
-        # Major > Minor (a Major+Minor combo resolves to Major, not Minor).
-        if [[ "${has_breaking_label}" -eq 1 ]]; then
+        # labels are (accidentally) present on a single PR. Major >
+        # Minor > documentation (a Minor+doc combo resolves to Minor).
+        if [[ "${has_major_label}" -eq 1 ]]; then
             COMP_BREAKING[$comp]=1
-            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Breaking Change label"$'\n'
-        elif [[ "${has_major_label}" -eq 1 ]]; then
-            COMP_NON_DOC[$comp]=1
-            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Major Change label"$'\n'
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Major Change label (breaking)"$'\n'
         elif [[ "${has_minor_label}" -eq 1 ]]; then
+            COMP_NON_DOC[$comp]=1
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Minor Change label (additive)"$'\n'
+        elif [[ "${has_bugfix_label}" -eq 1 ]]; then
             COMP_DOC[$comp]=1
-            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: Minor Change label"$'\n'
+            COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: documentation label (bugfix)"$'\n'
         elif [[ "${COMMIT_COMP_DOCS_ONLY[$comp]}" -eq 1 ]]; then
             COMP_DOC[$comp]=1
             COMP_REASONS[$comp]="${COMP_REASONS[$comp]:-}${reason_prefix}: docs-only heuristic"$'\n'
@@ -2717,9 +2720,9 @@ log ""
 # Map internal bump tokens to operator-readable change classes.
 bump_label() {
     case "$1" in
-        generation) echo "Breaking" ;;
-        minor)      echo "Major" ;;
-        patch)      echo "Minor" ;;
+        generation) echo "Major (breaking)" ;;
+        minor)      echo "Minor" ;;
+        patch)      echo "Bugfix" ;;
         pinned)     echo "Pinned" ;;
         none)       echo "-" ;;
         *)          echo "$1" ;;
@@ -2821,16 +2824,17 @@ aidl_hash_status() {
 #   structural  what the AIDL actually changed: the binder toolchain's
 #               dump-surface/diff-surface (linux_binder_idl#27) classifies
 #               last-frozen vs current/ as breaking / major / none (the
-#               tool's literal classes; `major` means additive and the
-#               audit table displays it as such).
+#               tool's literal classes: `breaking` displays as major,
+#               `major` means additive and displays as minor).
 #               A surface-identical pair whose .aidl sources still differ
 #               is doc-only (comment/doc edits are stripped from dumps).
 #   label       the change class the PR labels imply (same detector the
 #               release run uses; none when untouched in the window).
 #   declared    metadata.yaml's version field (authors pre-bump it).
 #
-# Gate table (era 0): breaking => generation bump, additive => minor,
-# doc-only => patch, identical => none. Era >= 1 components must never
+# Gate table (era 0): structural breaking => major bump, additive =>
+# minor, surface-identical respin => bugfix, identical => none. Era >= 1
+# components must never
 # classify breaking (standard AIDL discipline) — that row hard-fails
 # regardless of labels. Any disagreement flags the row; --strict turns
 # flags into a non-zero exit so tagging can be gated on a clean audit.
@@ -2861,12 +2865,14 @@ if [[ "${AUDIT}" -eq 1 ]]; then
         esac
     }
 
-    # Human-readable class for the table (code-truth column).
+    # Human-readable class for the table — field words, matching the
+    # label scheme (#712): major = breaking, minor = additive,
+    # bugfix = surface-identical respin.
     _audit_class_display() {
         case "$1" in
-            generation) echo "breaking" ;;
-            minor)      echo "additive" ;;
-            patch)      echo "doc-only" ;;
+            generation) echo "major" ;;
+            minor)      echo "minor" ;;
+            patch)      echo "bugfix" ;;
             none)       echo "none" ;;
             *)          echo "$1" ;;
         esac

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -73,9 +73,9 @@ done
 # Legacy workflow labels
 for lbl in "review-cycle" "sprint-required" "scope:multi-component" "scope:documentation" "documentation-change" \
            "breaking-change"; do
-    # `breaking-change` was replaced by `Breaking Change` in #545 — delete
-    # the lowercase form. `documentation` is kept (see Change-class labels
-    # below — it's equivalent to `Minor Change`, both drive a patch bump).
+    # `breaking-change` was replaced in #545 and the class was folded into
+    # `Major Change` in #712 — delete the lowercase form. `documentation`
+    # is kept (see Change-class labels below — the bugfix tier).
     delete_label "$lbl"
 done
 
@@ -118,11 +118,11 @@ echo ""
 # Workflow labels
 # ---------------------------------------------------------------------------
 
-echo "Change-class labels (every PR carries exactly one, see #545):"
-create_label "Breaking Change"      "b60205" "Breaking interface change — bumps version generation segment"
-create_label "Major Change"         "a2eeef" "Additive interface change — bumps minor; the default for real work"
-create_label "Minor Change"         "fef2c0" "Small non-doc change (typo / log message / comment-only refactor) — bumps patch"
-create_label "documentation"        "0075ca" "Documentation-only change — bumps patch; auto-applied when every changed file is doc-like"
+echo "Change-class labels (every PR carries exactly one, see #712 — label names mean what the fields mean):"
+create_label "Major Change"         "b60205" "Breaking interface change (renames/removals/signature changes) — bumps major"
+create_label "Minor Change"         "a2eeef" "Additive, backwards-compatible interface change — bumps minor; the default for real work"
+create_label "documentation"        "0075ca" "Surface-untouched change (docs/comments/metadata/trivial fixes) — bumps bugfix; auto-applied when every changed file is doc-like"
+create_label "Breaking Change"      "d4c5f9" "RETIRED (#712): alias of Major Change accepted during transition — do not apply to new PRs"
 
 echo ""
 


### PR DESCRIPTION
Closes #712. Decision: label names align with the fields they bump — the root cause of the recurring 'Major means additive?!' confusion.

| Label | Bump | Meaning |
| --- | --- | --- |
| `Major Change` | major | breaking (renames, removals, signature changes) — auto-applied on `!:` titles |
| `Minor Change` | minor | additive, backwards-compatible — the default for real interface work |
| `documentation` | bugfix | surface untouched — auto-applied for doc-only PRs |
| `Breaking Change` | — | **retired**; deprecated alias of Major Change during transition |

## Changed
- `release.sh`: label→bump mapping (+ alias), usage, table + audit display words (major/minor/bugfix).
- `configure_pr.sh`: `!:` ⇒ Major Change; docs-only ⇒ documentation; default ⇒ Minor Change.
- `setup_labels.sh`: new definitions; Breaking Change kept as a retired-alias label.
- `versioning-sop.md`: label tables, severity order, CR section, breaking-changes section.

## Already applied live (reversible)
- GitHub label descriptions/colors updated; `Breaking Change` marked RETIRED.
- Open carriers remapped: #706/#411/#688/#521/#707 → `Major Change` (breaking intent preserved); #710/#711/#387 → `Minor Change` (they were additive under the old meaning); #573 keeps `Major Change` (its `!:` title always meant breaking — now the label agrees).

## Safety
- Historical windows: old `Breaking Change` labels alias to major; old additive-intent `Major Change` labels could over-read as breaking, but the structural audit (`--audit --strict`) cross-checks every declared class against the real AIDL diff — misreads get flagged, not shipped. Current 0.22.0 window carries no such labels.
- Audit re-run post-change: unchanged (planecontrol still the sole flag).

---

## Also closes #714: the audit is the default, not an opt-in
- `--audit` is **always strict** (non-zero exit on any flag); `--strict` is a deprecated no-op.
- **Write/branch paths run the audit automatically**: `stage <module>` and `--apply` first audit the components being written (scoped — an unrelated component's drift doesn't block your stage) and refuse to proceed on disagreement. Verified live: staging planecontrol is blocked at the gate before any write.
- `--no-audit` joins the `--no-build`/`--no-snapshot` testing-only escape family.
- SOP pre-tag section rewritten: the release flow enforces the gate itself; standalone `--audit` is the anytime/CI sweep.

Closes #714.