### PR TITLE
rag: present sensor as sensor/motion + sensor/thermal

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,9 +2,9 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-07-07 |
-| **Components** | 31 |
-| 🟢 **GREEN** | 17 |
+| **Generated** | 2026-07-13 |
+| **Components** | 32 |
+| 🟢 **GREEN** | 18 |
 | 🟡 **AMBER** | 14 |
 | 🔴 **RED** | 0 |
 
@@ -14,7 +14,7 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **17** | Reviewed & Approved — Interface stable on develop |
+| 🟢 GREEN | **18** | Reviewed & Approved — Interface stable on develop |
 | 🟡 AMBER | **14** | Under Active Ingestion — Will enter sprint review when ready |
 | 🔴 RED | **0** | Not Started / Blocked — Strategy or definition required |
 
@@ -29,13 +29,13 @@
 | 🟢 | audiodecoder | 0.2.0.0 | Audio decoder resource management and codec format support | 0/4 | Architecture + AV_Architecture |
 | 🟢 | audiosink | 0.2.0.0 | Audio output rendering and sink device management | 0/4 | Architecture + AV_Architecture |
 | 🟢 | avbuffer | 0.2.0.0 | AV buffer allocation and secure video path management | 4/4 | Architecture + AV_Architecture |
-| 🟢 | avclock | 0.2.0.0 | Audio/video clock synchronization and timing control | 0/4 | Architecture + AV_Architecture |
-| 🟢 | common | 0.2.0.0 | Shared base AIDL types and definitions used across all HAL interfaces | 0/2 | Architecture |
+| 🟢 | avclock | 0.2.0.1 | Audio/video clock synchronization and timing control | 0/4 | Architecture + AV_Architecture |
+| 🟢 | common | 0.2.1.0 | Shared base AIDL types and definitions used across all HAL interfaces | 0/2 | Architecture |
 | 🟢 | drm | 0.1.0.0 | DRM plugin and crypto plugin interfaces for content protection | 0/4 | Architecture + AV_Architecture |
 | 🟢 | hdmicec | 0.1.0.0 | HDMI CEC protocol messaging and device control | 4/4 | Architecture + AV_Architecture |
 | 🟢 | hdmiinput | 0.1.0.0 | HDMI input port management and signal detection | 3/4 | Architecture + AV_Architecture |
 | 🟢 | hdmioutput | 0.1.0.0 | HDMI output port configuration and display control | 3/4 | Architecture + AV_Architecture |
-| 🟢 | videodecoder | 0.2.0.0 | Video decoder resource management and codec support | 0/4 | Architecture + AV_Architecture |
+| 🟢 | videodecoder | 0.2.0.1 | Video decoder resource management and codec support | 0/4 | Architecture + AV_Architecture |
 | 🟢 | videosink | 0.2.0.0 | Video output rendering and display sink management | 0/4 | Architecture + AV_Architecture |
 
 
@@ -48,7 +48,8 @@
 | 🟢 | deepsleep | 0.1.0.0 | Deep sleep and low-power state management | 3/4 | Architecture |
 | 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/4 | Architecture + Kernel_Architecture |
 | 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/4 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
+| 🟢 | sensor/motion | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
+| 🟢 | sensor/thermal | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -143,7 +144,8 @@
 | 🟢 | deepsleep | 3/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟢 | deviceinfo | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 | 🟢 | indicator | 4/4 | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | sensor | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | sensor/motion | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | sensor/thermal | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -126,8 +126,6 @@ rag_icon() {
 }
 
 for f in $METADATA_FILES; do
-    TOTAL=$((TOTAL + 1))
-
     comp=$(yaml_val "$f" "component")
     version=$(yaml_val "$f" "version")
     status=$(yaml_val "$f" "status")
@@ -144,8 +142,17 @@ for f in $METADATA_FILES; do
     [ "$review_deadline" = "~" ] && review_deadline=""
     [ "$target_green" = "~" ] && target_green=""
     review_progress=$(yaml_review_progress "$f")
-    path=$(component_path "$f")
+    base_path=$(component_path "$f")
     icon=$(rag_icon "$status")
+
+    # Present the single sensor module as its two sub-interfaces
+    # (com.rdk.hal.sensor.motion / .thermal). Report-only: one module, one
+    # metadata.yaml and version — both rows share its status and reviews.
+    PATHS="$base_path"
+    [ "$comp" = "sensor" ] && PATHS="sensor/motion sensor/thermal"
+
+    for path in $PATHS; do
+    TOTAL=$((TOTAL + 1))
 
     # Build row (AMBER/RED use full detail, with lifecycle dates — no Reviews column)
     row="| ${icon} | ${path} | ${version} | ${priority:-—} | ${status_detail:-—} | ${action:-—} | ${review_deadline:-—} | ${target_green:-—} | ${owners:-—} |"
@@ -205,6 +212,7 @@ for f in $METADATA_FILES; do
             append_review_row RED_SOC_REVIEW_ROWS RED_OEM_REVIEW_ROWS "${priority:-99}\t${detail_row}"
             ;;
     esac
+    done  # PATHS (sensor expands to motion + thermal)
 done
 
 # Generate report


### PR DESCRIPTION
Closes #734.

The `sensor` module ships two cleanly separated sub-interfaces — `com.rdk.hal.sensor.motion` and `com.rdk.hal.sensor.thermal`, each with its own HFP YAML — but the RAG report showed a single `sensor` row. This expands it into two rows so the dashboard reflects both capabilities, matching the programme's two-component view (`component:motion_sensor` / `component:thermal_sensor`; ENT-8650 vs ENT-8651).

**Report-only — no interface or versioning change.** `sensor` stays one module (one `metadata.yaml`, one `interface.yaml`, one version); both rows share its status/version/reviews. The generator now iterates a per-component path list (just the component path, except `sensor` → `motion` + `thermal`), with the counters moved inside that loop so rows and tallies stay consistent.

| | Before | After |
|---|---|---|
| Components | 31 | 32 |
| GREEN | 17 | 18 |
| sensor rows | `sensor` | `sensor/motion`, `sensor/thermal` |

**Incidental:** the regenerated report also refreshes three versions that were stale in the committed copy (avclock 0.2.0.1, common 0.2.1.0, videodecoder 0.2.0.1) — pre-existing drift from metadata bumps without a report regen.

If independent versioning/lifecycle per sensor type is wanted later, that's the heavier module-split option (deferred).