### PR TITLE
Update audio video decoder hfps

### DIFF
--- a/audiodecoder/current/hfp-audiodecoder.yaml
+++ b/audiodecoder/current/hfp-audiodecoder.yaml
@@ -22,28 +22,402 @@
 
 # HAL Feature Profile for audiodecoder
 
-audiodecoder:                   # Component object begins
-    interfaceVersion: current
-    IAudioDecoder:              # Resource list
-      - 0:                      # Resource object begins
-         supportedCodecs:       # Array of codec capabilities
-           - AAC_LC
-           - HE_AAC
-           - HE_AAC2
-           - DOLBY_AC3
-           - DOLBY_AC3_PLUS
-           - DOLBY_AC3_PLUS_JOC
-           - DOLBY_AC4
-           - X_HE_AAC
-         supportsSecure: true
-      - 1:                      # Resource object begins
-         supportedCodecs:       # Array of codec capabilities
-           - AAC_LC
-           - HE_AAC
-           - HE_AAC2
-           - DOLBY_AC3
-           - DOLBY_AC3_PLUS
-           - DOLBY_AC3_PLUS_JOC
-           - DOLBY_AC4
-           - X_HE_AAC
-         supportsSecure: true
+audiodecoder: # Component object begins
+  interfaceVersion: current
+  Capabilities:
+    - 0:
+      codecCapabilities:
+        - PCM:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 1536000
+              maxChannels: 8
+              maxSampleRateInHz: 192000
+              maxBitDepth: 32
+
+        - AAC:
+          profiles:
+            - LC:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HE_V1:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HE_V2:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - ELD:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - X_HE:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - MPEG_AUDIO:
+          profiles:
+            - LAYER_1:
+              maxBitrateInBps: 448000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - LAYER_2:
+              maxBitrateInBps: 384000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - MP3:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - ALAC:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 4608000
+              maxChannels: 8
+              maxSampleRateInHz: 192000
+              maxBitDepth: 32
+
+        - SBC:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 345000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - DOLBY_AC3:
+          profiles:
+            - STANDARD:
+              maxBitrateInBps: 6144000
+              maxChannels: 16
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - DOLBY_EAC3:
+          profiles:
+            - PLUS:
+              maxBitrateInBps: 6144000
+              maxChannels: 16
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+            - PLUS_JOC:
+              maxBitrateInBps: 6144000
+              maxChannels: 16
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - DOLBY_AC4:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 6000000
+              maxChannels: 8
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - DOLBY_TRUEHD:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 18432000
+              maxChannels: 16
+              maxSampleRateInHz: 192000
+              maxBitDepth: 24
+
+        - FLAC:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 4608000
+              maxChannels: 8
+              maxSampleRateInHz: 192000
+              maxBitDepth: 32
+
+        - VORBIS:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 500000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - OPUS:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 510000
+              maxChannels: 8
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - REALAUDIO:
+          profiles:
+            - RA8:
+              maxBitrateInBps: 352000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - RA10:
+              maxBitrateInBps: 352000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - USAC:
+          profiles:
+            - BASELINE:
+              maxBitrateInBps: 512000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - EXTENDED_HE_AAC:
+              maxBitrateInBps: 512000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - DTS:
+          profiles:
+            - CORE:
+              maxBitrateInBps: 6144000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HD_HRA:
+              maxBitrateInBps: 6144000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HD_MA:
+              maxBitrateInBps: 6144000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - AVS:
+          profiles:
+            - AVS1_PART2:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - AVS2:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - AVS3:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+      supportsSecure: true
+    - 1:
+      codecCapabilities:
+        - PCM:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 1536000
+              maxChannels: 8
+              maxSampleRateInHz: 192000
+              maxBitDepth: 32
+
+        - AAC:
+          profiles:
+            - LC:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HE_V1:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HE_V2:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - ELD:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - X_HE:
+              maxBitrateInBps: 576000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - MPEG_AUDIO:
+          profiles:
+            - LAYER_1:
+              maxBitrateInBps: 448000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - LAYER_2:
+              maxBitrateInBps: 384000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - MP3:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - ALAC:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 4608000
+              maxChannels: 8
+              maxSampleRateInHz: 192000
+              maxBitDepth: 32
+
+        - SBC:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 345000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - DOLBY_AC3:
+          profiles:
+            - STANDARD:
+              maxBitrateInBps: 6144000
+              maxChannels: 16
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - DOLBY_EAC3:
+          profiles:
+            - PLUS:
+              maxBitrateInBps: 6144000
+              maxChannels: 16
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+            - PLUS_JOC:
+              maxBitrateInBps: 6144000
+              maxChannels: 16
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - DOLBY_AC4:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 6000000
+              maxChannels: 8
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - DOLBY_TRUEHD:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 18432000
+              maxChannels: 16
+              maxSampleRateInHz: 192000
+              maxBitDepth: 24
+
+        - FLAC:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 4608000
+              maxChannels: 8
+              maxSampleRateInHz: 192000
+              maxBitDepth: 32
+
+        - VORBIS:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 500000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - OPUS:
+          profiles:
+            - BASE:
+              maxBitrateInBps: 510000
+              maxChannels: 8
+              maxSampleRateInHz: 48000
+              maxBitDepth: 24
+
+        - REALAUDIO:
+          profiles:
+            - RA8:
+              maxBitrateInBps: 352000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - RA10:
+              maxBitrateInBps: 352000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+
+        - USAC:
+          profiles:
+            - BASELINE:
+              maxBitrateInBps: 512000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - EXTENDED_HE_AAC:
+              maxBitrateInBps: 512000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - DTS:
+          profiles:
+            - CORE:
+              maxBitrateInBps: 6144000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HD_HRA:
+              maxBitrateInBps: 6144000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+            - HD_MA:
+              maxBitrateInBps: 6144000
+              maxChannels: 8
+              maxSampleRateInHz: 96000
+              maxBitDepth: 24
+
+        - AVS:
+          profiles:
+            - AVS1_PART2:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - AVS2:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+            - AVS3:
+              maxBitrateInBps: 320000
+              maxChannels: 2
+              maxSampleRateInHz: 48000
+              maxBitDepth: 16
+      supportsSecure: true

--- a/videodecoder/current/hfp-videodecoder.yaml
+++ b/videodecoder/current/hfp-videodecoder.yaml
@@ -22,7 +22,7 @@
 
 # HAL Feature Profile for videodecoder
 #
-# Mirrors CodecCapabilities.aidl + Profile.aidl field-for-field.
+# Mirrors codecCapabilities/profile capabilities field-for-field.
 # Reference implementation aligned with
 # rdk-hpk-documentation/hfp-reference/videodecoder/hfp-videodecoder.yaml.
 #
@@ -34,18 +34,23 @@
 #   - `maxBitrateInBps` is an inclusive ceiling for the profile/level.
 #     Use `0` only if the SoC vendor doesn't publish a real cap.
 
-videodecoder:                   # Component object begins
+videodecoder: # Component object begins
   interfaceVersion: current
   supportedOperationalModes:
     - NON_TUNNELLED
-  IVideoDecoder:                # Resource list
-    - 0:                        # Resource object begins (high-tier decoder)
-      supportedCodecs:          # Array of CodecCapabilities
+  Capabilities: # Resource list
+    - 0: # Resource object begins (high-tier decoder)
+      codecCapabilities:
         - MPEG2_VIDEO:
             profiles:
-              - profile: MPEG2_MAIN
-                maxLevel: MPEG2_LEVEL_MAIN
-                maxBitrateInBps: 15000000
+              - MPEG2_SIMPLE:
+                  maxLevel: MPEG2_LEVEL_HIGH
+                  maxBitrateInBps: 50000000
+              - MPEG2_MAIN:
+                  maxLevel: MPEG2_LEVEL_HIGH
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
@@ -53,15 +58,21 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - H264_AVC:
             profiles:
-              - profile: H264_BASELINE
-                maxLevel: H264_LEVEL_4_1
-                maxBitrateInBps: 50000000
-              - profile: H264_MAIN
-                maxLevel: H264_LEVEL_4_1
-                maxBitrateInBps: 50000000
-              - profile: H264_HIGH
-                maxLevel: H264_LEVEL_4_1
-                maxBitrateInBps: 50000000
+              - H264_BASELINE:
+                  maxLevel: H264_LEVEL_5_2
+                  maxBitrateInBps: 50000000
+              - H264_MAIN:
+                  maxLevel: H264_LEVEL_5_2
+                  maxBitrateInBps: 50000000
+              - H264_HIGH:
+                  maxLevel: H264_LEVEL_5_2
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
+              - DOLBY_VISION
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
@@ -69,15 +80,21 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - H265_HEVC:
             profiles:
-              - profile: H265_MAIN
-                maxLevel: H265_LEVEL_5_2
-                maxBitrateInBps: 150000000
-              - profile: H265_MAIN_10
-                maxLevel: H265_LEVEL_5_2
-                maxBitrateInBps: 150000000
-              - profile: H265_MAIN_10_HDR10
-                maxLevel: H265_LEVEL_5_2
-                maxBitrateInBps: 150000000
+              - H265_MAIN:
+                  maxLevel: H265_LEVEL_6_2
+                  maxBitrateInBps: 150000000
+              - H265_MAIN_10:
+                  maxLevel: H265_LEVEL_6_2
+                  maxBitrateInBps: 150000000
+              - H265_MAIN_10_HDR10:
+                  maxLevel: H265_LEVEL_6_2
+                  maxBitrateInBps: 150000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
+              - DOLBY_VISION
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
@@ -85,12 +102,23 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - VP9:
             profiles:
-              - profile: VP9_PROFILE_0
-                maxLevel: VP9_LEVEL_5_1
-                maxBitrateInBps: 150000000
-              - profile: VP9_PROFILE_2
-                maxLevel: VP9_LEVEL_5_1
-                maxBitrateInBps: 150000000
+              - VP9_PROFILE_0:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - VP9_PROFILE_1:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - VP9_PROFILE_2:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - VP9_PROFILE_3:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
@@ -98,33 +126,41 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - AV1:
             profiles:
-              - profile: AV1_MAIN
-                maxLevel: AV1_LEVEL_5_1
-                maxBitrateInBps: 150000000
+              - AV1_MAIN:
+                  maxLevel: AV1_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - AV1_HIGH:
+                  maxLevel: AV1_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
+              - DOLBY_VISION
             maxFrameRate: 60
             maxFrameWidth: 3840
             maxFrameHeight: 2160
             supportedOutputPixelFormats:
               - YCBCR420
-      supportedDynamicRanges:
-        - SDR
-        - HLG
-        - HDR10
-        - HDR10_PLUS
-        - DOLBY_VISION
       supportedColorimetries:
         - BT601_525
         - BT601_625
         - BT709
         - BT2020
       supportsSecure: true
-    - 1:                          # Resource object begins (secondary HD decoder)
-      supportedCodecs:
+    - 1: # Resource object begins (secondary HD decoder)
+      codecCapabilities:
         - MPEG2_VIDEO:
             profiles:
-              - profile: MPEG2_MAIN
-                maxLevel: MPEG2_LEVEL_MAIN
-                maxBitrateInBps: 15000000
+              - MPEG2_SIMPLE:
+                  maxLevel: MPEG2_LEVEL_HIGH
+                  maxBitrateInBps: 50000000
+              - MPEG2_MAIN:
+                  maxLevel: MPEG2_LEVEL_HIGH
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
@@ -132,15 +168,21 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - H264_AVC:
             profiles:
-              - profile: H264_BASELINE
-                maxLevel: H264_LEVEL_4_1
-                maxBitrateInBps: 50000000
-              - profile: H264_MAIN
-                maxLevel: H264_LEVEL_4_1
-                maxBitrateInBps: 50000000
-              - profile: H264_HIGH
-                maxLevel: H264_LEVEL_4_1
-                maxBitrateInBps: 50000000
+              - H264_BASELINE:
+                  maxLevel: H264_LEVEL_5_2
+                  maxBitrateInBps: 50000000
+              - H264_MAIN:
+                  maxLevel: H264_LEVEL_5_2
+                  maxBitrateInBps: 50000000
+              - H264_HIGH:
+                  maxLevel: H264_LEVEL_5_2
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
+              - DOLBY_VISION
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
@@ -148,12 +190,21 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - H265_HEVC:
             profiles:
-              - profile: H265_MAIN
-                maxLevel: H265_LEVEL_4_1
-                maxBitrateInBps: 50000000
-              - profile: H265_MAIN_10
-                maxLevel: H265_LEVEL_4_1
-                maxBitrateInBps: 50000000
+              - H265_MAIN:
+                  maxLevel: H265_LEVEL_6_2
+                  maxBitrateInBps: 150000000
+              - H265_MAIN_10:
+                  maxLevel: H265_LEVEL_6_2
+                  maxBitrateInBps: 150000000
+              - H265_MAIN_10_HDR10:
+                  maxLevel: H265_LEVEL_6_2
+                  maxBitrateInBps: 150000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
+              - DOLBY_VISION
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
@@ -161,9 +212,23 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - VP9:
             profiles:
-              - profile: VP9_PROFILE_0
-                maxLevel: VP9_LEVEL_4_1
-                maxBitrateInBps: 50000000
+              - VP9_PROFILE_0:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - VP9_PROFILE_1:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - VP9_PROFILE_2:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - VP9_PROFILE_3:
+                  maxLevel: VP9_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
@@ -171,16 +236,23 @@ videodecoder:                   # Component object begins
               - YCBCR420
         - AV1:
             profiles:
-              - profile: AV1_MAIN
-                maxLevel: AV1_LEVEL_4_1
-                maxBitrateInBps: 50000000
+              - AV1_MAIN:
+                  maxLevel: AV1_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+              - AV1_HIGH:
+                  maxLevel: AV1_LEVEL_6_2
+                  maxBitrateInBps: 50000000
+            dynamicRange:
+              - SDR
+              - HLG
+              - HDR10
+              - HDR10_PLUS
+              - DOLBY_VISION
             maxFrameRate: 60
             maxFrameWidth: 1920
             maxFrameHeight: 1080
             supportedOutputPixelFormats:
               - YCBCR420
-      supportedDynamicRanges:
-        - SDR
       supportedColorimetries:
         - BT601_525
         - BT601_625


### PR DESCRIPTION
Update audio video decoder hfps to support w3c media capabilities
Existing attributes in hfp are not modified unless it is needed for new schema to support media capabilities

Task: https://github.com/rdkcentral/rdk-halif-aidl/issues/767