### PR TITLE
fix(docs): build_docs.sh normalizes snapshot site_name before building the site

### DIFF
--- a/avclock/0.2.0.1/mkdocs.yml
+++ b/avclock/0.2.0.1/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: avclock
+site_name: avclock-0.2.0.1
 docs_dir: docs

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -108,12 +108,56 @@ EOF
 }
 
 # ----------------------------------------------------------------------------
+# normalize_snapshot_site_names() : Ensure every snapshot mkdocs.yml carries a
+# unique site_name.
+#
+# create_snapshot() copies <component>/current/mkdocs.yml verbatim, so a fresh
+# snapshot inherits the bare component site_name. Once the top-level nav
+# registers current/ and the snapshot together, the mkdocs-monorepo plugin
+# rejects the duplicate names and the build aborts. Rewrite each
+# <component>/<X.Y.Z.W>/mkdocs.yml to "site_name: <component>-<version>";
+# current/ keeps the bare component name. Runs before every command that
+# builds the site, so the publish flow needs no manual site-name pass.
+# ----------------------------------------------------------------------------
+function normalize_snapshot_site_names()
+{
+  local fixed=0
+  local snapshot_yml comp_dir version component expected current_name
+
+  while IFS= read -r snapshot_yml; do
+    comp_dir="$(dirname "$(dirname "${snapshot_yml}")")"
+    component="$(basename "${comp_dir}")"
+    version="$(basename "$(dirname "${snapshot_yml}")")"
+    expected="${component}-${version}"
+    current_name="$(sed -n 's/^site_name:[[:space:]]*//p' "${snapshot_yml}" | head -1)"
+    if [ "${current_name}" != "${expected}" ]; then
+      sed -i "s/^site_name:.*/site_name: ${expected}/" "${snapshot_yml}"
+      echo "[INFO]   normalized ${snapshot_yml#"${REPO_ROOT}"/}: site_name '${current_name}' -> '${expected}'"
+      fixed=$((fixed + 1))
+    fi
+  done < <(find "${REPO_ROOT}" -maxdepth 4 \
+             \( -name out -o -name site -o -name build -o -name external_content -o -name python_venv \) -prune \
+             -o -regextype posix-extended \
+             -regex '.*/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/mkdocs\.yml' -print)
+
+  if [ ${fixed} -gt 0 ]; then
+    echo "[INFO] normalized ${fixed} snapshot site_name(s) — commit the corrected mkdocs.yml file(s)."
+  fi
+}
+
+# ----------------------------------------------------------------------------
 # main() : Main entry point. Handle command-line arguments, then run commands.
 # ----------------------------------------------------------------------------
 function main() 
 {
   local CMD=$1
   shift || true  # Shift off the first argument to allow further options
+
+  case "${CMD}" in
+    serve|build|deploy|release)
+      normalize_snapshot_site_names
+      ;;
+  esac
 
   case "${CMD}" in
     serve)

--- a/planecontrol/0.2.0.0/mkdocs.yml
+++ b/planecontrol/0.2.0.0/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: planecontrol
+site_name: planecontrol-0.2.0.0
 docs_dir: docs

--- a/videodecoder/0.2.0.1/mkdocs.yml
+++ b/videodecoder/0.2.0.1/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: videodecoder
+site_name: videodecoder-0.2.0.1
 docs_dir: docs


### PR DESCRIPTION
## Summary

Fixes the docs publish flow so it never needs a manual site-name pass: generate the latest docs, and when ready run `build_docs.sh release <version>` — the site change is applied automatically.

- New `normalize_snapshot_site_names()` in `docs/build_docs.sh`: before any command that builds the site (`serve`, `build`, `deploy`, `release`), every `<component>/<X.Y.Z.W>/mkdocs.yml` is rewritten to `site_name: <component>-<version>` (the mkdocs-monorepo plugin rejects duplicates otherwise). `current/` keeps the bare component name. Corrections are reported so they can be committed; a clean tree is untouched.
- Includes the normalization output for the 0.22.0 cohort — avclock/0.2.0.1, videodecoder/0.2.0.1, planecontrol/0.2.0.0 — restoring a green docs build on develop.

Snapshot mkdocs.yml files are copied verbatim from `current/` at freeze time, so every new cohort previously needed a manual patch (354ba66c did this for 0.21.0).

## Verification

- `./docs/build_docs.sh build` on develop + this change: normalizes the three 0.22.0 files, site builds in ~12s, exit 0.
- Second run: zero corrections, tree untouched (idempotent).
- Before the change the same build aborts on duplicated site names.

Closes #749. Refs #604 (release.sh `create_snapshot()` emitting the correct site_name at freeze time remains the companion fix).