### PR TITLE
fix(release): label-detector hygiene — skip merge commits, mkdocs.yml is doc-like (#715)

### DIFF
--- a/scripts/configure_pr.sh
+++ b/scripts/configure_pr.sh
@@ -141,6 +141,7 @@ def is_doc(p):
     if base == "CHANGELOG" or base.startswith("CHANGELOG."): return True
     if base == "metadata.yaml": return True
     if base.startswith("hfp-") and base.endswith(".yaml"): return True
+    if base == "mkdocs.yml": return True
     return False
 fs=[f["path"] for f in json.load(sys.stdin)["files"]]
 print("yes" if fs and all(is_doc(p) for p in fs) else "no")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1295,7 +1295,7 @@ component_from_path() {
 is_doc_like_path() {
     local path="$1"
     case "$path" in
-        docs/*|*/docs/*|*.md|*.rst|*.txt|*/README|*/README.*|*/CHANGELOG|*/CHANGELOG.*|*/metadata.yaml|*/hfp-*.yaml)
+        docs/*|*/docs/*|*.md|*.rst|*.txt|*/README|*/README.*|*/CHANGELOG|*/CHANGELOG.*|*/metadata.yaml|*/hfp-*.yaml|mkdocs.yml|*/mkdocs.yml)
             return 0
             ;;
         *)
@@ -1455,6 +1455,14 @@ for sha in "${FP_COMMITS[@]}"; do
     phase "    [${_commit_idx}/${_commit_total}] ${sha:0:8} ${_subj_short}"
     parent="$(git rev-parse "${sha}^1" 2>/dev/null || true)"
     [[ -n "${parent}" ]] || continue
+
+    # Skip merge commits (#715): in the squash-merge workflow every
+    # reviewable change is a non-merge commit; merges on develop are
+    # release back-merges (e.g. "Merge tag '0.21.0' into develop") whose
+    # thousand-file diffs would classify every component default-minor.
+    if git rev-parse -q --verify "${sha}^2" >/dev/null 2>&1; then
+        continue
+    fi
 
     mapfile -t changed_files < <(git diff --name-only "${parent}" "${sha}")
     [[ ${#changed_files[@]} -gt 0 ]] || continue


### PR DESCRIPTION
Closes #715. Two systemic signal-pollution fixes found auditing the post-merge 0.22.0 window:

1. **Merge commits skipped**: the 0.21.0 back-merge (1010 files, no PR) classified every component default-minor — and every future release window would repeat it. Squash-merge workflow means every reviewable change is a non-merge commit.
2. **`mkdocs.yml` is doc-like** in both `release.sh:is_doc_like_path()` and `configure_pr.sh:is_doc()` — nav-only changes are bugfix-tier.

Verified: avclock's window derivation went from two default-minor pollutants to pure bugfix signals (documentation labels, linked-issue-type-Bug, docs heuristic).

## Surfaced follow-up (decision needed, noted on #715)
The remaining avclock/videodecoder audit flags come from the **subsume pass propagating common's minor bump (halcompat, #711) to every importer**, while their structural class is bugfix. Design question: when a dependency bumps additively, do importers bump at all — and if so, at what class (the re-pin changes no importer surface)? Affects the 0.22.0 staging plan.