### PR TITLE
docs(transformation): match the AIDL method order in the interface snippet

### DIFF
--- a/docs/transformation/westeros_graphics_fb_transform.md
+++ b/docs/transformation/westeros_graphics_fb_transform.md
@@ -36,13 +36,10 @@ HAL boundary — renderable buffers and presentation:
 ```aidl
 @VintfStability
 interface IGraphicsFbProvider {
-    // Buffer lifecycle — vendor allocation behind a standard FD
     GraphicsFbCapabilities getCapabilities();
+    boolean                commitGraphicsFb(in int graphicsFbId);   // presentation
     ParcelFileDescriptor   createGraphicsFb(in int width, in int height, out GraphicsFbInfo outInfo);
     void                   destroyGraphicsFb(in int graphicsFbId);
-
-    // Presentation
-    boolean commitGraphicsFb(in int graphicsFbId);
 }
 
 @VintfStability


### PR DESCRIPTION
Closes #771

The `IGraphicsFbProvider` snippet in the Westeros transformation document grouped its methods by concern, which moved `commitGraphicsFb()` to last:

```aidl
    // Buffer lifecycle — vendor allocation behind a standard FD
    GraphicsFbCapabilities getCapabilities();
    ParcelFileDescriptor   createGraphicsFb(in int width, in int height, out GraphicsFbInfo outInfo);
    void                   destroyGraphicsFb(in int graphicsFbId);

    // Presentation
    boolean commitGraphicsFb(in int graphicsFbId);
```

Method order fixes the transaction ordinals, so the snippet documented a different binary contract to the one the interface defines. An implementer working from it assigns ordinals that will not match a client built against the real AIDL.

The snippet now follows the declared order in `planecontrol/current/com/rdk/hal/planecontrol/IGraphicsFbProvider.aidl` — `getCapabilities` (L53), `commitGraphicsFb` (L73), `createGraphicsFb` (L95), `destroyGraphicsFb` (L107) — with the presentation call marked inline rather than by regrouping.

The same defect in the VSI Graphics document was raised in review on #766 and corrected there.