### PR TITLE
docs(governance): fold the change request process into the Versioning SOP (#763)

### DIFF
--- a/docs/governance/versioning-sop.md
+++ b/docs/governance/versioning-sop.md
@@ -369,7 +369,85 @@ Feedback from one cycle may require design iteration and a subsequent cycle.
 
 ---
 
-## 5. The "14+5" Accelerated Delivery Cycle
+## 5. Raising and Executing a Change
+
+Every change runs through a ticket-driven, auditable process. Nothing reaches
+`develop` without a tracked requirement behind it.
+
+### Where the work is tracked
+
+**JIRA owns the planning view.** Milestone completion and delivery status live
+in JIRA so PMs track progress across releases without working in GitHub.
+
+**GitHub owns engineering truth.** This is a public open-source project, and
+GitHub holds a complete, auditable history of every change, visible to internal
+and external contributors alike. All change context lives where every
+contributor can see it, and engineering status is synced back to JIRA against
+the planning requirements.
+
+### RDK-M core contributors: direct branching
+
+Core contributors have write access and branch from the repository directly.
+
+```text
+ Requirement     Ticket        Branch        PR & Review       Merge
+ ──────────► ──────────► ──────────────► ──────────────► ──────────────►
+                                          If major change:
+  Stakeholder   GitHub       Feature        14-Day Review   Develop
+  identifies    Issue        branch per     + 5-Day         branch
+  need          created      ticket         Resolution      (protected)
+```
+
+### Community contributors: fork-based branching
+
+Contributors without write access work from a fork. The same governance, review
+and approval rules apply to every contribution regardless of its origin.
+
+```text
+ Fork Repo     Clone & Branch    Commit & Push     Submit PR       Review & Merge
+ ──────────► ──────────────► ──────────────► ──────────────► ──────────────►
+  Fork the      Clone locally    Push changes      PR to the       Core team
+  repository    & create a       to your fork      original        reviews &
+  on GitHub     topic branch     on GitHub         repository      approves
+```
+
+### Branch naming
+
+Every change begins with a GitHub issue and is implemented on a branch named
+for it — `feature/{issue#}-{synopsis}`. Branch naming is enforced, so every
+commit traces back to a tracked requirement.
+
+### Audit trail
+
+Every change is traceable from requirement through to release:
+
+| Artefact | What it records |
+|----------|-----------------|
+| **GitHub Issue** | The original requirement, discussion and decisions |
+| **Feature branch** | Named branch linking every commit to the issue |
+| **Pull request** | Review comments, approvals and CI results |
+| **Changelog** | Generated per release from merged work |
+| **Release notes** | Published with every GitHub Release |
+
+### Enforcement
+
+The process is enforced by the repository rather than by convention:
+
+| Control | Mechanism |
+|---------|-----------|
+| Ticket-driven workflow | Branch naming rules |
+| Protected `develop` | Branch protection and rulesets |
+| Reviewer assignment | CODEOWNERS |
+| Contributor licensing | CLA enforcement |
+| Security scanning | FOSSID |
+| Licence scanning | BlackDuck |
+| Copyright headers | Header check |
+| Time-boxed review | The 14+5 cycle, Section 6 |
+| Multi-team sign-off | Four mandatory teams plus a domain reviewer, Section 9 |
+
+---
+
+## 6. The "14+5" Accelerated Delivery Cycle
 
 All HAL interface changes move through a strictly time-boxed review lifecycle.
 
@@ -421,7 +499,7 @@ separately through the PR and merge process.
 
 ---
 
-## 6. Pre-Baseline: The Path to AIDL Baseline 1.0
+## 7. Pre-Baseline: The Path to AIDL Baseline 1.0
 
 ### Current State
 
@@ -528,7 +606,7 @@ been individually frozen. This is the milestone, not a gate.
 
 ---
 
-## 7. Post-Baseline: Maintaining AIDL After Freeze
+## 8. Post-Baseline: Maintaining AIDL After Freeze
 
 Once a component is frozen at AIDL Baseline, it follows AIDL stable
 interface versioning. The rules are strict and non-negotiable.
@@ -571,7 +649,7 @@ for post-baseline).
 
 ---
 
-## 8. Stakeholder Management & Roles
+## 9. Stakeholder Management & Roles
 
 ### Mandatory Reviewers (all components)
 
@@ -615,7 +693,7 @@ Each reviewer team's sign-off is tracked in `metadata.yaml`:
 
 ---
 
-## 9. Tooling & Automation
+## 10. Tooling & Automation
 
 ### metadata.yaml — Single Source of Truth
 

--- a/docs/presentations/change-request-process/00-title.md
+++ b/docs/presentations/change-request-process/00-title.md
@@ -8,3 +8,9 @@ G. Weatherup
 March 2026
 
 *Version 0.2 - Draft for Review*
+
+---
+
+Presentation material. The normative process is
+[HAL Delivery & Versioning SOP](../../governance/versioning-sop.md) — where the
+rules conflict, the SOP is correct.


### PR DESCRIPTION
Closes #763.

The change request process was documented in three places stating the same rules.

| Where | What it was |
|---|---|
| `docs/governance/versioning-sop.md` | Already owned the versioning scheme, change-class labels, RAG states, the 14+5 cycle, mandatory reviewer teams and sign-off values |
| `docs/presentations/change-request-process/` | A 15-slide deck plus PDF presenting the same rules |
| `docs/governance/change-request-process.md` | An untracked prose page repeating the deck, not in the `mkdocs.yml` nav, so rendering nowhere |

## It had already drifted

The prose page documented a `breaking-change` label and described feature changes as carrying *"no specific label"*. The SOP records `Breaking Change` as **retired**, and states that every PR carries exactly one change-class label — `Major Change`, `Minor Change` or `documentation` — because "an unlabelled PR is an unfinished PR".

Anyone following the duplicate would have labelled their PR wrongly. That is the cost of the third copy, not a hypothetical.

## What this does

`versioning-sop.md` gains **Section 5 — Raising and Executing a Change**, carrying only what the SOP did not already state:

- Where work is tracked — JIRA owns planning, GitHub owns engineering truth
- Direct branching for RDK-M core contributors
- Fork-based branching for community contributors
- The `feature/{issue#}-{synopsis}` branch naming rule
- The audit trail from requirement through to release
- The repository controls that enforce the process

Everything the SOP already said stays where it was, so nothing is duplicated and **the stale label table is not carried forward**.

Sections 5–9 shift to 6–10. No heading text changed on any linked anchor, so the inbound links — including the deck slide 10 link to `#how-prs-drive-the-version-bump` — still resolve.

The deck stays as presentation material and now says so on its title slide, citing the SOP as normative where the two disagree. That leaves one place a rule can be changed.

`docs/governance/change-request-process.md` is deleted.