### PR TITLE
feat(audiodecoder): add bitrateBps to FrameMetadata (#139)

### DIFF
--- a/audiodecoder/current/com/rdk/hal/audiodecoder/FrameMetadata.aidl
+++ b/audiodecoder/current/com/rdk/hal/audiodecoder/FrameMetadata.aidl
@@ -133,6 +133,24 @@ parcelable FrameMetadata {
 	byte[] SoCPrivate;
 
 	/**
+	 * Bitrate of the source elementary stream for this frame, in bits per second.
+	 *
+	 * The encoded bitrate reported by the decoder for the source audio
+	 * (e.g. ~640000 for 640 kbps AC-3, ~1500000 for a DTS core). For variable
+	 * bitrate streams this is the instantaneous/most-recent bitrate the decoder
+	 * derives for this frame.
+	 *
+	 * Informational only — used for metrics, UI reporting, and stream
+	 * diagnostics; it does not affect decoding or presentation.
+	 *
+	 * Set to 0 when the decoder does not know or report a bitrate (e.g. raw PCM,
+	 * or a codec/container that carries no bitrate). Type rationale: `int`
+	 * (not `long`) is sufficient — the maximum lossless audio bitrate (Dolby
+	 * TrueHD, DTS-HD MA) is well under 2^31 bits per second.
+	 */
+	int bitrateBps;
+
+	/**
 	 * Private extension for future use.
 	 */
 	ParcelableHolder extension;


### PR DESCRIPTION
Closes #139.

Adds `bitrateBps` to `audiodecoder` `FrameMetadata` — the encoded bitrate of the source elementary stream for the frame, in bits per second.

- **Informational only**: metrics, UI reporting, stream diagnostics. Does not affect decoding or presentation.
- `0` when the decoder reports no bitrate (raw PCM, or a codec/container carrying none). For VBR streams it is the instantaneous/most-recent bitrate derived for the frame.
- `int` (not `long`): the maximum lossless audio bitrate (Dolby TrueHD, DTS-HD MA) is well under 2^31 bps.

**Change class:** Minor Change — additive field on the shipped `audiodecoder` parcelable (0.2.0.0 → next). Appended at the **bottom**, immediately before the `ParcelableHolder extension`, so the field ordinals of the released 0.2.0.0 snapshot are preserved.
