### PR TITLE
fix(rag): render sensor as sensor/motion + sensor/thermal rows

### DIFF
--- a/RAG_STATUS_REPORT.md
+++ b/RAG_STATUS_REPORT.md
@@ -2,9 +2,9 @@
 
 | | |
 |---|---|
-| **Generated** | 2026-07-10 |
-| **Components** | 30 |
-| 🟢 **GREEN** | 18 |
+| **Generated** | 2026-07-14 |
+| **Components** | 31 |
+| 🟢 **GREEN** | 19 |
 | 🟡 **AMBER** | 12 |
 | 🔴 **RED** | 0 |
 
@@ -14,7 +14,7 @@
 
 | Status | Count | Meaning |
 |--------|-------|---------|
-| 🟢 GREEN | **18** | Reviewed & Approved — Interface stable on develop |
+| 🟢 GREEN | **19** | Reviewed & Approved — Interface stable on develop |
 | 🟡 AMBER | **12** | Under Active Ingestion — Will enter sprint review when ready |
 | 🔴 RED | **0** | Not Started / Blocked — Strategy or definition required |
 
@@ -49,7 +49,8 @@
 | 🟢 | deviceinfo | 0.1.0.0 | Device information and platform capability reporting | 4/4 | Architecture + Kernel_Architecture |
 | 🟢 | firmwareupdate | 0.2.0.0 | Update lifecycle for multiple firmware types at multiple locations across the system | 1/4 | Architecture + Kernel_Architecture |
 | 🟢 | indicator | 0.1.0.0 | LED and visual indicator state management | 4/4 | Architecture + Graphics_Architecture |
-| 🟢 | sensor | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
+| 🟢 | sensor/motion | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
+| 🟢 | sensor/thermal | 0.2.0.0 | Hardware sensor data acquisition and monitoring | 4/4 | Architecture + Kernel_Architecture |
 
 
 ---
@@ -143,7 +144,8 @@
 | 🟢 | deviceinfo | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 | 🟢 | firmwareupdate | 1/4 | ☐ | ☐ | N/A | N/A | N/A | N/A | N/A | ☐ | ✅ |
 | 🟢 | indicator | 4/4 | ✅ | ✅ | N/A | N/A | N/A | ✅ | N/A | N/A | ✅ |
-| 🟢 | sensor | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | sensor/motion | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
+| 🟢 | sensor/thermal | 4/4 | ✅ | ✅ | N/A | N/A | N/A | N/A | N/A | ✅ | ✅ |
 
 ### OEM — 🟡 AMBER
 

--- a/scripts/generate_rag_report.sh
+++ b/scripts/generate_rag_report.sh
@@ -135,8 +135,6 @@ for f in $METADATA_FILES; do
         common) continue ;;
     esac
 
-    TOTAL=$((TOTAL + 1))
-
     version=$(yaml_val "$f" "version")
     status=$(yaml_val "$f" "status")
     description=$(yaml_val "$f" "description")
@@ -155,19 +153,25 @@ for f in $METADATA_FILES; do
     path=$(component_path "$f")
     icon=$(rag_icon "$status")
 
-    # Build row (AMBER/RED use full detail, with lifecycle dates — no Reviews column)
-    row="| ${icon} | ${path} | ${version} | ${priority:-—} | ${status_detail:-—} | ${action:-—} | ${review_deadline:-—} | ${target_green:-—} | ${owners:-—} |"
-
-    # Build GREEN row (per-team detail is in the Review Status section)
-    green_row="| ${icon} | ${path} | ${version} | ${description:-—} | ${review_progress} | ${owners:-—} |"
-
-    # Build review detail row with per-team columns
-    detail_row="| ${icon} | ${path} | ${review_progress}"
-    for team in $ALL_TEAMS; do
-        team_status=$(yaml_reviewer_status "$f" "$team")
-        detail_row="${detail_row} | $(review_icon "$team_status")"
-    done
-    detail_row="${detail_row} |"
+    # sensor ships two cleanly separated sub-interfaces — motion and thermal —
+    # each with its own HFP, and the programme tracks them as two capabilities
+    # (component:motion_sensor / component:thermal_sensor). Render one dashboard
+    # row per sub-interface so both show up. Report-only: the module stays one
+    # (one metadata.yaml / interface.yaml / version); every row shares its
+    # status, version and reviews. The sub-interface labels are read from the
+    # snapshot's HFP directories, not hard-coded, so they track the interface.
+    # Scoped to sensor by name: other multi-directory components (e.g. broadcast
+    # demux/frontend) have no per-sub HFP and are not separate capabilities.
+    row_paths="$path"
+    if [ "$comp" = "sensor" ]; then
+        subs=""
+        for d in "$(dirname "$f")/current/com/rdk/hal/${comp}"/*/; do
+            [ -d "$d" ] || continue
+            ls "${d}"hfp-*.yaml >/dev/null 2>&1 || continue
+            subs="${subs}${subs:+ }${comp}/$(basename "$d")"
+        done
+        [ -n "$subs" ] && row_paths="$subs"
+    fi
 
     # Helper: append row to the correct SOC/OEM/Shared bucket
     append_row() {
@@ -191,28 +195,48 @@ for f in $METADATA_FILES; do
         fi
     }
 
-    case "$status" in
-        GREEN)
-            GREEN_COUNT=$((GREEN_COUNT + 1))
-            append_row GREEN_SOC_ROWS GREEN_OEM_ROWS GREEN_SHARED_ROWS "$green_row"
-            append_review_row GREEN_SOC_REVIEW_ROWS GREEN_OEM_REVIEW_ROWS "$detail_row"
-            # If component has a risk note, also list it in AMBER as a watch item
-            if [ -n "$risk" ]; then
-                amber_row="| ${RAG_AMBER} | ${path} *(risk)* | ${version} | ${priority:-—} | ${status_detail:-—} | ${risk} | ${review_deadline:-—} | ${target_green:-—} | ${owners:-—} |"
-                append_row AMBER_SOC_ROWS AMBER_OEM_ROWS AMBER_SHARED_ROWS "$amber_row"
-            fi
-            ;;
-        AMBER)
-            AMBER_COUNT=$((AMBER_COUNT + 1))
-            append_row AMBER_SOC_ROWS AMBER_OEM_ROWS AMBER_SHARED_ROWS "$row"
-            append_review_row AMBER_SOC_REVIEW_ROWS AMBER_OEM_REVIEW_ROWS "${priority:-99}\t${detail_row}"
-            ;;
-        RED)
-            RED_COUNT=$((RED_COUNT + 1))
-            append_row RED_SOC_ROWS RED_OEM_ROWS RED_SHARED_ROWS "$row"
-            append_review_row RED_SOC_REVIEW_ROWS RED_OEM_REVIEW_ROWS "${priority:-99}\t${detail_row}"
-            ;;
-    esac
+    # One row per presentation path (one for most components; two for sensor).
+    # Each presented capability counts once in the totals.
+    for path in $row_paths; do
+        TOTAL=$((TOTAL + 1))
+
+        # Build row (AMBER/RED use full detail, with lifecycle dates — no Reviews column)
+        row="| ${icon} | ${path} | ${version} | ${priority:-—} | ${status_detail:-—} | ${action:-—} | ${review_deadline:-—} | ${target_green:-—} | ${owners:-—} |"
+
+        # Build GREEN row (per-team detail is in the Review Status section)
+        green_row="| ${icon} | ${path} | ${version} | ${description:-—} | ${review_progress} | ${owners:-—} |"
+
+        # Build review detail row with per-team columns
+        detail_row="| ${icon} | ${path} | ${review_progress}"
+        for team in $ALL_TEAMS; do
+            team_status=$(yaml_reviewer_status "$f" "$team")
+            detail_row="${detail_row} | $(review_icon "$team_status")"
+        done
+        detail_row="${detail_row} |"
+
+        case "$status" in
+            GREEN)
+                GREEN_COUNT=$((GREEN_COUNT + 1))
+                append_row GREEN_SOC_ROWS GREEN_OEM_ROWS GREEN_SHARED_ROWS "$green_row"
+                append_review_row GREEN_SOC_REVIEW_ROWS GREEN_OEM_REVIEW_ROWS "$detail_row"
+                # If component has a risk note, also list it in AMBER as a watch item
+                if [ -n "$risk" ]; then
+                    amber_row="| ${RAG_AMBER} | ${path} *(risk)* | ${version} | ${priority:-—} | ${status_detail:-—} | ${risk} | ${review_deadline:-—} | ${target_green:-—} | ${owners:-—} |"
+                    append_row AMBER_SOC_ROWS AMBER_OEM_ROWS AMBER_SHARED_ROWS "$amber_row"
+                fi
+                ;;
+            AMBER)
+                AMBER_COUNT=$((AMBER_COUNT + 1))
+                append_row AMBER_SOC_ROWS AMBER_OEM_ROWS AMBER_SHARED_ROWS "$row"
+                append_review_row AMBER_SOC_REVIEW_ROWS AMBER_OEM_REVIEW_ROWS "${priority:-99}\t${detail_row}"
+                ;;
+            RED)
+                RED_COUNT=$((RED_COUNT + 1))
+                append_row RED_SOC_ROWS RED_OEM_ROWS RED_SHARED_ROWS "$row"
+                append_review_row RED_SOC_REVIEW_ROWS RED_OEM_REVIEW_ROWS "${priority:-99}\t${detail_row}"
+                ;;
+        esac
+    done
 done
 
 # Generate report


### PR DESCRIPTION
The RAG dashboard collapses `sensor` into a single row, but the module ships two cleanly separated sub-interfaces — `com.rdk.hal.sensor.motion` and `com.rdk.hal.sensor.thermal` — each with its own HFP, and the programme tracks them as two capabilities (`component:motion_sensor` / `component:thermal_sensor`).

`generate_rag_report.sh` now emits one row per sub-interface (`sensor/motion`, `sensor/thermal`) in both the status table and the review-status detail section. Each capability counts once in the totals (Components 30 → 31, GREEN 18 → 19). Every row shares the module's single status, version and reviews.

Report-only: the module stays one — one `metadata.yaml`, one `interface.yaml`, one version. No interface or versioning change.

The sub-interface labels are read from the snapshot's HFP directories, not hard-coded, so they track the interface. Scoped to `sensor` by name; other multi-directory components (e.g. `broadcast` demux/frontend) carry no per-sub HFP and are not separate capabilities.

Base is **release/0.22.0** (unreleased) — an in-flight stabilisation fix, not a hotfix. Fixes #734.